### PR TITLE
docs: v5.9.0 release notes + walkthroughs

### DIFF
--- a/.drafts/v5.9.0-release-notes-and-walkthrough.md
+++ b/.drafts/v5.9.0-release-notes-and-walkthrough.md
@@ -1,0 +1,152 @@
+# SOLA v5.9.0 — Release Notes, Feature Summary, and 20-minute Admin Walkthrough
+
+## Part 1: Release Notes (4 June 2026)
+
+SOLA now makes the learning path *visual* and recognizes when a learner is ready to move on. v5.7.0 looked backward (cross-course mastery), v5.8.0 added a forward conversational hint; v5.9.0 turns that path into a panel the learner can open and adds a gentle "ready for the next course" nudge. Off by default; advisory only; uses the learner's own program allocation; no schema change.
+
+- **Visual learning-path panel.** A new "my path" button in the widget header opens an in-drawer panel that shows the learner's program (a Saylor Degree or a Learn certificate) as a sequence of course nodes — done / current / upcoming, with ordering and "course X of Y". Each node expands to its objectives and the learner's mastery of them, including objectives already demonstrated in another course (via the v5.7.0 equivalency). The panel loads lazily from a new `get_learning_path` web service the first time it's opened.
+- **Next-course readiness nudge.** When the learner meets the bar for the current course — Moodle course completion, or at least a configurable share of the course's objectives mastered (default 80%), whichever happens first — SOLA surfaces a dismissible "ready for {next course}" banner whose "View my path" button opens the panel, and mentions it conversationally by extending the v5.8.0 program-path block. The banner dismissal persists per course, and the tone stays gentle: it never pushes a learner ahead before they're ready.
+- **One aggregator behind three surfaces.** A new `learning_path` class is the single source of truth. A cheap `readiness()` (current course only) feeds the page-load banner and the conversational line; a fuller `full_path()` feeds the panel web service. It composes v5.8.0 `program_path` (program, ordering, next course), `objective_manager` (per-course objectives + mastery), and `cross_course_mastery` (demonstrated-elsewhere). Every read is guarded so the feature degrades to silence wherever no program applies.
+- **Accessible by construction.** Course status and objective mastery are conveyed with a shape glyph plus a text label, never color alone (WCAG 2.1 SC 1.4.1). The panel toggle, node expand/collapse, and banner dismiss are keyboard-operable with correct ARIA.
+- **New pedagogy default `learning_path`, off by default**, resolvable per course, plus a `learning_path_mastery_threshold` setting (default 80). Reads only the current learner's own program allocation; never changes enrolment or mastery.
+- **No new schema.** No table, no scheduled task. The panel reads live behind a request-scoped cache and a capability-checked web service.
+
+### Backwards compatibility
+
+Default-off and self-suppressing: an install upgrades to v5.9.0 and behaves identically until an admin enables `learning_path` on a course that belongs to a program. Installs without the Moodle Programs plugin (including local dev) show no header button and no banner — the feature is inert.
+
+### Testing
+
+- New `tests/learning_path_test.php`: readiness (flag-off, mastery at the 80% threshold, below threshold) and `full_path` (null when off, program/position/status structure). The `program_path` refactor that extracted `program_memberships` / `next_courses_for` stays behavior-preserving (`program_path_test` 16/16).
+- Live end-to-end on dev against a real `tool_muprog` Degree: panel renders correct positions, statuses, ordering, objectives, and next courses; the readiness nudge fires on mastery. This caught a real bug — `completion_info` is not autoloaded, so the mastery trigger was silently masked until `completionlib.php` was required — exactly the class of issue that only live testing surfaces.
+- Full plugin suite 371/371; validators 36/0; jailbreak 32/32 (the panel and nudge use only the current learner's own allocation); a11y harness 19/19; widget initializes with 0 JS errors on a course page.
+- i18n: the 19 new strings are translated into all 45 non-English languages (placeholders preserved, all lang files lint clean).
+- Publicly released (GitHub tag `v5.9.0`) and deployed to all five dev sites — dev.sylr.org, dev405.sylr.org, dev500.sylr.org (Moodle 5.0), dev501.sylr.org (Moodle 5.1, `public/` layout), and dev503.sylr.org (Moodle 5.2) — with the BUS101 smoke passing on each.
+
+Plugin version `2026060500`, release `5.9.0`.
+
+---
+
+## Part 2: Key SOLA Features (current snapshot)
+
+| Capability | Status |
+|---|---|
+| **Visual learning-path panel: the learner's program as expandable course nodes (status, objectives, mastery), opened from the widget header** | **v5.9.0 NEW** |
+| **Next-course readiness nudge: a "ready for the next course" banner + conversational line on completion or high mastery, default 80%** | **v5.9.0 NEW** |
+| Forward learning-path awareness: where this course leads next in the learner's program (Degrees + Learn), with concept bridges | v5.8.0 |
+| Cross-course mastery rollup: recognizes objectives mastered in another course, advisory prompt block + personalized focus-next starter | v5.7.0 |
+| Proportional prompt allocation across four buckets with admin-tunable weights and context-aware boost | v5.6.0 |
+| Per-call failover decorator on chat path; provider circuit breaker | v5.5.0 |
+| Golden tutor benchmark harness (50-prompt rubric set) | v5.5.1 |
+| Production security hardening for pilot rollout + red-team audit follow-ups | v5.4.5 + v5.5.4 |
+| Multi-provider AI backend with SSE streaming (OpenAI, Claude, Mistral, Llama via Together, xAI, DeepSeek, Gemini, Ollama) | shipped |
+| Structured prompt builder with per-section priorities + drop-on-priority safety net | v4.12.0 |
+| Talking-avatar provider integrations (D-ID, HeyGen, Tavus, Synthesia Agents) with per-minute cost tracking | v4.9.0 + v4.10.0 |
+| Pedagogy defaults (mastery, cross-course mastery, forward learning-path, learning-path map + nudge, Socratic, worked examples, flashcards, code sandbox, essay feedback, talking avatar) | v4.5.0 + v4.8.1 + v5.7.0 + v5.8.0 + v5.9.0 |
+| Vendor DPA gating + LLM rate-card auto-refresh from upstream pricing JSON | v4.6.0 + v4.7.0 |
+| Runtime validators, RAG drift auto-reindex, PDF text extractor, needs-review queue | v4.8.0 |
+| Personalized greeting + coaching, practice quizzes, study plans, scheduled reminders | shipped |
+| 46-language i18n with auto-detection; 46-lang STT/TTS | shipped |
+| OpenAI Realtime voice mode (WebSocket, live transcript, ELL coaching) | shipped |
+| RAG semantic search (default on; embedding-based retrieval) | v4.0.0+ |
+| Conversation starters, 50-pair conversation cap, dynamic SOLA_NEXT chips | shipped |
+| Learning Radar (multi-schedule, Redash export, citations, anomaly digest) | v4.2.0 + v4.3.0 |
+
+---
+
+## Part 3: 20-minute Admin Walkthrough
+
+This walkthrough is the demo script for showing v5.9.0 to instructors, ops leadership, or external collaborators. It covers the visual learning-path panel and the next-course nudge end to end: where the path data comes from, what the learner sees, when the "ready" nudge fires, and the off switches and privacy posture.
+
+### 0. Setup (1 min)
+
+Sign into a course that belongs to a program, ideally a **Degrees** course inside an ordered (prerequisite- or required-order) program so the panel shows a real sequence. On dev, the seeded `solapilot` Degree (three ordered courses, with objectives mastered on the middle course) is the ready-made demo. Open SOLA via the side tab. Keep the prompt-debug log handy for the conversational half: `tail -f ~/Sites/moodledata/temp/sola_prompt_debug.log`.
+
+### 1. The arc this completes (2 min)
+
+Frame it against the last two releases. v5.7.0 looked *backward* ("you've shown this elsewhere, I won't re-drill it"). v5.8.0 looked *forward*, but only in conversation ("here's where this leads"). v5.9.0 makes that forward view something the learner can *see* — a panel of their whole program — and adds a moment of recognition: when they've cleared the current course, SOLA says so and points to what's next. Same honesty rules as v5.8.0; this is the visible, motivational layer on top.
+
+### 2. Turn it on (2 min)
+
+Site administration → Plugins → Local plugins → AI Course Assistant → **Pedagogy defaults**. Tick **Learning path map and next-course nudge** (`learning_path`). It's off by default and resolvable per course, so you can pilot it on one program's courses first. While you're here, note the new **Learning-path readiness threshold (%)** setting (`learning_path_mastery_threshold`, default 80) — the share of a course's objectives a learner must master before the nudge treats them as ready. Save.
+
+### 3. The path panel (5 min)
+
+Reopen SOLA on the course. A new **"my path"** button appears in the widget header (it shows only when the course belongs to a program the learner is allocated to — that's the first off switch in action). Click it: the panel opens and lists the program's courses as nodes.
+
+Walk the node anatomy:
+- **Status** — a glyph plus a label: a check for *Done*, a filled marker for *You are here* (the current course), an open marker for *Upcoming*. The glyph-plus-label pairing is deliberate: status is never carried by color alone, so it reads for color-blind learners and screen readers alike.
+- **Position and ordering** — "Course 2 of 3", and, for an ordered program, the sequence the courses must be taken in.
+- **Objectives on expand** — click a node (it's a real disclosure button, keyboard-operable, with `aria-expanded`) and it reveals that course's objectives with the learner's mastery of each: *Mastered*, *In progress*, *Not started*, or *Shown in another course* — the last pulled from the v5.7.0 cross-course equivalency, so a competency proven in a sibling course shows as already demonstrated here.
+
+Two things to call out: the panel loads only when opened (a single capability-checked `get_learning_path` web service call, not on every page), and a course with no objectives defined simply shows the node without an expandable body — it degrades, it doesn't error.
+
+### 4. The readiness nudge (4 min)
+
+Now the moment of recognition. On a course where the learner has either completed it (Moodle course completion) or mastered at least the threshold share of its objectives (default 80%), reopening SOLA shows a banner near the top of the drawer: **"Nice work — you're ready for {next course}."** Its **View my path** button opens the panel you just toured; its **Dismiss** button hides it, and that dismissal persists for that course (stored client-side), so a learner isn't nagged on every visit.
+
+Then show the conversational half. Send a chat turn and read the line appended to the program block in the debug log — SOLA affirms they've met the bar and points forward to the next course, in its own voice, without quoting scores or sounding like it's reading a database. The trigger is "whichever first": a fast learner who masters the objectives gets the nudge before formal completion; a learner who simply finishes gets it on completion. Demonstrate the threshold by lowering `learning_path_mastery_threshold` and watching a borderline learner cross into "ready".
+
+### 5. How it's built, briefly (2 min)
+
+One `learning_path` aggregator backs all three surfaces, so they can never disagree: a cheap `readiness()` (current course only) drives the banner and the conversational line at page load, and a fuller `full_path()` drives the panel's web service when it's opened. It composes the v5.8.0 program reader, the objective/mastery store, and the cross-course equivalency. No new table, no scheduled task — the program tables are read live behind a request cache.
+
+### 6. The off switches and the honesty rules (2 min)
+
+Recap control. `learning_path` is **off by default**; it's resolvable **per course** (pilot narrowly) and **site-wide**; it respects the global **emergency kill switch**; and it **self-suppresses** wherever the Programs plugin is absent, the learner has no allocation, or there's nothing to say. On top of that, the same honesty rules as v5.8.0 hold: an any-order Learn certificate is shown as membership and position without an invented sequence; objectives appear only where an admin defined them; a course the learner hasn't worked shows mastery as *Not started* rather than guessing.
+
+### 7. Privacy & cost (1 min)
+
+The panel and nudge are built only from the *current* learner's own allocation, objectives, and mastery — no other student's data, so the jailbreak/memory-leak suite stays at 32/32, and the web service enforces course capability before returning anything. There's no new per-call provider cost: the panel is local database work behind a lazy, capability-checked endpoint, and the conversational line sits inside the v5.6.0 proportional prompt budget like any other section.
+
+### 8. The deferred work (1 min)
+
+Explicitly out of scope for v5.9.0:
+
+- An external nudge digest (email or Moodle notification) — today the nudge is in-widget only.
+- A configurable count of next courses, and a configurable concept-bridge threshold.
+- An opt-in mode that uses course-program membership when a learner has no allocation (off by default for honesty).
+
+### 9. Q&A (rolling)
+
+- **"Will this change anything on upgrade?"** No. Off by default and self-suppressing; nothing appears until an admin enables `learning_path` on a course in a program.
+- **"Why don't I see the 'my path' button?"** The course isn't in a program the signed-in learner is allocated to, or the feature isn't enabled for that course. The button is intentionally hidden rather than shown-and-empty.
+- **"What exactly makes a learner 'ready'?"** Either Moodle course completion or mastering at least the threshold percentage of the course's tracked objectives, whichever happens first. The threshold is an admin setting, default 80.
+- **"Is the panel accessible?"** Yes — status and mastery use shape-plus-text, not color alone (WCAG 1.4.1); the toggle, node expansion, and dismiss are keyboard-operable with ARIA; the a11y harness is at 19/19.
+- **"Could it leak another student's path?"** No. It reads only the current learner's own allocation, and the web service enforces course capability. 32/32 jailbreak.
+- **"Does it work on Degrees and Learn both?"** Yes — same plugin and adapter as v5.8.0. Ordered Degrees show a sequence; any-order Learn certificates show membership and position without inventing one.
+- **"Any extra cost or load per page?"** No. The panel only calls its web service when a learner opens it; the banner is computed from the current course at page render; there's no new table or scheduled task.
+
+---
+
+## Part 4: Learner-facing blurb
+
+**Short (announcement banner / one-liner):**
+
+> New in your course assistant: see your whole path. Open SOLA and tap "my path" to see where this course sits in your program, what you've already got down, and what's coming next. When you've got this course covered, SOLA will let you know you're ready for the next one.
+
+**Fuller (course announcement or changelog homepage):**
+
+> **Your learning path, now at a glance**
+>
+> Your course assistant just got a new view. Tap the "my path" button at the top of SOLA to open a map of your program: every course laid out in order, with where you are now, what's done, and what's ahead. Open any course to see its goals and how you're doing on each one, including anything you've already shown you know from another course.
+>
+> SOLA will also give you a heads-up when you're ready to move on. Once you've finished a course or mastered enough of its goals, it'll point you toward what's next, so you always know where you're headed. Nothing changes about how you work day to day, and SOLA will never rush you. It's just there when you want to see the bigger picture.
+
+---
+
+## Part 5: 5-minute Admin Walkthrough (lightning version)
+
+The fast demo — turn it on, show the panel, show the nudge, name the guardrails.
+
+**0. Setup (30s).** Sign into a Degrees course in a program (on dev, the seeded `solapilot` Degree works). Open SOLA via the side tab.
+
+**1. Turn it on (45s).** Site administration → Plugins → Local plugins → AI Course Assistant → **Pedagogy defaults** → tick **Learning path map and next-course nudge** (`learning_path`). Point out it's off by default and resolvable per course, and the **readiness threshold** setting next to it (default 80% of a course's objectives). Save.
+
+**2. The path panel (90s).** Reopen SOLA; a **"my path"** button now sits in the header (it only appears when the course is in a program the learner is enrolled in). Click it: the program shows as a list of course nodes — *Done* / *You are here* / *Upcoming*, each with a glyph **and** a text label (status never rides on color alone), plus "Course 2 of 3" and the order. Expand a node to reveal its objectives and the learner's mastery of each, including "Shown in another course" for anything they already proved elsewhere. It loads only when opened, and a course with no objectives just shows the node without a body.
+
+**3. The readiness nudge (90s).** On a course the learner has completed or where they've mastered enough objectives (the threshold), reopening SOLA shows a banner: **"Nice work — you're ready for {next course}."** Its **View my path** button opens the panel; **Dismiss** hides it and stays hidden for that course. Send a chat turn and show SOLA say the same thing in its own voice, no scores quoted. The trigger is whichever comes first, completion or mastery.
+
+**4. Guardrails, in one breath (45s).** Off by default, per-course or site-wide, respects the emergency kill switch, and self-suppresses with no program or no allocation. It reads only the current learner's own path — no other student's data (32/32 jailbreak), capability-checked web service, no new table or scheduled task, no extra per-call cost. Accessible: shape-plus-text, keyboard-operable, a11y harness 19/19.
+
+**Close:** same honesty as v5.8.0 — ordered Degrees show a real sequence, any-order Learn certificates show position without inventing one.


### PR DESCRIPTION
Adds the v5.9.0 release-notes-and-walkthrough draft to `.drafts/` (consistent with prior tracked release drafts):

- Part 1 — release notes (headline, bullets, backwards-compat, testing)
- Part 2 — key-features snapshot
- Part 3 — 20-minute admin walkthrough
- Part 4 — learner-facing blurb (short + fuller)
- Part 5 — 5-minute lightning walkthrough

Docs only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)