### PR TITLE
hotfix(cdn): bundle path_map + core/notification shim — prod drawer dead

### DIFF
--- a/cdn/rollup.config.mjs
+++ b/cdn/rollup.config.mjs
@@ -53,11 +53,16 @@ function buildBundle() {
     const ajaxShim = readFileSync(resolve(__dirname, 'shims', 'ajax.js'), 'utf8');
     const strShim = readFileSync(resolve(__dirname, 'shims', 'str.js'), 'utf8');
     const configShim = readFileSync(resolve(__dirname, 'shims', 'config.js'), 'utf8');
+    const notificationShim = readFileSync(resolve(__dirname, 'shims', 'notification.js'), 'utf8');
 
     // Read all AMD source modules. Dependency order: deps first.
+    // IMPORTANT: every module that any other bundled module `define()`s a
+    // dependency on MUST appear here, or the mini-AMD loader throws
+    // "Unknown module" at runtime and the whole widget fails to init. path_map
+    // (v5.9.0) is depended on by chat; omitting it broke the CDN drawer on prod.
     const modules = [
         'markdown', 'audio_player', 'sse_client', 'speech', 'realtime',
-        'voice', 'repository', 'quiz', 'i18n_strings', 'ui', 'chat',
+        'voice', 'repository', 'quiz', 'i18n_strings', 'ui', 'path_map', 'chat',
     ];
 
     const amdSources = modules.map(name => {
@@ -145,6 +150,13 @@ import '../styles.css';
     _resolved['core/config'] = (function() {
         ${configShim.replace(/export\s+default\s+.*/, '').replace(/export\s*\{[^}]*\}/, '')}
         return cfg;
+    })();
+
+    // core/notification shim — bundled modules (e.g. path_map) use only
+    // Notification.exception(); surface errors to the console in CDN mode.
+    _resolved['core/notification'] = (function() {
+        ${notificationShim.replace(/export\s+default\s+.*/, '').replace(/export\s*\{[^}]*\}/, '')}
+        return {exception: exception};
     })();
 
     // ---- Register AMD modules ----

--- a/cdn/shims/notification.js
+++ b/cdn/shims/notification.js
@@ -1,0 +1,18 @@
+/**
+ * Shim for Moodle's core/notification module (CDN bundle).
+ *
+ * SOLA's bundled modules use only Notification.exception() (in a couple of
+ * rejected-Promise handlers, e.g. the learning-path panel fetch). Moodle's real
+ * notification modal isn't available in CDN mode, so we surface the error to the
+ * console instead. Keeping the same `exception` shape means the bundled modules
+ * need no CDN-specific changes.
+ */
+
+function exception(error) {
+    if (window.console && window.console.error) {
+        window.console.error('SOLA:', error);
+    }
+}
+
+export default {exception: exception};
+export {exception};


### PR DESCRIPTION
## Prod outage: SOLA drawer not opening on Learn + Degrees

**Root cause.** The CDN frontend bundle (`sola.min.js`, served from GitHub Pages, loaded by prod in CDN mode) is built from a hardcoded module list in `cdn/rollup.config.mjs`. v5.9.0 added `amd/src/path_map.js` and made `chat.js` `define()` a dependency on it, but the list was never updated, and `path_map`'s `core/notification` dep had no CDN shim. So the v5.9.0 CDN bundle had `chat` depending on an unbundled module → the mini-AMD loader throws `Unknown module "path_map"` at runtime → init aborts → widget/drawer dead on every CDN-mode install (Saylor Learn + Degrees prod).

Only prod is affected: local and all dev sites use Moodle AMD (each module loaded individually), where `path_map` resolves fine. That's why v5.9.0 testing didn't catch it. The breaking bundle shipped via cdn-deploy on the #27 merge (2026-06-04 23:16).

## Fix
- Add `path_map` to the bundle module list in `cdn/rollup.config.mjs`.
- Add `cdn/shims/notification.js` (minimal `core/notification` shim; `Notification.exception` → console).

## Verification
- Rebuilt bundle includes `path_map` (its unique strings present); bundle URL audit clean (allowlist).
- Headless runtime test: **old live prod bundle throws `Unknown module "path_map"`; fixed bundle throws nothing** and resolves `chat` cleanly.

## Deploy note
`cdn-deploy.yml` republishes the bundle to GitHub Pages on merge (touches `cdn/`). Prod picks it up on Pages cache expiry, or instantly if the `cdn_version` admin setting is bumped. Follow-up worth filing: derive the bundle module list from `amd/src/*` (or add a build-time resolve check) so a new module can't silently break CDN mode again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)