### PR TITLE
test(cdn): regression tests for bundle dependency check (module + shim)

### DIFF
--- a/.github/workflows/cdn-deploy.yml
+++ b/.github/workflows/cdn-deploy.yml
@@ -31,6 +31,14 @@ jobs:
         working-directory: cdn
         run: npm ci
 
+      - name: Run CDN bundle dependency-check tests
+        # Regression guard for the missing-module / missing-shim outage class
+        # (chat -> path_map unbundled, path_map -> core/notification unshimmed).
+        # Fails the deploy before publishing a bundle that would throw
+        # "Unknown module" at runtime on CDN-mode installs (prod).
+        working-directory: cdn
+        run: npm test
+
       - name: Build CDN bundle
         working-directory: cdn
         run: npm run build

--- a/cdn/package.json
+++ b/cdn/package.json
@@ -5,7 +5,8 @@
   "description": "CDN build for SOLA Moodle plugin frontend",
   "scripts": {
     "build": "rollup -c rollup.config.mjs",
-    "watch": "rollup -c rollup.config.mjs --watch"
+    "watch": "rollup -c rollup.config.mjs --watch",
+    "test": "node --test test/*.test.mjs"
   },
   "devDependencies": {
     "@rollup/plugin-terser": "^1.0.0",

--- a/cdn/rollup.config.mjs
+++ b/cdn/rollup.config.mjs
@@ -8,6 +8,15 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const amdSrc = resolve(__dirname, '..', 'amd', 'src');
 
 /**
+ * The core/* modules the CDN bundle provides via shims. The dependency check
+ * (assertDependenciesResolvable) treats these as resolvable. MUST stay in sync
+ * with the shims actually registered into _resolved in buildBundle() — the
+ * dependency-check regression test asserts that, so a name listed here but not
+ * wired (a "missing shim" the check would wrongly trust) fails the test.
+ */
+export const CDN_SHIMS = ['core/ajax', 'core/str', 'core/config', 'core/notification'];
+
+/**
  * Build a single concatenated bundle that includes a mini AMD loader,
  * all shim modules, and all plugin AMD modules.
  *
@@ -48,7 +57,7 @@ export default {
     ],
 };
 
-function buildBundle() {
+export function buildBundle() {
     // Read shim files.
     const ajaxShim = readFileSync(resolve(__dirname, 'shims', 'ajax.js'), 'utf8');
     const strShim = readFileSync(resolve(__dirname, 'shims', 'str.js'), 'utf8');
@@ -211,10 +220,8 @@ import '../styles.css';
  * @param {{name: string, code: string}[]} amdSources Bundled module sources.
  * @param {string[]} modules Bundled module short names.
  */
-function assertDependenciesResolvable(amdSources, modules) {
-    // Keep in sync with the shims registered into _resolved in buildBundle().
-    const SHIMS = ['core/ajax', 'core/str', 'core/config', 'core/notification'];
-    const available = new Set([...modules, ...SHIMS]);
+export function assertDependenciesResolvable(amdSources, modules) {
+    const available = new Set([...modules, ...CDN_SHIMS]);
 
     const errors = [];
     for (const { name, code } of amdSources) {

--- a/cdn/test/dependency-check.test.mjs
+++ b/cdn/test/dependency-check.test.mjs
@@ -1,0 +1,69 @@
+// Regression tests for the CDN bundle dependency check.
+//
+// Guards the 2026-06-04/06-08 prod outage class: the CDN frontend bundle is
+// concatenated from a hardcoded module list + shims, and a missing module or a
+// missing shim only fails at runtime ("Unknown module") on CDN-mode installs
+// (prod) — invisible to local/dev which use Moodle AMD. These tests assert the
+// build-time guard catches BOTH the missing-module and the missing-shim cases.
+//
+// Run: npm test  (from cdn/) — uses node's built-in test runner.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    assertDependenciesResolvable,
+    buildBundle,
+    CDN_SHIMS,
+} from '../rollup.config.mjs';
+
+test('the real CDN bundle config passes the dependency check', () => {
+    // buildBundle() runs assertDependenciesResolvable() on the real modules.
+    assert.doesNotThrow(() => buildBundle());
+});
+
+test('catches a bundled module depending on an unbundled module', () => {
+    // The exact 06-04 shape: chat depends on path_map, but path_map isn't bundled.
+    const sources = [{
+        name: 'chat',
+        code: "define(['local_ai_course_assistant/path_map'], function(p){ return {}; });",
+    }];
+    assert.throws(
+        () => assertDependenciesResolvable(sources, ['chat']),
+        /dependency check FAILED[\s\S]*path_map/,
+    );
+});
+
+test('catches a bundled module depending on an unprovided shim (missing-shim case)', () => {
+    // core/popup is neither a bundled module nor a registered shim.
+    const sources = [{
+        name: 'ui',
+        code: "define(['core/str', 'core/popup'], function(s, p){ return {}; });",
+    }];
+    assert.throws(
+        () => assertDependenciesResolvable(sources, ['ui']),
+        /dependency check FAILED[\s\S]*core\/popup/,
+    );
+});
+
+test('a real shim dependency (core/notification) is accepted', () => {
+    const sources = [{
+        name: 'path_map',
+        code: "define(['core/str', 'core/notification', 'local_ai_course_assistant/repository'], function(){ return {}; });",
+    }];
+    assert.doesNotThrow(
+        () => assertDependenciesResolvable(sources, ['path_map', 'repository']),
+    );
+});
+
+test('every shim the check trusts is actually registered in the bundle', () => {
+    // The deeper missing-shim hole: CDN_SHIMS could list a core/* name that
+    // buildBundle() never wires into _resolved. The check would then "resolve"
+    // a dependency that throws Unknown module at runtime. Assert no drift.
+    const src = buildBundle();
+    for (const shim of CDN_SHIMS) {
+        assert.ok(
+            src.includes(`_resolved['${shim}']`),
+            `shim "${shim}" is trusted by the dependency check but is not registered in buildBundle()`,
+        );
+    }
+});


### PR DESCRIPTION
Follow-up to the CDN drawer outage. The build-time `assertDependenciesResolvable()` guard (PR #35) rejects an unresolvable dependency, but it was only verified manually. This adds an actual regression test, explicitly covering the **missing-shim** case the request called out.

`cdn/test/dependency-check.test.mjs` (node's built-in test runner):
1. the real bundle config passes the check;
2. a bundled module depending on an **unbundled module** is caught (the 06-04 `chat → path_map` shape);
3. a bundled module depending on an **unprovided shim** is caught (missing-shim case — e.g. `path_map`'s `core/notification` had no shim);
4. a real shim dependency (`core/notification`) resolves;
5. **every name in `CDN_SHIMS` is actually registered in `buildBundle()`** — closes the deeper missing-shim hole where the check would *trust* a shim that was never wired into the loader.

Exports `assertDependenciesResolvable` / `buildBundle` / `CDN_SHIMS` from `rollup.config.mjs` so they're testable, and runs `npm test` in `cdn-deploy.yml` **before** the build, so a gap fails the deploy instead of shipping a bundle that throws `Unknown module` on prod.

**Verified:** 5/5 tests pass locally; `npm run build` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)