### PR TITLE
fix(flashcards): don't apply raw-endpoint CSP to full Moodle pages (v6.2.1)

### DIFF
--- a/classes/security.php
+++ b/classes/security.php
@@ -146,35 +146,61 @@ class security {
      * Call from every SOLA entry point that renders learner-affecting HTML
      * or streams AI output.
      */
-    public static function send_security_headers(): void {
+    public static function send_security_headers(bool $fullmoodlepage = false): void {
         if (headers_sent()) {
             return;
         }
-        $connect = [
-            "'self'",
-            'https://api.openai.com',
-            'https://api.anthropic.com',
-            'https://api.x.ai',
-            'https://api.mistral.ai',
-            'https://api.deepseek.com',
-            'https://generativelanguage.googleapis.com',
-            'https://api.minimax.chat',
-            'https://openrouter.ai',
-            'wss://api.openai.com',
-            'wss://api.x.ai',
-        ];
-        $csp = "default-src 'self'; "
-             . "script-src 'self' 'unsafe-inline'; "
-             . "style-src 'self' 'unsafe-inline'; "
-             . "img-src 'self' data: blob:; "
-             . "media-src 'self' blob:; "
-             . "font-src 'self' data:; "
-             . 'connect-src ' . implode(' ', $connect) . '; '
-             . "frame-ancestors 'self';";
-        header('Content-Security-Policy: ' . $csp);
-        header('X-Content-Type-Options: nosniff');
-        header('X-Frame-Options: SAMEORIGIN');
-        header('Referrer-Policy: same-origin');
+        foreach (self::build_security_headers($fullmoodlepage) as $name => $value) {
+            header($name . ': ' . $value);
+        }
+    }
+
+    /**
+     * Build the security headers as a name => value map (pure; no side effects,
+     * so it is unit-testable).
+     *
+     * The strict Content-Security-Policy is for the plugin's own raw output
+     * endpoints (SSE, TTS, transcribe, webhooks, media viewer). It omits
+     * 'unsafe-eval', which Moodle's YUI library requires: a full Moodle page
+     * rendered via $OUTPUT->header() cannot run its core JS (YUI init,
+     * requirejs string loading) under this CSP, and the MathJax CDN is blocked,
+     * so flashcard / essay-feedback / sandbox / dashboard pages render broken
+     * (clicks and math fail). Full Moodle pages therefore get only the non-CSP
+     * hardening headers — matching Moodle core, which ships no page-level CSP —
+     * while the raw endpoints keep the lock-down.
+     *
+     * @param bool $fullmoodlepage True for full Moodle pages (omit the CSP).
+     * @return array<string, string> Header name => value.
+     */
+    public static function build_security_headers(bool $fullmoodlepage = false): array {
+        $headers = [];
+        if (!$fullmoodlepage) {
+            $connect = [
+                "'self'",
+                'https://api.openai.com',
+                'https://api.anthropic.com',
+                'https://api.x.ai',
+                'https://api.mistral.ai',
+                'https://api.deepseek.com',
+                'https://generativelanguage.googleapis.com',
+                'https://api.minimax.chat',
+                'https://openrouter.ai',
+                'wss://api.openai.com',
+                'wss://api.x.ai',
+            ];
+            $headers['Content-Security-Policy'] = "default-src 'self'; "
+                 . "script-src 'self' 'unsafe-inline'; "
+                 . "style-src 'self' 'unsafe-inline'; "
+                 . "img-src 'self' data: blob:; "
+                 . "media-src 'self' blob:; "
+                 . "font-src 'self' data:; "
+                 . 'connect-src ' . implode(' ', $connect) . '; '
+                 . "frame-ancestors 'self';";
+        }
+        $headers['X-Content-Type-Options'] = 'nosniff';
+        $headers['X-Frame-Options'] = 'SAMEORIGIN';
+        $headers['Referrer-Policy'] = 'same-origin';
+        return $headers;
     }
 
     /**

--- a/classes/security.php
+++ b/classes/security.php
@@ -145,6 +145,9 @@ class security {
      *
      * Call from every SOLA entry point that renders learner-affecting HTML
      * or streams AI output.
+     *
+     * @param bool $fullmoodlepage True for full Moodle pages, which omit the
+     *                             strict CSP (it breaks Moodle's own YUI/JS).
      */
     public static function send_security_headers(bool $fullmoodlepage = false): void {
         if (headers_sent()) {

--- a/essay_feedback.php
+++ b/essay_feedback.php
@@ -48,7 +48,7 @@ $PAGE->set_course($course);
 $PAGE->set_title(get_string('essay_feedback:title', 'local_ai_course_assistant'));
 $PAGE->set_heading($course->fullname);
 
-security::send_security_headers();
+security::send_security_headers(true);
 
 echo $OUTPUT->header();
 ?>

--- a/flashcards.php
+++ b/flashcards.php
@@ -49,7 +49,7 @@ $PAGE->set_course($course);
 $PAGE->set_title(get_string('flashcards:title', 'local_ai_course_assistant'));
 $PAGE->set_heading($course->fullname);
 
-security::send_security_headers();
+security::send_security_headers(true);
 
 $due = flashcard_manager::get_due((int) $USER->id, $courseid, 30);
 

--- a/instructor_dashboard.php
+++ b/instructor_dashboard.php
@@ -66,7 +66,7 @@ $PAGE->set_title(get_string('instructor_dashboard:title', 'local_ai_course_assis
     \local_ai_course_assistant\branding::short_name()));
 $PAGE->set_heading($course->fullname);
 
-security::send_security_headers();
+security::send_security_headers(true);
 
 // v4.8.0: needs-review queue resolve action.
 if ($action === 'resolvereview' && confirm_sesskey()) {

--- a/tests/a11y/flashcard-click-check.js
+++ b/tests/a11y/flashcard-click-check.js
@@ -1,0 +1,108 @@
+// Live regression check for the flashcard review page (v6.2.x).
+//
+// Guards the fix where security::send_security_headers() applied a strict CSP
+// (no 'unsafe-eval') to flashcards.php — a full Moodle page — which broke
+// Moodle's own YUI/requireJS and blocked the MathJax CDN, leaving the page
+// JS-broken. This harness logs in, opens the flashcard page, and asserts:
+//   1. the page loads with NO uncaught JS / CSP errors,
+//   2. clicking "Reveal" shows the answer,
+//   3. clicking a grade button advances to the next card.
+//
+// Prereq: local Moodle at http://localhost:8080 (admin/Admin1234!), course
+// id=2 with flashcards enabled and at least 2 cards due for the admin user.
+// Seed with a CLI that calls flashcard_manager::save_batch() and
+// set_config('flashcards_enabled_course_2', 1, 'local_ai_course_assistant').
+// Run: node tests/a11y/flashcard-click-check.js
+const fs = require('fs');
+const puppeteer = require('puppeteer');
+
+const BASE = process.env.SOLA_A11Y_BASE || 'http://localhost:8080';
+const USER = process.env.SOLA_A11Y_USER || 'admin';
+const PASS = process.env.SOLA_A11Y_PASS || 'Admin1234!';
+const COURSEID = process.env.SOLA_A11Y_COURSEID || '2';
+
+function pickChrome() {
+  const c = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+  if (fs.existsSync(c)) return c;
+  try { return puppeteer.executablePath(); } catch (e) { return undefined; }
+}
+
+async function login(page) {
+  await page.goto(`${BASE}/login/index.php`, { waitUntil: 'networkidle2' });
+  await page.waitForSelector('#username', { timeout: 15000 });
+  await page.type('#username', USER);
+  await page.type('#password', PASS);
+  await Promise.all([
+    page.waitForNavigation({ waitUntil: 'networkidle2' }),
+    page.click('#loginbtn'),
+  ]);
+  if (/\/login\/index\.php/.test(page.url())) {
+    throw new Error('Login failed; check credentials / pending upgrade.');
+  }
+}
+
+(async () => {
+  const browser = await puppeteer.launch({
+    executablePath: pickChrome(),
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+  const fail = (m) => { console.log('FAIL: ' + m); process.exitCode = 1; };
+  const jsErrors = [];
+  try {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1100, height: 900 });
+    page.on('pageerror', (e) => jsErrors.push('PAGEERROR: ' + e.message));
+    page.on('console', (m) => { if (m.type() === 'error') jsErrors.push('CONSOLE.ERROR: ' + m.text()); });
+
+    await login(page);
+    await page.goto(`${BASE}/local/ai_course_assistant/flashcards.php?courseid=${COURSEID}`,
+      { waitUntil: 'networkidle2', timeout: 30000 });
+
+    const init = await page.evaluate(() => {
+      const cards = Array.from(document.querySelectorAll('.aica-fc-card'));
+      const vis = cards.filter((c) => getComputedStyle(c).display !== 'none');
+      return { numCards: cards.length, visibleCards: vis.length };
+    });
+    console.log('INITIAL:', JSON.stringify(init));
+    if (init.numCards < 2) { fail('need >= 2 due cards seeded for course ' + COURSEID); throw new Error('stop'); }
+    if (init.visibleCards !== 1) fail('exactly one card should be visible at a time');
+
+    // The fix: no CSP-induced JS errors on this full Moodle page.
+    if (jsErrors.length) fail('page had JS/CSP errors on load: ' + JSON.stringify(jsErrors));
+
+    // Reveal the answer.
+    const revealed = await page.evaluate(() => {
+      const card = Array.from(document.querySelectorAll('.aica-fc-card')).find((c) => getComputedStyle(c).display !== 'none');
+      const btn = card && card.querySelector('.aica-fc-reveal');
+      if (!btn) return false;
+      btn.click();
+      const back = card.querySelector('.aica-fc-back');
+      return back ? getComputedStyle(back).display !== 'none' : false;
+    });
+    if (!revealed) fail('clicking Reveal did not show the answer');
+
+    // Grade "Easy" and confirm advance to the next card.
+    const firstQ = await page.evaluate(() => {
+      const card = Array.from(document.querySelectorAll('.aica-fc-card')).find((c) => getComputedStyle(c).display !== 'none');
+      return card.querySelector('.aica-fc-q').textContent.trim();
+    });
+    await page.evaluate(() => {
+      const card = Array.from(document.querySelectorAll('.aica-fc-card')).find((c) => getComputedStyle(c).display !== 'none');
+      card.querySelector('.aica-fc-grade[data-q="5"]').click();
+    });
+    await new Promise((r) => setTimeout(r, 900));
+    const afterGrade = await page.evaluate(() => {
+      const card = Array.from(document.querySelectorAll('.aica-fc-card')).find((c) => getComputedStyle(c).display !== 'none');
+      return card ? card.querySelector('.aica-fc-q').textContent.trim() : null;
+    });
+    if (afterGrade === firstQ) fail('grading did not advance to the next card');
+
+    if (jsErrors.length) fail('JS/CSP errors after interaction: ' + JSON.stringify(jsErrors));
+    if (!process.exitCode) console.log('PASS: flashcard page loads clean, reveal + grade work.');
+  } catch (e) {
+    if (e.message !== 'stop') { console.log('ERROR: ' + e.message); process.exitCode = 1; }
+  } finally {
+    await browser.close();
+  }
+})();

--- a/tests/security_headers_test.php
+++ b/tests/security_headers_test.php
@@ -1,0 +1,59 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Unit tests for security::build_security_headers (v6.2.x).
+ *
+ * Guards the fix where the strict CSP broke Moodle's own YUI/requireJS on full
+ * Moodle pages (flashcards, essay feedback, sandbox, instructor dashboard).
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_ai_course_assistant\security::build_security_headers
+ */
+final class security_headers_test extends \advanced_testcase {
+
+    public function test_raw_endpoint_sends_strict_csp(): void {
+        $h = security::build_security_headers(false);
+        $this->assertArrayHasKey('Content-Security-Policy', $h);
+        $csp = $h['Content-Security-Policy'];
+        $this->assertStringContainsString("script-src 'self' 'unsafe-inline'", $csp);
+        $this->assertStringContainsString("default-src 'self'", $csp);
+        // The raw CSP must NOT permit eval (defence-in-depth for data endpoints).
+        $this->assertStringNotContainsString('unsafe-eval', $csp);
+    }
+
+    public function test_full_moodle_page_omits_csp(): void {
+        $h = security::build_security_headers(true);
+        // A full Moodle page must NOT receive the plugin CSP — it breaks YUI
+        // (needs unsafe-eval) and blocks the MathJax CDN, crippling page JS.
+        $this->assertArrayNotHasKey('Content-Security-Policy', $h);
+    }
+
+    public function test_hardening_headers_present_in_both_modes(): void {
+        foreach ([true, false] as $fullpage) {
+            $h = security::build_security_headers($fullpage);
+            $this->assertSame('nosniff', $h['X-Content-Type-Options']);
+            $this->assertSame('SAMEORIGIN', $h['X-Frame-Options']);
+            $this->assertSame('same-origin', $h['Referrer-Policy']);
+        }
+    }
+}

--- a/vendor_dpa.php
+++ b/vendor_dpa.php
@@ -41,7 +41,7 @@ $PAGE->set_title(get_string('admin:vendor_dpa:title', 'local_ai_course_assistant
 $PAGE->set_heading(get_string('admin:vendor_dpa:title', 'local_ai_course_assistant',
     \local_ai_course_assistant\branding::short_name()));
 
-\local_ai_course_assistant\security::send_security_headers();
+\local_ai_course_assistant\security::send_security_headers(true);
 
 echo $OUTPUT->header();
 

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_ai_course_assistant';
-$plugin->version = 2026061004;
+$plugin->version = 2026061005;
 $plugin->requires = 2024100700; // Moodle 4.5+.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '6.2.0';
+$plugin->release = '6.2.1';


### PR DESCRIPTION
## Summary

The flashcard review page didn't work because `security::send_security_headers()` applied a strict Content-Security-Policy (no `'unsafe-eval'`) to `flashcards.php` — a **full Moodle page**. Moodle's YUI requires `eval`, so the CSP broke core JS (YUI init, requireJS string loading) and blocked the MathJax CDN, leaving the page JS-broken (and any math on cards unrendered).

Reproduced with Puppeteer: **6 CSP/`unsafe-eval` pageerrors** on load. The same CSP hit five full Moodle pages: flashcards, essay_feedback, sandbox, instructor_dashboard, vendor_dpa. (`sandbox.php` already worked around it by not calling the function.)

**Fix:** `send_security_headers(bool $fullmoodlepage = false)`. Full-page callers pass `true` and receive only the non-CSP hardening headers (`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`) — matching Moodle core, which ships no page-level CSP. The plugin's **raw output endpoints** (SSE, TTS, transcribe, webhooks, media viewer) are unchanged and keep the lock-down. Header construction extracted to a pure, unit-testable `build_security_headers()`.

## Test Plan
- [x] Puppeteer before: 6 CSP/eval pageerrors; after: **0 JS errors**, reveal shows answer, grade advances to next card
- [x] Grade persists end-to-end: graded card rescheduled in DB (`repetitions=1, interval_days=4`, SM-2-lite "Easy")
- [x] New unit tests `security_headers_test` (3/3): raw mode keeps strict CSP (and never `unsafe-eval`), full-page mode omits CSP, both keep hardening headers
- [x] New a11y harness `tests/a11y/flashcard-click-check.js`
- [x] Validators 36/36; all changed PHP lint-clean
- [x] version 6.2.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)