### PR TITLE
fix(voice): STT accepts real recordings; TTS uses the provider registry (v6.2.2)

### DIFF
--- a/classes/hook_callbacks.php
+++ b/classes/hook_callbacks.php
@@ -581,11 +581,13 @@ class hook_callbacks {
 
         // Voice mode availability (global flags only; per-course control via starter toggles).
         $realtimeenabled = (bool)get_config('local_ai_course_assistant', 'realtime_enabled');
-        $realtimeapikey = get_config('local_ai_course_assistant', 'realtime_apikey');
-        $provider       = get_config('local_ai_course_assistant', 'provider');
-        $mainapikey     = get_config('local_ai_course_assistant', 'apikey');
-        $hasttskey = !empty($realtimeapikey) || ($provider === 'openai' && !empty($mainapikey));
-        $ttsurl = $hasttskey
+        // v6.2.x: gate the speaker button on whether ANY voice provider is
+        // configured (a voice_providers row, or the legacy realtime/OpenAI key),
+        // not the legacy key alone. tts.php resolves the actual provider through
+        // the registry; the old legacy-only check hid registry-configured
+        // provider TTS on sites running a non-OpenAI chat provider, silently
+        // degrading the speaker to the browser SpeechSynthesis voice.
+        $ttsurl = \local_ai_course_assistant\voice_registry::is_configured()
             ? (new \moodle_url('/local/ai_course_assistant/tts.php'))->out(false)
             : '';
 

--- a/classes/security.php
+++ b/classes/security.php
@@ -38,6 +38,21 @@ class security {
         'audio/mp3', 'audio/wav', 'audio/x-wav', 'audio/flac', 'audio/aac',
     ];
 
+    /**
+     * Container MIME types that finfo emits for audio-only MediaRecorder
+     * recordings. A WebM/Matroska audio container sniffs as video/webm (or, on
+     * some magic databases, application/octet-stream); an MP4 audio container
+     * sniffs as video/mp4; an Ogg container as application/ogg or video/ogg.
+     * The earlier audio/*-only allowlist rejected every real browser recording
+     * with HTTP 415, so STT never produced a transcript.
+     *
+     * @var string[]
+     */
+    public const AUDIO_CONTAINER_ALLOWLIST = [
+        'video/webm', 'video/ogg', 'video/mp4', 'video/x-matroska',
+        'application/ogg',
+    ];
+
     /** @var int Maximum audio upload size in bytes (25 MB). */
     public const MAX_AUDIO_BYTES = 25 * 1024 * 1024;
 
@@ -130,6 +145,40 @@ class security {
             if (isset($parts['port']) && (int) $parts['port'] !== (int) $port) {
                 continue;
             }
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Decide whether an uploaded audio file is acceptable for transcription.
+     *
+     * Validation is defence-in-depth (the file is forwarded only to the STT
+     * provider, never stored or executed), so it accepts what real browser
+     * recordings actually look like:
+     *  - a direct audio/* match (AUDIO_MIME_ALLOWLIST), or
+     *  - a known audio container that finfo reports as video/* or
+     *    application/ogg (AUDIO_CONTAINER_ALLOWLIST), or
+     *  - a generic sniff (octet-stream / empty / text/plain — magic-database
+     *    dependent) but only when the browser-declared type is an allowlisted
+     *    audio/* type.
+     *
+     * @param string $sniffed  MIME type from finfo on the file bytes.
+     * @param string $declared Browser-declared MIME ($_FILES['audio']['type']).
+     * @return bool
+     */
+    public static function is_allowed_audio_upload(string $sniffed, string $declared): bool {
+        $sniffed = strtolower(trim($sniffed));
+        $declared = strtolower(trim($declared));
+        if (in_array($sniffed, self::AUDIO_MIME_ALLOWLIST, true)) {
+            return true;
+        }
+        if (in_array($sniffed, self::AUDIO_CONTAINER_ALLOWLIST, true)) {
+            return true;
+        }
+        $generic = ['application/octet-stream', 'text/plain', ''];
+        if (in_array($sniffed, $generic, true)
+            && in_array($declared, self::AUDIO_MIME_ALLOWLIST, true)) {
             return true;
         }
         return false;

--- a/classes/voice_registry.php
+++ b/classes/voice_registry.php
@@ -221,6 +221,30 @@ class voice_registry {
     }
 
     /**
+     * Lightweight config-only check: is any voice provider configured?
+     *
+     * Unlike {@see resolve()} this does NOT run the spend guard, so it is cheap
+     * enough to call on every course-page render (e.g. to decide whether to
+     * show the speaker button). A configured voice_providers row serves any
+     * capability via resolve()'s first-row fallback, and the legacy single-key
+     * config (realtime_apikey, or the main OpenAI key) also counts. This fixes
+     * the speaker button being gated on the legacy key alone, which hid
+     * registry-configured TTS on sites running a non-OpenAI chat provider.
+     *
+     * @return bool
+     */
+    public static function is_configured(): bool {
+        if (!empty(self::parse_rows())) {
+            return true;
+        }
+        if (!empty(get_config('local_ai_course_assistant', 'realtime_apikey'))) {
+            return true;
+        }
+        return get_config('local_ai_course_assistant', 'provider') === 'openai'
+            && !empty(get_config('local_ai_course_assistant', 'apikey'));
+    }
+
+    /**
      * Return true when any voice capability (Realtime, TTS, or STT) resolves
      * to a configured provider. Used by the widget to suppress mic, speaker,
      * and voice tab affordances (and the matching help and welcome copy) on

--- a/tests/voice_audio_test.php
+++ b/tests/voice_audio_test.php
@@ -1,0 +1,92 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Unit tests for the voice STT/TTS fixes (v6.2.x):
+ *  - security::is_allowed_audio_upload (STT MediaRecorder container types).
+ *  - voice_registry::is_configured (TTS button gating includes the registry).
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_ai_course_assistant\security::is_allowed_audio_upload
+ */
+final class voice_audio_test extends \advanced_testcase {
+
+    public function test_direct_audio_types_accepted(): void {
+        $this->assertTrue(security::is_allowed_audio_upload('audio/webm', 'audio/webm'));
+        $this->assertTrue(security::is_allowed_audio_upload('audio/wav', ''));
+        // Case-insensitive.
+        $this->assertTrue(security::is_allowed_audio_upload('AUDIO/MPEG', ''));
+    }
+
+    public function test_mediarecorder_container_types_accepted(): void {
+        // What finfo actually emits for audio-only MediaRecorder recordings.
+        $this->assertTrue(security::is_allowed_audio_upload('video/webm', 'audio/webm'));
+        $this->assertTrue(security::is_allowed_audio_upload('video/mp4', 'audio/mp4'));
+        $this->assertTrue(security::is_allowed_audio_upload('application/ogg', 'audio/ogg'));
+    }
+
+    public function test_generic_sniff_trusts_declared_audio_type(): void {
+        // octet-stream / text/plain only pass when the browser said it's audio.
+        $this->assertTrue(security::is_allowed_audio_upload('application/octet-stream', 'audio/ogg'));
+        $this->assertTrue(security::is_allowed_audio_upload('text/plain', 'audio/webm'));
+        $this->assertTrue(security::is_allowed_audio_upload('', 'audio/mp4'));
+    }
+
+    public function test_generic_sniff_without_audio_declared_rejected(): void {
+        $this->assertFalse(security::is_allowed_audio_upload('application/octet-stream', ''));
+        $this->assertFalse(security::is_allowed_audio_upload('application/octet-stream', 'application/pdf'));
+    }
+
+    public function test_clearly_non_audio_rejected(): void {
+        $this->assertFalse(security::is_allowed_audio_upload('image/png', 'image/png'));
+        $this->assertFalse(security::is_allowed_audio_upload('application/pdf', 'audio/webm'));
+    }
+
+    public function test_is_configured_false_when_nothing_set(): void {
+        $this->resetAfterTest(true);
+        set_config('voice_providers', '', 'local_ai_course_assistant');
+        set_config('realtime_apikey', '', 'local_ai_course_assistant');
+        set_config('provider', 'anthropic', 'local_ai_course_assistant');
+        set_config('apikey', 'sk-anthropic', 'local_ai_course_assistant');
+        // Non-OpenAI chat provider with a key but no voice config: not configured.
+        $this->assertFalse(voice_registry::is_configured());
+    }
+
+    public function test_is_configured_true_with_registry_row(): void {
+        $this->resetAfterTest(true);
+        set_config('realtime_apikey', '', 'local_ai_course_assistant');
+        set_config('provider', 'anthropic', 'local_ai_course_assistant');
+        // A voice_providers row must count even when chat runs on a non-OpenAI
+        // provider — this is the regression the TTS fix addresses.
+        set_config('voice_providers', 'openai|sk-voice|OpenAI Voice', 'local_ai_course_assistant');
+        $this->assertTrue(voice_registry::is_configured());
+    }
+
+    public function test_is_configured_true_with_legacy_keys(): void {
+        $this->resetAfterTest(true);
+        set_config('voice_providers', '', 'local_ai_course_assistant');
+        set_config('provider', 'openai', 'local_ai_course_assistant');
+        set_config('apikey', 'sk-openai', 'local_ai_course_assistant');
+        set_config('realtime_apikey', '', 'local_ai_course_assistant');
+        $this->assertTrue(voice_registry::is_configured());
+    }
+}

--- a/transcribe.php
+++ b/transcribe.php
@@ -73,7 +73,11 @@ if ($size <= 0 || $size > \local_ai_course_assistant\security::MAX_AUDIO_BYTES) 
 $finfo = finfo_open(FILEINFO_MIME_TYPE);
 $sniffed = $finfo ? finfo_file($finfo, $tmp) : '';
 if ($finfo) { finfo_close($finfo); }
-if (!in_array($sniffed, \local_ai_course_assistant\security::AUDIO_MIME_ALLOWLIST, true)) {
+// MediaRecorder audio containers sniff as video/* or octet-stream (not audio/*),
+// so a strict audio/*-only check 415'd every real browser recording. Accept the
+// container types real recordings produce; see security::is_allowed_audio_upload.
+$declaredtype = !empty($_FILES['audio']['type']) ? (string) $_FILES['audio']['type'] : '';
+if (!\local_ai_course_assistant\security::is_allowed_audio_upload((string) $sniffed, $declaredtype)) {
     http_response_code(415);
     echo json_encode(['error' => 'Unsupported audio format.']);
     exit;

--- a/tts.php
+++ b/tts.php
@@ -115,6 +115,16 @@ if ($httpcode !== 200) {
     exit;
 }
 
+// Some providers/proxies return HTTP 200 with a JSON error or empty body (e.g.
+// a moderation refusal). Returning that as base64 "audio" makes the client
+// decode garbage and silently fall back to the browser voice with no
+// diagnostic. Audio (mp3) never starts with '{', so reject a non-audio 200.
+if ($response === false || $response === '' || $response[0] === '{') {
+    http_response_code(502);
+    echo json_encode(['error' => 'TTS provider returned no audio']);
+    exit;
+}
+
 // Log TTS cost: approximate tokens from character count (~4 chars/token).
 $charcount = mb_strlen($text);
 $approxtokens = (int) ceil($charcount / 4);

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_ai_course_assistant';
-$plugin->version = 2026061005;
+$plugin->version = 2026061006;
 $plugin->requires = 2024100700; // Moodle 4.5+.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '6.2.1';
+$plugin->release = '6.2.2';


### PR DESCRIPTION
## Summary

Three concrete code bugs (verified by reproduction, not just config) that made enabled-and-configured voice "do nothing":

1. **STT (critical) — every browser recording was rejected.** `transcribe.php` validated the upload against an `audio/*`-only `finfo` allowlist, but MediaRecorder audio containers sniff as `video/webm`, `video/mp4`, `application/ogg`, or `application/octet-stream`. So every recording got **HTTP 415** and no transcript appeared (the JS treats the error as "nothing spoken" and silently restarts). New `security::is_allowed_audio_upload()` accepts the container types real recordings produce, and trusts a generic sniff only when the browser-declared type is audio. The ext-map already used the declared type, so Whisper still receives the right extension.

2. **TTS (high) — the configured provider voice was never used.** The speaker button's `ttsurl` in `hook_callbacks.php` was gated on the **legacy** single-key check (`realtime_apikey` / OpenAI main key), never the `voice_providers` registry. A site running a non-OpenAI chat provider that configured TTS the documented way got an empty `ttsurl` and silently fell back to the browser `SpeechSynthesis` voice. New config-only `voice_registry::is_configured()` (no per-page spend-guard cost) gates the button correctly.

3. **TTS (robustness).** `tts.php` returned HTTP 200 with non-audio bodies (JSON error / empty) as base64 "audio". Now rejects a non-audio 200 with 502 so the fallback is intentional and loggable.

Voice remains **off by default** (unchanged) — this just makes it work when an admin enables and configures it.

## Test Plan
- [x] Unit tests `voice_audio_test` 8/8: `is_allowed_audio_upload` (direct audio, `video/*` + `application/ogg` containers, generic+declared-audio accepted, generic-without-audio + non-audio rejected, case-insensitive) and `is_configured` (empty→false, registry row→true, legacy keys→true)
- [x] Reproduced the STT MIME mismatch with `finfo` on real container headers (`video/mp4`, `application/octet-stream`)
- [x] Validators 36/36; all changed PHP lint-clean
- [x] version 6.2.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)