### PR TITLE
docs: add direct admin-settings URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Originally built by Tom Caswell and David Ta at Saylor University, open-sourced 
 1. Download or clone this repository
 2. Extract to `{moodle_root}/local/ai_course_assistant/`
 3. Visit Site Administration → Notifications to complete installation
-4. Configure settings at Site Administration → Plugins → Local plugins → AI Course Assistant
+4. Configure settings at Site Administration → Plugins → Local plugins → AI Course Assistant, or go directly to `{moodle_root_url}/admin/category.php?category=local_ai_course_assistant`
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

The user guide and README gave the **navigation path** to the plugin settings (Site Administration → Plugins → Local plugins → AI Course Assistant) but not the **direct URL**. Adds the direct address so admins can reach the settings page in one click:

`https://<your-moodle-site>/admin/category.php?category=local_ai_course_assistant`

This is the same URL the plugin's own admin pages already link to (`rag_admin.php`, `analytics.php`, `course_settings.php`, etc.).

- README.md: appended to the install/configure step.
- Wiki `Admin-Settings.md` and `Installation.md` updated in the wiki repo (already pushed).

## Test Plan
- [x] URL matches the canonical `new moodle_url('/admin/category.php', ['category' => 'local_ai_course_assistant'])` used across the plugin
- Docs-only change; no code or version impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)