### PR TITLE
feat(nav): course More-menu links to SOLA settings + analytics (v6.6.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Originally built by Tom Caswell and David Ta at Saylor University, open-sourced 
 3. Visit Site Administration → Notifications to complete installation
 4. Configure settings at Site Administration → Plugins → Local plugins → AI Course Assistant, or go directly to `{moodle_root_url}/admin/category.php?category=local_ai_course_assistant`
 
+### Finding the admin pages
+
+All admin pages live under one hub: **Site administration → Plugins → Local plugins → AI Course Assistant**. Bookmark the hub directly: `{moodle_root_url}/admin/category.php?category=local_ai_course_assistant` — it lists every settings page and tool (Analytics, RAG Index, Prompt Debug Log, Emergency Controls, the editors). The Site administration search box also finds every page by name (try "AI Course"). Course staff additionally get **Course AI Settings** and **AI Tutor Analytics** links in each course's "More" menu (v6.6.1+). Note: Moodle does not show a "Settings" link for local plugins on the Plugins overview page (admin/plugins.php) — that column only exists for other plugin types, so use the hub bookmark instead.
+
 ## Configuration
 
 ### Required Settings

--- a/classes/prompt_debug.php
+++ b/classes/prompt_debug.php
@@ -135,6 +135,10 @@ class prompt_debug {
      */
     public static function write_entry(string $entry): void {
         $logpath = self::log_path();
+        // PHP caches stat results per path within a process, so filesize()
+        // can return a stale value after the file was written earlier in the
+        // same request — the rotation check then silently never fires.
+        clearstatcache(true, $logpath);
         if (file_exists($logpath) && filesize($logpath) > self::MAX_LOG_BYTES) {
             file_put_contents($logpath, '');
         }

--- a/lib.php
+++ b/lib.php
@@ -140,3 +140,43 @@ function local_ai_course_assistant_get_custom_avatars(): array {
     }
     return $out;
 }
+
+/**
+ * Add AI Course Assistant links to the course navigation ("More" menu).
+ *
+ * Admin feedback: the per-course settings and analytics pages were hard to
+ * find, buried under Site administration. This surfaces them where staff
+ * already are — on the course page — gated by the same capabilities the
+ * target pages themselves enforce. Learners (capability :use only) see
+ * nothing. Note Moodle never shows a "Settings" link for local plugins on
+ * the Plugins overview page (core hardcodes get_settings_section_name() to
+ * null for the local type), so course navigation is the supported way to
+ * make these pages findable outside the Site administration tree.
+ *
+ * @param navigation_node $navigation The course navigation node to extend.
+ * @param stdClass $course The course record.
+ * @param context_course $context The course context.
+ */
+function local_ai_course_assistant_extend_navigation_course(navigation_node $navigation, stdClass $course,
+        context_course $context): void {
+    if (has_capability('local/ai_course_assistant:manage', $context)) {
+        $navigation->add(
+            get_string('coursesettings:title', 'local_ai_course_assistant'),
+            new moodle_url('/local/ai_course_assistant/course_settings.php', ['courseid' => $course->id]),
+            navigation_node::TYPE_SETTING,
+            null,
+            'aicacoursesettings',
+            new pix_icon('i/settings', '')
+        );
+    }
+    if (has_capability('local/ai_course_assistant:viewanalytics', $context)) {
+        $navigation->add(
+            get_string('analytics:title', 'local_ai_course_assistant'),
+            new moodle_url('/local/ai_course_assistant/instructor_dashboard.php', ['courseid' => $course->id]),
+            navigation_node::TYPE_SETTING,
+            null,
+            'aicaanalytics',
+            new pix_icon('i/report', '')
+        );
+    }
+}

--- a/templates/analytics_dashboard.mustache
+++ b/templates/analytics_dashboard.mustache
@@ -26,6 +26,7 @@
         "token_analytics_url": "#",
         "analytics_base_url": "#",
         "form_action": "https://example.invalid/local/ai_course_assistant/analytics.php",
+        "experiment_form_action": "https://example.invalid/local/ai_course_assistant/analytics.php",
         "meta_ai_sse_url": "https://example.invalid/local/ai_course_assistant/meta_ai_sse.php",
         "sesskey": "abc123",
         "courseid_param": 0,

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_ai_course_assistant';
-$plugin->version = 2026061015;
+$plugin->version = 2026061016;
 $plugin->requires = 2024100700; // Moodle 4.5+.
 $plugin->supported = [405, 503]; // Tested on Moodle 4.5 through 5.3dev.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '6.6.0';
+$plugin->release = '6.6.1';


### PR DESCRIPTION
## Summary

Admin feedback: SOLA's admin settings and analytics pages are hard to find. Two-track fix; this PR is the code track (the docs track — wiki Home "Finding the admin pages" section — is already pushed and live, zero deploy).

- **Course "More" menu links** via `local_ai_course_assistant_extend_navigation_course`: **Course AI Settings** (gated `:manage` → `course_settings.php`) and **AI Tutor Analytics** (gated `:viewanalytics` → `instructor_dashboard.php`). Same capabilities the target pages enforce; learners see nothing. Reuses existing lang strings — zero i18n churn.
- **README**: "Finding the admin pages" section near the start (hub bookmark URL, admin-search tip).

**Why not a Settings link on admin/plugins.php** (the original suggestion): Moodle hardcodes `get_settings_section_name()` to `null` for local-type plugins (`lib/classes/plugininfo/base.php:545` + `local.php` does not override), so core never renders that column for local plugins — no supported way to add it. Documented in the callback docblock and README.

No deploy pressure: this rides the next release; nothing in the in-flight Catalyst request changes.

## Test Plan
- [x] PHP lint clean; PHPDoc complete on the new callback
- [x] Live Puppeteer check: both links present in course 2 nav with correct URLs; both target pages HTTP 200
- [x] Capability-gated identically to the target pages
- [ ] CI matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)