### PR TITLE
v6.7.0: Soapbox speech-practice feature (off by default)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 SOLA (Saylor Online Learning Assistant) is a Moodle local plugin that provides an AI-powered learning coach embedded in course pages. Students interact via a side tab on the right edge of the page (default: halfway down), which opens a chat drawer. A floating avatar button at the bottom corner is an alternative placement available via the Display Mode admin setting.
 
 - **Plugin component:** `local_ai_course_assistant`
-- **Current version:** `2026061015`, release `6.6.0`
+- **Current version:** `2026061500`, release `6.7.0`
 - **Source folder (canonical):** the git repo at `~/Library/CloudStorage/Dropbox/!Saylor/ai-projects/ai_course_assistant/` (edit and commit here; the older `aicoursetutor/ai_course_assistant` path is a stale remnant, do not deploy from it)
 - **Zip for upload:** built from the repo via `create_fixed_zip.sh`
 - **GitHub:** `https://github.com/saylordotorg/moodle-local_ai_course_assistant` (public)
@@ -54,6 +54,7 @@ SOLA (Saylor Online Learning Assistant) is a Moodle local plugin that provides a
 - RAG chunk-selection debug (v6.4.1): `prompt_debug_enabled` log gains a RETRIEVED CHUNKS block (score/cmid/module/content per chunk); debug viewer renders a chunks card; `prompt_playground.php` gains a live-retrieval test against the real retriever.
 - Avatar animation probe (v6.5.0, Stage 0 of the talking-avatar evaluation): SVG avatar idle blink (pure CSS, keyed off `data-avataranim` on the widget root) + `avatar_animation_enabled` setting (default on) gating blink, Web Audio mouth-sync, CSS mouth fallback, and the speaking pulse as one unit; per-course A/B override `avatar_animation_course_<id>`; on the policy bundle allowlist; `prefers-reduced-motion` respected in the rAF path. Decision doc: `.drafts/sola-talking-avatars-decision-2026-06-11.md`.
 - A/B experiment readout (v6.6.0): analytics dashboard comparison card (two course pickers, 10 engagement metrics with B vs A deltas) powered by `analytics::get_experiment_metrics()`; generic for any per-course experiment. Fix: `get_session_stats()` undercounted sessions (userid-keyed rows collapsed by get_records_sql; now id-keyed). Prompt debug formatter/parser/rotation extracted to `classes/prompt_debug.php` (shared by sse.php, prompt_debug_view.php, prompt_playground.php) with 12 tests pinning the log format (`tests/prompt_debug_test.php`).
+- Soapbox speech practice (v6.7.0): learner records a longer spoken presentation (optional name/topic/target-length), it is transcribed, scored against a per-course `speech` rubric, and saved to a personal score history. Off by default; per-course gated via `feature_flags::resolve('soapbox', $courseid)` (site `soapbox_enabled` default + `soapbox_enabled_course_<id>` three-way override). Learner page `soapbox.php` (course-nav link for `:use` when enabled); long-form STT endpoint `soapbox_transcribe.php` (300s timeout, 25MB cap, `soapbox_stt` rate bucket 12/600); scoring external function `score_speech`. Three STT tiers chosen by `soapbox_stt_mode` (server default / browser): self-hosted Whisper (free, via voice_registry), hosted OpenAI Whisper, or in-browser Web Speech API (free, no server). New `speech` rubric type in `rubric_manager` (5 default criteria; authorable on `rubric_admin.php`). Nullable `session_meta` column on `_practice_scores` holds the name/topic/target blob; audio and transcript text are NEVER stored. Privacy provider covers `session_meta` (metadata + export).
 
 ---
 
@@ -108,6 +109,10 @@ See `.drafts/sola-vendor-recommendations-2026-06-09.md` (concise canonical) and 
 | `classes/provider/claude_provider.php` | v5.11.0 `model_supports_temperature()` per-prefix deny-list (Opus 4.7/4.8/4.9 reject temperature) |
 | `classes/analytics.php` | Usage analytics and provider comparison |
 | `classes/external/generate_quiz.php` | Quiz generation (AI-guided + manual topic) |
+| `soapbox.php` | v6.7.0 Soapbox learner page (setup panel, record/transcribe, rubric feedback, My Speeches history); inline vanilla JS, server + browser STT modes |
+| `soapbox_transcribe.php` | v6.7.0 long-form STT endpoint (300s timeout, 25MB cap, `soapbox_stt` rate bucket); voice_registry-resolved Whisper |
+| `classes/external/score_speech.php` | v6.7.0 score a transcribed speech vs the `speech` rubric; persists score + meta (no audio/transcript) via `rubric_manager::save_score` |
+| `classes/rubric_manager.php` | Practice rubrics + `_practice_scores`; v6.7.0 adds `TYPE_SPEECH`, `DEFAULT_SPEECH_CRITERIA`, and `save_score` `$meta` (→ `session_meta`) |
 | `classes/external/get_realtime_token.php` | Fetches OpenAI Realtime ephemeral token |
 | `classes/external/save_avatar_preference.php` | Saves avatar selection to user preferences |
 | `rag_admin.php` | RAG index admin page (stat cards, per-course reindex/clear) |

--- a/classes/external/score_speech.php
+++ b/classes/external/score_speech.php
@@ -1,0 +1,255 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant\external;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->libdir . '/externallib.php');
+
+use external_api;
+use external_function_parameters;
+use external_value;
+use external_single_structure;
+use external_multiple_structure;
+use local_ai_course_assistant\provider\base_provider;
+use local_ai_course_assistant\rubric_manager;
+use local_ai_course_assistant\feature_flags;
+
+/**
+ * Soapbox: score a transcribed speech against the per-course speech rubric and
+ * return per-criterion scores + overall feedback, and persist the result to the
+ * learner's speech history (no audio or transcript text is stored). Non-
+ * streaming; called from soapbox.php after STT produces the transcript.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Tom Caswell & David Ta / Saylor University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class score_speech extends external_api {
+
+    /**
+     * @return external_function_parameters
+     */
+    public static function execute_parameters(): external_function_parameters {
+        return new external_function_parameters([
+            'courseid'   => new external_value(PARAM_INT, 'Course ID'),
+            'transcript' => new external_value(PARAM_RAW, 'STT transcript of the speech'),
+            'name'       => new external_value(PARAM_TEXT, 'Learner-chosen speech name', VALUE_DEFAULT, ''),
+            'topic'      => new external_value(PARAM_TEXT, 'Learner-chosen topic', VALUE_DEFAULT, ''),
+            'targetsec'  => new external_value(PARAM_INT, 'Target speech length in seconds (0 = none)', VALUE_DEFAULT, 0),
+            'durationsec' => new external_value(PARAM_INT, 'Actual recorded duration in seconds', VALUE_DEFAULT, 0),
+        ]);
+    }
+
+    /**
+     * @param int $courseid
+     * @param string $transcript
+     * @param string $name
+     * @param string $topic
+     * @param int $targetsec
+     * @param int $durationsec
+     * @return array
+     */
+    public static function execute(int $courseid, string $transcript, string $name = '',
+            string $topic = '', int $targetsec = 0, int $durationsec = 0): array {
+        global $USER;
+        $params = self::validate_parameters(self::execute_parameters(), [
+            'courseid' => $courseid, 'transcript' => $transcript, 'name' => $name,
+            'topic' => $topic, 'targetsec' => $targetsec, 'durationsec' => $durationsec,
+        ]);
+        $courseid = (int) $params['courseid'];
+        $context = \context_course::instance($courseid);
+        self::validate_context($context);
+        require_capability('local/ai_course_assistant:use', $context);
+
+        if (!feature_flags::resolve('soapbox', $courseid)) {
+            return self::empty_result('disabled');
+        }
+
+        $speech = trim($params['transcript']);
+        if (mb_strlen($speech) < 40) {
+            return self::empty_result('too_short');
+        }
+        if (mb_strlen($speech) > 40000) {
+            $speech = mb_substr($speech, 0, 40000);
+        }
+        $name = trim($params['name']);
+        $topic = trim($params['topic']);
+        $targetsec = max(0, (int) $params['targetsec']);
+        $durationsec = max(0, (int) $params['durationsec']);
+
+        // Resolve the per-course speech rubric (falls back to the global default).
+        // get_active_rubric() returns the criteria already decoded to an array.
+        $rubric = rubric_manager::get_active_rubric($courseid, rubric_manager::TYPE_SPEECH);
+        $criteriadefs = ($rubric && is_array($rubric->criteria)) ? $rubric->criteria : rubric_manager::DEFAULT_SPEECH_CRITERIA;
+        if (!is_array($criteriadefs) || empty($criteriadefs)) {
+            $criteriadefs = rubric_manager::DEFAULT_SPEECH_CRITERIA;
+        }
+        $maxscore = 5;
+        $rubriclines = [];
+        foreach ($criteriadefs as $c) {
+            $cn = (string) ($c['name'] ?? '');
+            $cd = (string) ($c['description'] ?? '');
+            $cm = (int) ($c['max_score'] ?? 5);
+            if ($cm > 0) {
+                $maxscore = $cm;
+            }
+            $rubriclines[] = "- {$cn}: {$cd} (0-{$cm})";
+        }
+        $rubrictext = implode("\n", $rubriclines);
+
+        $contextline = 'The learner is practising a spoken presentation.';
+        if ($topic !== '') {
+            $contextline .= ' Their stated topic is: "' . mb_substr($topic, 0, 300) . '".';
+        }
+        if ($targetsec > 0) {
+            $mins = round($targetsec / 60, 1);
+            $contextline .= " Their target length is about {$mins} minute(s)";
+            if ($durationsec > 0) {
+                $actualmin = round($durationsec / 60, 1);
+                $contextline .= "; they actually spoke for about {$actualmin} minute(s)";
+            }
+            $contextline .= '.';
+        }
+
+        $sysprompt = "You are a supportive public-speaking coach giving formative feedback on a learner's spoken "
+            . "presentation. You are reading a speech-to-text transcript, so ignore transcription artefacts "
+            . "(missing punctuation, homophone errors, '[inaudible]') and do not penalise them. {$contextline} "
+            . "Score each rubric criterion from 0 (not evident) to {$maxscore} (strong mastery). For each criterion give "
+            . "one or two sentences of concrete, encouraging feedback naming a specific strength and the single "
+            . "highest-leverage improvement. Then give a short overall comment and three concrete next-time tips ordered "
+            . "by impact. Be encouraging; this is practice. Respond with JSON only, in this shape:\n"
+            . '{"criteria":[{"name":"...","score":3,"feedback":"..."}], "overall":"...", "tips":["...","...","..."]}'
+            . "\n\nRUBRIC:\n{$rubrictext}\n\nTRANSCRIPT:\n{$speech}";
+
+        try {
+            $provider = base_provider::create_from_config($courseid);
+            $response = $provider->chat_completion(
+                $sysprompt,
+                [['role' => 'user', 'content' => 'Produce the feedback JSON now.']],
+                [
+                    'response_schema' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'criteria' => [
+                                'type' => 'array',
+                                'items' => [
+                                    'type' => 'object',
+                                    'properties' => [
+                                        'name'     => ['type' => 'string'],
+                                        'score'    => ['type' => 'integer'],
+                                        'feedback' => ['type' => 'string'],
+                                    ],
+                                    'required' => ['name', 'score', 'feedback'],
+                                ],
+                            ],
+                            'overall' => ['type' => 'string'],
+                            'tips'    => ['type' => 'array', 'items' => ['type' => 'string']],
+                        ],
+                        'required' => ['criteria', 'overall', 'tips'],
+                    ],
+                ]
+            );
+        } catch (\Throwable $e) {
+            return self::empty_result('provider_error');
+        }
+
+        $decoded = json_decode($response, true);
+        if (!$decoded || !isset($decoded['criteria'])) {
+            if (preg_match('/\{[\s\S]*\}/', $response, $m)) {
+                $decoded = json_decode($m[0], true);
+            }
+        }
+        if (!$decoded || !isset($decoded['criteria']) || !is_array($decoded['criteria'])) {
+            return self::empty_result('parse_error');
+        }
+
+        $criteria = [];
+        $sum = 0;
+        foreach ($decoded['criteria'] as $c) {
+            $sc = (int) ($c['score'] ?? 0);
+            $sum += $sc;
+            $criteria[] = [
+                'name'     => (string) ($c['name'] ?? ''),
+                'score'    => $sc,
+                'feedback' => (string) ($c['feedback'] ?? ''),
+            ];
+        }
+        $overall = (string) ($decoded['overall'] ?? '');
+        $tips = array_map('strval', (array) ($decoded['tips'] ?? []));
+
+        // Persist to the learner's speech history. We store the scores, feedback,
+        // duration, and a meta blob with the name/topic/target — never the audio
+        // or the transcript text.
+        $scoreid = 0;
+        try {
+            $rubricid = $rubric ? (int) $rubric->id : 0;
+            $meta = ['name' => $name, 'topic' => $topic, 'target' => $targetsec, 'tips' => $tips];
+            $scoreid = rubric_manager::save_score(
+                $rubricid, (int) $USER->id, $courseid, rubric_manager::TYPE_SPEECH,
+                $criteria, (int) round($sum / max(1, count($criteria))), $overall, $durationsec, $meta
+            );
+        } catch (\Throwable $e) {
+            // History persistence is best-effort; still return the feedback.
+            $scoreid = 0;
+        }
+
+        return [
+            'success'  => true,
+            'message'  => 'ok',
+            'criteria' => $criteria,
+            'overall'  => $overall,
+            'tips'     => $tips,
+            'scoreid'  => $scoreid,
+        ];
+    }
+
+    /**
+     * @param string $code
+     * @return array
+     */
+    private static function empty_result(string $code): array {
+        return [
+            'success'  => false,
+            'message'  => $code,
+            'criteria' => [],
+            'overall'  => '',
+            'tips'     => [],
+            'scoreid'  => 0,
+        ];
+    }
+
+    /**
+     * @return external_single_structure
+     */
+    public static function execute_returns(): external_single_structure {
+        return new external_single_structure([
+            'success'  => new external_value(PARAM_BOOL, 'Whether feedback was produced'),
+            'message'  => new external_value(PARAM_ALPHAEXT, 'Status code'),
+            'criteria' => new external_multiple_structure(
+                new external_single_structure([
+                    'name'     => new external_value(PARAM_RAW, 'Criterion name'),
+                    'score'    => new external_value(PARAM_INT, 'Score'),
+                    'feedback' => new external_value(PARAM_RAW, 'Feedback text'),
+                ])
+            ),
+            'overall'  => new external_value(PARAM_RAW, 'Overall comment'),
+            'tips'     => new external_multiple_structure(new external_value(PARAM_RAW, 'Next-time tip')),
+            'scoreid'  => new external_value(PARAM_INT, 'Saved history row id (0 if not saved)'),
+        ]);
+    }
+}

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -163,6 +163,7 @@ class provider implements
                 'overall_score' => 'privacy:metadata:local_ai_course_assistant_practice_scores:overall_score',
                 'scores' => 'privacy:metadata:local_ai_course_assistant_practice_scores:scores',
                 'ai_feedback' => 'privacy:metadata:local_ai_course_assistant_practice_scores:ai_feedback',
+                'session_meta' => 'privacy:metadata:local_ai_course_assistant_practice_scores:session_meta',
                 'timecreated' => 'privacy:metadata:local_ai_course_assistant_practice_scores:timecreated',
             ],
             'privacy:metadata:local_ai_course_assistant_practice_scores'
@@ -532,6 +533,7 @@ class provider implements
                         'scores' => $score->scores,
                         'ai_feedback' => $score->ai_feedback,
                         'session_duration' => $score->session_duration,
+                        'session_meta' => $score->session_meta,
                         'timecreated' => transform::datetime($score->timecreated),
                     ]
                 );

--- a/classes/rubric_manager.php
+++ b/classes/rubric_manager.php
@@ -31,6 +31,18 @@ class rubric_manager {
     /** @var string Table name for practice scores. */
     private const TABLE_SCORES = 'local_ai_course_assistant_practice_scores';
 
+    /** @var string Rubric/session type for Soapbox speech practice. */
+    const TYPE_SPEECH = 'speech';
+
+    /** @var array Default Soapbox speech rubric criteria (graded class speech). */
+    const DEFAULT_SPEECH_CRITERIA = [
+        ['name' => 'Delivery & Fluency', 'description' => 'Pace, clarity, confidence, and smoothness of speaking.', 'max_score' => 5],
+        ['name' => 'Structure & Organization', 'description' => 'Clear opening, logical flow of ideas, and a strong close.', 'max_score' => 5],
+        ['name' => 'Content & Relevance', 'description' => 'Ideas stay on topic and are well supported and developed.', 'max_score' => 5],
+        ['name' => 'Language & Vocabulary', 'description' => 'Word choice, grammar, and varied, precise language.', 'max_score' => 5],
+        ['name' => 'Time Management', 'description' => 'Fits the target length without rushing or running long.', 'max_score' => 5],
+    ];
+
     /** @var array Default conversation practice rubric criteria. */
     const DEFAULT_CONVERSATION_CRITERIA = [
         [
@@ -213,6 +225,16 @@ class rubric_manager {
         if (!$pronunciationexists) {
             self::create_rubric(0, 'pronunciation', 'Pronunciation Practice Rubric', self::DEFAULT_PRONUNCIATION_CRITERIA);
         }
+
+        $speechexists = $DB->record_exists(self::TABLE_RUBRICS, [
+            'courseid' => 0,
+            'type' => self::TYPE_SPEECH,
+            'active' => 1,
+        ]);
+
+        if (!$speechexists) {
+            self::create_rubric(0, self::TYPE_SPEECH, 'Soapbox Speech Rubric', self::DEFAULT_SPEECH_CRITERIA);
+        }
     }
 
     /**
@@ -221,15 +243,16 @@ class rubric_manager {
      * @param int $rubricid
      * @param int $userid
      * @param int $courseid
-     * @param string $sessiontype 'conversation' or 'pronunciation'
+     * @param string $sessiontype 'conversation', 'pronunciation', or 'speech'
      * @param array $scores Array of per-criterion scores [{name, score, feedback}, ...]
      * @param int $overallscore Overall score for the session.
      * @param string $aifeedback AI-generated feedback text.
      * @param int $duration Session duration in seconds.
+     * @param array|null $meta Optional metadata blob (e.g. Soapbox name/topic/target); JSON-encoded. Never audio/transcript.
      * @return int The new score record ID.
      */
     public static function save_score(int $rubricid, int $userid, int $courseid, string $sessiontype,
-            array $scores, int $overallscore, string $aifeedback, int $duration): int {
+            array $scores, int $overallscore, string $aifeedback, int $duration, ?array $meta = null): int {
         global $DB;
 
         $record = new \stdClass();
@@ -241,6 +264,7 @@ class rubric_manager {
         $record->overall_score = $overallscore;
         $record->ai_feedback = $aifeedback;
         $record->session_duration = $duration;
+        $record->session_meta = ($meta !== null) ? json_encode($meta) : null;
         $record->timecreated = time();
 
         return $DB->insert_record(self::TABLE_SCORES, $record);
@@ -285,7 +309,11 @@ class rubric_manager {
         ]);
         if (!$exists) {
             $criteria = self::get_default_criteria($type);
-            $title = $type === 'pronunciation' ? 'Pronunciation Practice Rubric' : 'Conversation Practice Rubric';
+            $titles = [
+                'pronunciation' => 'Pronunciation Practice Rubric',
+                self::TYPE_SPEECH => 'Soapbox Speech Rubric',
+            ];
+            $title = $titles[$type] ?? 'Conversation Practice Rubric';
             self::create_rubric(0, $type, $title, $criteria);
         }
     }
@@ -297,7 +325,13 @@ class rubric_manager {
      * @return array
      */
     public static function get_default_criteria(string $type): array {
-        return $type === 'pronunciation' ? self::DEFAULT_PRONUNCIATION_CRITERIA : self::DEFAULT_CONVERSATION_CRITERIA;
+        if ($type === 'pronunciation') {
+            return self::DEFAULT_PRONUNCIATION_CRITERIA;
+        }
+        if ($type === self::TYPE_SPEECH) {
+            return self::DEFAULT_SPEECH_CRITERIA;
+        }
+        return self::DEFAULT_CONVERSATION_CRITERIA;
     }
 
     /**

--- a/course_settings.php
+++ b/course_settings.php
@@ -136,6 +136,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         'flashcards_on'           => 'flashcards_enabled_course_',
         'sandbox_on'              => 'code_sandbox_enabled_course_',
         'essay_on'                => 'essay_feedback_enabled_course_',
+        'soapbox_on'              => 'soapbox_enabled_course_',
         'we_on'                   => 'worked_examples_enabled_course_',
     ] as $field => $cfgprefix) {
         $v = optional_param($field, '', PARAM_RAW_TRIMMED);
@@ -476,16 +477,19 @@ echo html_writer::div(
             $fcraw        = get_config('local_ai_course_assistant', 'flashcards_enabled_course_' . $courseid);
             $sbraw        = get_config('local_ai_course_assistant', 'code_sandbox_enabled_course_' . $courseid);
             $essraw       = get_config('local_ai_course_assistant', 'essay_feedback_enabled_course_' . $courseid);
+            $sbxraw       = get_config('local_ai_course_assistant', 'soapbox_enabled_course_' . $courseid);
             $weraw        = get_config('local_ai_course_assistant', 'worked_examples_enabled_course_' . $courseid);
             $socraticgbl  = (bool) get_config('local_ai_course_assistant', 'socratic_mode_enabled');
             $fcgbl        = (bool) get_config('local_ai_course_assistant', 'flashcards_enabled');
             $sbgbl        = (bool) get_config('local_ai_course_assistant', 'code_sandbox_enabled');
             $essgbl       = (bool) get_config('local_ai_course_assistant', 'essay_feedback_enabled');
+            $sbxgbl       = (bool) get_config('local_ai_course_assistant', 'soapbox_enabled');
             $wegbl        = (bool) get_config('local_ai_course_assistant', 'worked_examples_enabled');
             // Resolved booleans for `if (X) { show secondary link }` checks.
             $fcon       = \local_ai_course_assistant\feature_flags::resolve('flashcards', $courseid);
             $sbon       = \local_ai_course_assistant\feature_flags::resolve('code_sandbox', $courseid);
             $esson      = \local_ai_course_assistant\feature_flags::resolve('essay_feedback', $courseid);
+            $sbxon      = \local_ai_course_assistant\feature_flags::resolve('soapbox', $courseid);
             $digeston   = (bool) get_config('local_ai_course_assistant', 'digest_email_enabled_course_' . $courseid);
             $extresraw  = get_config('local_ai_course_assistant', 'external_resources_enabled_course_' . $courseid);
             $extresglobal = (bool) get_config('local_ai_course_assistant', 'external_resources_enabled');
@@ -593,6 +597,28 @@ echo html_writer::div(
                                 ['courseid' => $courseid]))->out(false); ?>"
                            class="btn btn-sm btn-outline-secondary" target="_blank">
                             <?php echo get_string('essay_feedback:link', 'local_ai_course_assistant'); ?> &rarr;
+                        </a>
+                    </div>
+                    <?php } ?>
+                </div>
+            </div>
+
+            <?php // v6.7.0: Soapbox speech-practice toggle. Three-way (inherit/force on/force off). ?>
+            <div class="form-group row mt-2">
+                <label class="col-sm-3 col-form-label" for="aica-soapbox-on">
+                    <?php echo get_string('soapbox:title', 'local_ai_course_assistant'); ?>
+                </label>
+                <div class="col-sm-9">
+                    <?php echo $renderpedagogyselect('soapbox_on', $sbxraw, $sbxgbl, 'aica-soapbox-on'); ?>
+                    <small class="form-text text-muted">
+                        <?php echo get_string('soapbox:toggle_help', 'local_ai_course_assistant'); ?>
+                    </small>
+                    <?php if ($sbxon) { ?>
+                    <div class="mt-1">
+                        <a href="<?php echo (new moodle_url('/local/ai_course_assistant/soapbox.php',
+                                ['courseid' => $courseid]))->out(false); ?>"
+                           class="btn btn-sm btn-outline-secondary" target="_blank">
+                            <?php echo get_string('soapbox:link', 'local_ai_course_assistant'); ?> &rarr;
                         </a>
                     </div>
                     <?php } ?>

--- a/db/install.xml
+++ b/db/install.xml
@@ -453,11 +453,12 @@
         <FIELD NAME="rubricid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="courseid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="session_type" TYPE="char" LENGTH="20" NOTNULL="true" SEQUENCE="false" COMMENT="conversation or pronunciation"/>
+        <FIELD NAME="session_type" TYPE="char" LENGTH="20" NOTNULL="true" SEQUENCE="false" COMMENT="conversation, pronunciation, or speech"/>
         <FIELD NAME="scores" TYPE="text" NOTNULL="true" SEQUENCE="false" COMMENT="JSON array of per-criterion scores"/>
         <FIELD NAME="overall_score" TYPE="int" LENGTH="3" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="ai_feedback" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="AI-generated summary feedback"/>
         <FIELD NAME="session_duration" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Duration in seconds"/>
+        <FIELD NAME="session_meta" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Optional JSON metadata (e.g. Soapbox name/topic/target); never audio or transcript"/>
         <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>

--- a/db/services.php
+++ b/db/services.php
@@ -319,4 +319,12 @@ $functions = [
         'capabilities' => 'local/ai_course_assistant:use',
         'services'     => [MOODLE_OFFICIAL_MOBILE_SERVICE],
     ],
+    'local_ai_course_assistant_score_speech' => [
+        'classname'    => \local_ai_course_assistant\external\score_speech::class,
+        'description'  => 'Soapbox: score a transcribed speech against the per-course speech rubric and save history.',
+        'type'         => 'read',
+        'ajax'         => true,
+        'capabilities' => 'local/ai_course_assistant:use',
+        'services'     => [MOODLE_OFFICIAL_MOBILE_SERVICE],
+    ],
 ];

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1098,5 +1098,20 @@ function xmldb_local_ai_course_assistant_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2026061014, 'local', 'ai_course_assistant');
     }
 
+    if ($oldversion < 2026061500) {
+        // v6.7.0 (Soapbox): optional JSON metadata column on practice scores.
+        // Soapbox stores the learner-chosen name/topic/target-time blob here
+        // (never audio or transcript text) so the speech-history list can label
+        // and filter past attempts. Nullable text; pre-existing rows stay NULL.
+        $table = new xmldb_table('local_ai_course_assistant_practice_scores');
+        $field = new xmldb_field('session_meta', XMLDB_TYPE_TEXT, null,
+            null, null, null, null, 'session_duration');
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        upgrade_plugin_savepoint(true, 2026061500, 'local', 'ai_course_assistant');
+    }
+
     return true;
 }

--- a/lang/en/local_ai_course_assistant.php
+++ b/lang/en/local_ai_course_assistant.php
@@ -676,6 +676,7 @@ $string['privacy:metadata:local_ai_course_assistant_practice_scores:session_type
 $string['privacy:metadata:local_ai_course_assistant_practice_scores:overall_score'] = 'The overall score achieved.';
 $string['privacy:metadata:local_ai_course_assistant_practice_scores:scores'] = 'Per-criterion scores in JSON format.';
 $string['privacy:metadata:local_ai_course_assistant_practice_scores:ai_feedback'] = 'AI-generated feedback on the practice session.';
+$string['privacy:metadata:local_ai_course_assistant_practice_scores:session_meta'] = 'Optional metadata you supplied for the session, such as the name, topic, and target length of a Soapbox speech. Never includes audio or a transcript.';
 $string['privacy:metadata:local_ai_course_assistant_practice_scores:timecreated'] = 'The time the score was recorded.';
 
 // v5.3.17: privacy metadata strings for tables added in v5.0–v5.3 that
@@ -1191,6 +1192,8 @@ $string['pedagogy:code_sandbox']           = 'Python code sandbox on by default'
 $string['pedagogy:code_sandbox_desc']      = 'When on, the in-browser Python sandbox is available in every course unless the course has its own override.';
 $string['pedagogy:essay_feedback']         = 'Essay feedback on by default';
 $string['pedagogy:essay_feedback_desc']    = 'When on, AI essay feedback is available in every course unless the course has its own override.';
+$string['pedagogy:soapbox']                = 'Soapbox speech feedback on by default';
+$string['pedagogy:soapbox_desc']           = 'When on, the Soapbox speech-practice tool is available in every course unless the course has its own override. Leave off and enable it only in the courses that need it (typically speech and communication courses).';
 $string['pedagogy:talking_avatar']         = 'Talking avatar on by default';
 $string['pedagogy:talking_avatar_desc']    = 'When on, the talking-avatar surface is enabled in every course unless the course has its own override. Requires a configured provider (D-ID, HeyGen, Tavus, or Synthesia Agents) below; otherwise the widget shows a "configure a provider" notice and the avatar does not animate.';
 $string['pedagogy:crossmastery']           = 'Cross-course mastery rollup on by default';
@@ -1534,6 +1537,46 @@ $string['essay_feedback:col_score']    = 'Score';
 $string['essay_feedback:col_feedback'] = 'Feedback';
 $string['essay_feedback:toggle']       = 'Enable Essay feedback for this course';
 $string['essay_feedback:toggle_help']  = 'Learners get a dedicated page to paste a draft and receive rubric-scored feedback with revision suggestions. Off by default.';
+
+// Soapbox speech practice (v6.7.0).
+$string['settings:soapbox_stt_mode']        = 'Soapbox transcription mode';
+$string['settings:soapbox_stt_mode_desc']   = 'How Soapbox turns a recorded speech into text. Server uses the configured Whisper provider (self-hosted is free; hosted OpenAI is about USD 0.006 per minute). Browser uses the learner\'s built-in speech recognition (free, no server, works in Chrome and Safari only). Server is recommended so transcription quality does not depend on the learner\'s browser.';
+$string['settings:soapbox_stt_mode_server'] = 'Server (Whisper provider)';
+$string['settings:soapbox_stt_mode_browser']= 'Browser (free, no server)';
+$string['soapbox:title']            = 'Soapbox';
+$string['soapbox:link']             = 'Soapbox speech practice';
+$string['soapbox:disabled']         = 'Soapbox is not enabled for this course.';
+$string['soapbox:intro']            = 'Give a speech and get coaching. Optionally set a name, topic, and target length, then record yourself speaking. Soapbox transcribes your speech, scores it against a speaking rubric, and gives you concrete tips. Your audio and the transcript are never stored, only your scores and feedback.';
+$string['soapbox:optional']         = 'optional';
+$string['soapbox:name_label']       = 'Name this speech';
+$string['soapbox:topic_label']      = 'Topic';
+$string['soapbox:time_label']       = 'Target length';
+$string['soapbox:no_target']        = 'No target';
+$string['soapbox:record']           = 'Record speech';
+$string['soapbox:stop']             = 'Stop and get feedback';
+$string['soapbox:recording']        = 'Recording. Speak naturally; click stop when you finish.';
+$string['soapbox:transcribing']     = 'Transcribing your speech…';
+$string['soapbox:scoring']          = 'Scoring your speech…';
+$string['soapbox:too_short']        = 'That recording was too short to score. Aim for at least a sentence or two and try again.';
+$string['soapbox:mic_denied']       = 'Microphone access is needed to record. Allow microphone access and try again.';
+$string['soapbox:no_browser_stt']   = 'This browser does not support in-browser speech recognition. Try Chrome or Safari, or ask your administrator to switch Soapbox to server transcription.';
+$string['soapbox:browser_note']     = 'This speech is transcribed in your browser. Nothing is uploaded. Works best in Chrome and Safari.';
+$string['soapbox:server_note']      = 'Your recording is uploaded for transcription only and is not stored.';
+$string['soapbox:error']            = 'Could not score this speech right now. Try again in a moment.';
+$string['soapbox:audio_too_large']  = 'That recording is too large. Keep speeches under about 25 MB (roughly 20 minutes).';
+$string['soapbox:no_stt']           = 'No transcription provider is configured. Ask your administrator to set up Whisper or enable browser transcription.';
+$string['soapbox:result_heading']   = 'Rubric scores';
+$string['soapbox:overall_heading']  = 'Overall';
+$string['soapbox:tips_heading']     = 'Tips for next time';
+$string['soapbox:col_criterion']    = 'Criterion';
+$string['soapbox:col_score']        = 'Score';
+$string['soapbox:col_feedback']     = 'Feedback';
+$string['soapbox:history_heading']  = 'My speeches';
+$string['soapbox:history_empty']    = 'You have not recorded a speech yet. Record one above to start building your history.';
+$string['soapbox:untitled']         = 'Untitled speech';
+$string['soapbox:overall_badge']    = 'Overall {$a}';
+$string['soapbox:toggle']           = 'Enable Soapbox for this course';
+$string['soapbox:toggle_help']      = 'Learners get a dedicated page to record a speech and receive rubric-scored speaking feedback with tips. Audio and transcripts are never stored. Off by default.';
 
 // Code sandbox (v3.9.26).
 $string['sandbox:title']           = 'Python sandbox';

--- a/lib.php
+++ b/lib.php
@@ -179,4 +179,18 @@ function local_ai_course_assistant_extend_navigation_course(navigation_node $nav
             new pix_icon('i/report', '')
         );
     }
+    // v6.7.0: learner-facing Soapbox link. Unlike the admin nodes above, this is
+    // shown to any enrolled learner (capability :use) when Soapbox is enabled for
+    // the course, so students in speech courses have a discoverable way in.
+    if (has_capability('local/ai_course_assistant:use', $context)
+            && \local_ai_course_assistant\feature_flags::resolve('soapbox', $course->id)) {
+        $navigation->add(
+            get_string('soapbox:link', 'local_ai_course_assistant'),
+            new moodle_url('/local/ai_course_assistant/soapbox.php', ['courseid' => $course->id]),
+            navigation_node::TYPE_SETTING,
+            null,
+            'aicasoapbox',
+            new pix_icon('i/audio', '')
+        );
+    }
 }

--- a/rubric_admin.php
+++ b/rubric_admin.php
@@ -35,7 +35,7 @@ $courseid = optional_param('courseid', 0, PARAM_INT);
 $type = optional_param('type', 'conversation', PARAM_ALPHA);
 
 // Validate type.
-if (!in_array($type, ['conversation', 'pronunciation'])) {
+if (!in_array($type, ['conversation', 'pronunciation', 'speech'])) {
     $type = 'conversation';
 }
 
@@ -60,7 +60,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     $action = required_param('action', PARAM_ALPHA);
     $posttype = required_param('rubric_type', PARAM_ALPHA);
-    if (!in_array($posttype, ['conversation', 'pronunciation'])) {
+    if (!in_array($posttype, ['conversation', 'pronunciation', 'speech'])) {
         $posttype = 'conversation';
     }
 
@@ -230,6 +230,8 @@ echo $OUTPUT->header();
            class="<?php echo $type === 'conversation' ? 'active' : ''; ?>">Conversation Practice</a>
         <a href="<?php echo (new moodle_url('/local/ai_course_assistant/rubric_admin.php', ['courseid' => $courseid, 'type' => 'pronunciation']))->out(); ?>"
            class="<?php echo $type === 'pronunciation' ? 'active' : ''; ?>">Pronunciation Practice</a>
+        <a href="<?php echo (new moodle_url('/local/ai_course_assistant/rubric_admin.php', ['courseid' => $courseid, 'type' => 'speech']))->out(); ?>"
+           class="<?php echo $type === 'speech' ? 'active' : ''; ?>">Soapbox Speech</a>
     </div>
 
     <?php if ($is_inherited): ?>

--- a/settings.php
+++ b/settings.php
@@ -1638,6 +1638,7 @@ if ($hassiteconfig) {
         'flashcards_enabled'      => 'pedagogy:flashcards',
         'code_sandbox_enabled'    => 'pedagogy:code_sandbox',
         'essay_feedback_enabled'  => 'pedagogy:essay_feedback',
+        'soapbox_enabled'         => 'pedagogy:soapbox',
         'talking_avatar_enabled'  => 'pedagogy:talking_avatar',
         'crossmastery_enabled'    => 'pedagogy:crossmastery',
         'mastery_starter_enabled' => 'pedagogy:mastery_starter',
@@ -1651,6 +1652,22 @@ if ($hassiteconfig) {
             0
         ));
     }
+
+    // v6.7.0 Soapbox: which speech-to-text path the recorder uses. "server"
+    // transcribes through the configured Whisper provider (self-hosted free, or
+    // hosted OpenAI) via voice_registry; "browser" uses the learner's built-in
+    // Web Speech API (free, no server, Chrome/Safari only). Server is the default
+    // so transcription quality does not depend on the learner's browser.
+    $settings->add(new admin_setting_configselect(
+        'local_ai_course_assistant/soapbox_stt_mode',
+        get_string('settings:soapbox_stt_mode', 'local_ai_course_assistant'),
+        get_string('settings:soapbox_stt_mode_desc', 'local_ai_course_assistant'),
+        'server',
+        [
+            'server'  => get_string('settings:soapbox_stt_mode_server', 'local_ai_course_assistant'),
+            'browser' => get_string('settings:soapbox_stt_mode_browser', 'local_ai_course_assistant'),
+        ]
+    ));
 
     // v3.9.17: mastery tracking tunables. Per-course enable toggles live
     // on the per-course Objectives admin page; these are the site-wide

--- a/soapbox.php
+++ b/soapbox.php
@@ -1,0 +1,327 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Soapbox — learner speech-practice page. The student (optionally) names their
+ * speech, picks a topic and a target time, records a longer audio clip, which
+ * is transcribed (server Whisper or free in-browser speech recognition), and
+ * gets rubric-based AI feedback. Score history is kept per learner; the audio
+ * and transcript are never stored.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Tom Caswell & David Ta / Saylor University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once(__DIR__ . '/../../config.php');
+
+use local_ai_course_assistant\feature_flags;
+use local_ai_course_assistant\rubric_manager;
+use local_ai_course_assistant\security;
+
+require_login();
+
+$courseid = required_param('courseid', PARAM_INT);
+$course = get_course($courseid);
+$context = context_course::instance($courseid);
+require_capability('local/ai_course_assistant:use', $context);
+
+if (!feature_flags::resolve('soapbox', $courseid)) {
+    throw new \moodle_exception('soapbox:disabled', 'local_ai_course_assistant');
+}
+
+$pageurl = new moodle_url('/local/ai_course_assistant/soapbox.php', ['courseid' => $courseid]);
+$PAGE->set_url($pageurl);
+$PAGE->set_context($context);
+$PAGE->set_pagelayout('incourse');
+$PAGE->set_course($course);
+$PAGE->set_title(get_string('soapbox:title', 'local_ai_course_assistant'));
+$PAGE->set_heading($course->fullname);
+
+security::send_security_headers(true);
+
+// server = Whisper via voice_registry (self-hosted free, else hosted); browser =
+// in-browser Web Speech API (free, no server, Chrome/Safari).
+$sttmode = get_config('local_ai_course_assistant', 'soapbox_stt_mode') ?: 'server';
+$transcribeurl = (new moodle_url('/local/ai_course_assistant/soapbox_transcribe.php'))->out(false);
+$ajaxurl = (new moodle_url('/lib/ajax/service.php', ['sesskey' => sesskey()]))->out(false);
+
+$history = rubric_manager::get_user_scores($USER->id, $courseid, rubric_manager::TYPE_SPEECH, 20);
+
+echo $OUTPUT->header();
+?>
+<div style="max-width:880px;margin:0 auto" class="aica-soapbox" data-stt-mode="<?php echo s($sttmode); ?>">
+    <h2>📣 <?php echo get_string('soapbox:title', 'local_ai_course_assistant'); ?></h2>
+    <p class="text-muted"><?php echo get_string('soapbox:intro', 'local_ai_course_assistant'); ?></p>
+
+    <div class="card mb-3"><div class="card-body">
+        <div class="form-group">
+            <label for="sb-name"><strong><?php echo get_string('soapbox:name_label', 'local_ai_course_assistant'); ?></strong>
+                <span class="text-muted">(<?php echo get_string('soapbox:optional', 'local_ai_course_assistant'); ?>)</span></label>
+            <input type="text" id="sb-name" class="form-control" maxlength="120">
+        </div>
+        <div class="form-group mt-2">
+            <label for="sb-topic"><strong><?php echo get_string('soapbox:topic_label', 'local_ai_course_assistant'); ?></strong>
+                <span class="text-muted">(<?php echo get_string('soapbox:optional', 'local_ai_course_assistant'); ?>)</span></label>
+            <input type="text" id="sb-topic" class="form-control" maxlength="200">
+        </div>
+        <div class="form-group mt-2">
+            <label for="sb-target"><strong><?php echo get_string('soapbox:time_label', 'local_ai_course_assistant'); ?></strong></label>
+            <select id="sb-target" class="form-control" style="max-width:220px">
+                <option value="0"><?php echo get_string('soapbox:no_target', 'local_ai_course_assistant'); ?></option>
+                <option value="60">1 min</option>
+                <option value="120">2 min</option>
+                <option value="180" selected>3 min</option>
+                <option value="300">5 min</option>
+                <option value="420">7 min</option>
+                <option value="600">10 min</option>
+            </select>
+        </div>
+
+        <div class="mt-3 d-flex align-items-center" style="gap:12px;flex-wrap:wrap">
+            <button type="button" id="sb-record" class="btn btn-primary">
+                ● <?php echo get_string('soapbox:record', 'local_ai_course_assistant'); ?>
+            </button>
+            <span id="sb-timer" style="font-family:monospace;font-size:18px">00:00</span>
+            <span id="sb-status" class="text-muted"></span>
+        </div>
+        <p class="text-muted small mt-2" id="sb-mode-note"></p>
+    </div></div>
+
+    <div id="sb-result" style="display:none" class="mb-4"></div>
+
+    <h3><?php echo get_string('soapbox:history_heading', 'local_ai_course_assistant'); ?></h3>
+    <div id="sb-history">
+    <?php if (empty($history)) { ?>
+        <p class="text-muted" id="sb-history-empty"><?php echo get_string('soapbox:history_empty', 'local_ai_course_assistant'); ?></p>
+    <?php } else {
+        foreach ($history as $h) {
+            $meta = json_decode($h->session_meta ?? '', true) ?: [];
+            $hname = trim((string) ($meta['name'] ?? '')) ?: get_string('soapbox:untitled', 'local_ai_course_assistant');
+            $htopic = trim((string) ($meta['topic'] ?? ''));
+            $dur = (int) ($h->session_duration ?? 0);
+            $durtxt = sprintf('%d:%02d', intdiv($dur, 60), $dur % 60);
+            ?>
+        <details class="card mb-2"><summary class="card-header" style="cursor:pointer">
+            <strong><?php echo s($hname); ?></strong>
+            <?php if ($htopic !== '') { ?><span class="text-muted"> — <?php echo s($htopic); ?></span><?php } ?>
+            <span class="badge badge-info ml-2"><?php echo get_string('soapbox:overall_badge', 'local_ai_course_assistant', (int) $h->overall_score); ?></span>
+            <span class="text-muted ml-2 small"><?php echo userdate((int) $h->timecreated, get_string('strftimedatetimeshort', 'langconfig')); ?> · <?php echo $durtxt; ?></span>
+        </summary><div class="card-body">
+            <table class="generaltable" style="width:100%"><tbody>
+            <?php foreach ((array) $h->scores as $c) { ?>
+                <tr><td style="width:30%"><?php echo s($c['name'] ?? ''); ?></td>
+                    <td style="width:70px;font-family:monospace"><?php echo (int) ($c['score'] ?? 0); ?></td>
+                    <td><?php echo s($c['feedback'] ?? ''); ?></td></tr>
+            <?php } ?>
+            </tbody></table>
+            <?php if (!empty($h->ai_feedback)) { ?><p><?php echo s($h->ai_feedback); ?></p><?php } ?>
+        </div></details>
+    <?php } } ?>
+    </div>
+</div>
+
+<script>
+(function() {
+    var root = document.querySelector('.aica-soapbox');
+    var mode = root ? root.getAttribute('data-stt-mode') : 'server';
+    var TRANSCRIBE_URL = <?php echo json_encode($transcribeurl); ?>;
+    var AJAX_URL = <?php echo json_encode($ajaxurl); ?>;
+    var COURSEID = <?php echo (int) $courseid; ?>;
+    var recordBtn = document.getElementById('sb-record');
+    var timerEl = document.getElementById('sb-timer');
+    var statusEl = document.getElementById('sb-status');
+    var resultEl = document.getElementById('sb-result');
+    var modeNote = document.getElementById('sb-mode-note');
+
+    var STR = {
+        recording: <?php echo json_encode(get_string('soapbox:recording', 'local_ai_course_assistant')); ?>,
+        record: <?php echo json_encode('● ' . get_string('soapbox:record', 'local_ai_course_assistant')); ?>,
+        stop: <?php echo json_encode('■ ' . get_string('soapbox:stop', 'local_ai_course_assistant')); ?>,
+        transcribing: <?php echo json_encode(get_string('soapbox:transcribing', 'local_ai_course_assistant')); ?>,
+        scoring: <?php echo json_encode(get_string('soapbox:scoring', 'local_ai_course_assistant')); ?>,
+        too_short: <?php echo json_encode(get_string('soapbox:too_short', 'local_ai_course_assistant')); ?>,
+        mic_denied: <?php echo json_encode(get_string('soapbox:mic_denied', 'local_ai_course_assistant')); ?>,
+        no_browser_stt: <?php echo json_encode(get_string('soapbox:no_browser_stt', 'local_ai_course_assistant')); ?>,
+        browser_note: <?php echo json_encode(get_string('soapbox:browser_note', 'local_ai_course_assistant')); ?>,
+        server_note: <?php echo json_encode(get_string('soapbox:server_note', 'local_ai_course_assistant')); ?>,
+        error: <?php echo json_encode(get_string('soapbox:error', 'local_ai_course_assistant')); ?>,
+        result_heading: <?php echo json_encode(get_string('soapbox:result_heading', 'local_ai_course_assistant')); ?>,
+        col_criterion: <?php echo json_encode(get_string('soapbox:col_criterion', 'local_ai_course_assistant')); ?>,
+        col_score: <?php echo json_encode(get_string('soapbox:col_score', 'local_ai_course_assistant')); ?>,
+        col_feedback: <?php echo json_encode(get_string('soapbox:col_feedback', 'local_ai_course_assistant')); ?>,
+        overall_heading: <?php echo json_encode(get_string('soapbox:overall_heading', 'local_ai_course_assistant')); ?>,
+        tips_heading: <?php echo json_encode(get_string('soapbox:tips_heading', 'local_ai_course_assistant')); ?>
+    };
+    var esc = function(s) {
+        return String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    };
+    var SR = window.SpeechRecognition || window.webkitSpeechRecognition;
+    if (mode === 'browser') { modeNote.textContent = STR.browser_note; } else { modeNote.textContent = STR.server_note; }
+
+    var recording = false, startTs = 0, timerInt = null, mediaRec = null, chunks = [],
+        recognizer = null, browserTranscript = '';
+
+    var fmt = function(s) { return ('0' + Math.floor(s / 60)).slice(-2) + ':' + ('0' + (s % 60)).slice(-2); };
+    var tick = function() { timerEl.textContent = fmt(Math.floor((Date.now() - startTs) / 1000)); };
+    var setBusy = function(txt) { statusEl.textContent = txt || ''; };
+
+    var finishWithTranscript = function(transcript, durationSec) {
+        if (!transcript || transcript.trim().length < 40) {
+            setBusy(''); resultEl.style.display = 'block';
+            resultEl.innerHTML = '<div class="alert alert-warning">' + esc(STR.too_short) + '</div>';
+            recordBtn.disabled = false; return;
+        }
+        setBusy(STR.scoring);
+        var payload = JSON.stringify([{
+            index: 0, methodname: 'local_ai_course_assistant_score_speech',
+            args: {
+                courseid: COURSEID, transcript: transcript,
+                name: (document.getElementById('sb-name').value || ''),
+                topic: (document.getElementById('sb-topic').value || ''),
+                targetsec: parseInt(document.getElementById('sb-target').value, 10) || 0,
+                durationsec: durationSec || 0
+            }
+        }]);
+        fetch(AJAX_URL, { method: 'POST', credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' }, body: payload })
+        .then(function(r) { return r.json(); })
+        .then(function(resp) {
+            recordBtn.disabled = false; setBusy('');
+            var res = resp && resp[0] && resp[0].data;
+            resultEl.style.display = 'block';
+            if (!res || !res.success) {
+                resultEl.innerHTML = '<div class="alert alert-warning">' + esc(STR.error) +
+                    ' <code>' + esc(res && res.message ? res.message : 'unknown') + '</code></div>';
+                return;
+            }
+            var html = '<div class="card"><div class="card-body"><h3>' + esc(STR.result_heading) + '</h3>';
+            html += '<table class="generaltable" style="width:100%"><thead><tr><th>' + esc(STR.col_criterion) +
+                '</th><th style="width:80px">' + esc(STR.col_score) + '</th><th>' + esc(STR.col_feedback) + '</th></tr></thead><tbody>';
+            res.criteria.forEach(function(c) {
+                html += '<tr><td>' + esc(c.name) + '</td><td style="font-family:monospace">' + esc(c.score) +
+                    '</td><td>' + esc(c.feedback) + '</td></tr>';
+            });
+            html += '</tbody></table>';
+            if (res.overall) { html += '<h4 class="mt-3">' + esc(STR.overall_heading) + '</h4><p>' + esc(res.overall) + '</p>'; }
+            if (res.tips && res.tips.length) {
+                html += '<h4 class="mt-2">' + esc(STR.tips_heading) + '</h4><ol>';
+                res.tips.forEach(function(t) { html += '<li>' + esc(t) + '</li>'; });
+                html += '</ol>';
+            }
+            html += '</div></div>';
+            resultEl.innerHTML = html;
+            var empty = document.getElementById('sb-history-empty');
+            if (empty) { empty.style.display = 'none'; }
+        })
+        .catch(function() {
+            recordBtn.disabled = false; setBusy('');
+            resultEl.style.display = 'block';
+            resultEl.innerHTML = '<div class="alert alert-danger">' + esc(STR.error) + '</div>';
+        });
+    };
+
+    // ---- Server mode: MediaRecorder -> upload blob -> soapbox_transcribe.php ----
+    var startServer = function() {
+        navigator.mediaDevices.getUserMedia({ audio: true }).then(function(stream) {
+            chunks = [];
+            var mime = '';
+            ['audio/webm', 'audio/mp4', 'audio/ogg'].some(function(m) {
+                if (window.MediaRecorder && MediaRecorder.isTypeSupported(m)) { mime = m; return true; } return false;
+            });
+            mediaRec = mime ? new MediaRecorder(stream, { mimeType: mime }) : new MediaRecorder(stream);
+            mediaRec.ondataavailable = function(e) { if (e.data && e.data.size) { chunks.push(e.data); } };
+            mediaRec.onstop = function() {
+                stream.getTracks().forEach(function(t) { t.stop(); });
+                var durationSec = Math.floor((Date.now() - startTs) / 1000);
+                var blob = new Blob(chunks, { type: mediaRec.mimeType || 'audio/webm' });
+                setBusy(STR.transcribing);
+                var fd = new FormData();
+                fd.append('audio', blob, 'speech.' + ((mediaRec.mimeType || '').indexOf('mp4') !== -1 ? 'mp4' : 'webm'));
+                fd.append('sesskey', '<?php echo sesskey(); ?>');
+                fd.append('courseid', String(COURSEID));
+                fetch(TRANSCRIBE_URL, { method: 'POST', credentials: 'same-origin', body: fd })
+                    .then(function(r) { return r.json().then(function(j) { return { ok: r.ok, j: j }; }); })
+                    .then(function(o) {
+                        if (!o.ok || !o.j || !o.j.text) {
+                            recordBtn.disabled = false; setBusy('');
+                            resultEl.style.display = 'block';
+                            resultEl.innerHTML = '<div class="alert alert-warning">' + esc(STR.error) +
+                                ' <code>' + esc(o.j && o.j.error ? o.j.error : 'transcription') + '</code></div>';
+                            return;
+                        }
+                        finishWithTranscript(o.j.text, durationSec);
+                    })
+                    .catch(function() {
+                        recordBtn.disabled = false; setBusy('');
+                        resultEl.style.display = 'block';
+                        resultEl.innerHTML = '<div class="alert alert-danger">' + esc(STR.error) + '</div>';
+                    });
+            };
+            mediaRec.start();
+            beginUI();
+        }).catch(function() { alert(STR.mic_denied); });
+    };
+    var stopServer = function() { if (mediaRec && mediaRec.state !== 'inactive') { mediaRec.stop(); } endUI(); };
+
+    // ---- Browser mode: Web Speech API (free, no server) ----
+    var startBrowser = function() {
+        if (!SR) { alert(STR.no_browser_stt); return; }
+        browserTranscript = '';
+        recognizer = new SR();
+        recognizer.continuous = true; recognizer.interimResults = false;
+        recognizer.lang = document.documentElement.lang || 'en-US';
+        recognizer.onresult = function(e) {
+            for (var i = e.resultIndex; i < e.results.length; i++) {
+                if (e.results[i].isFinal) { browserTranscript += e.results[i][0].transcript + ' '; }
+            }
+        };
+        recognizer.onerror = function(ev) { if (ev.error === 'not-allowed') { alert(STR.mic_denied); } };
+        recognizer.onend = function() { if (recording) { try { recognizer.start(); } catch (x) {} } }; // keep going on auto-stop
+        try { recognizer.start(); } catch (x) {}
+        beginUI();
+    };
+    var stopBrowser = function() {
+        var durationSec = Math.floor((Date.now() - startTs) / 1000);
+        endUI();
+        if (recognizer) { try { recognizer.stop(); } catch (x) {} }
+        setTimeout(function() { finishWithTranscript(browserTranscript, durationSec); }, 400);
+    };
+
+    var beginUI = function() {
+        recording = true; startTs = Date.now(); timerEl.textContent = '00:00';
+        timerInt = setInterval(tick, 1000);
+        recordBtn.textContent = STR.stop; recordBtn.classList.remove('btn-primary'); recordBtn.classList.add('btn-danger');
+        setBusy(STR.recording); resultEl.style.display = 'none';
+    };
+    var endUI = function() {
+        recording = false; clearInterval(timerInt);
+        recordBtn.textContent = STR.record; recordBtn.classList.remove('btn-danger'); recordBtn.classList.add('btn-primary');
+        recordBtn.disabled = true;
+    };
+
+    recordBtn.addEventListener('click', function() {
+        if (!recording) {
+            if (mode === 'browser') { startBrowser(); } else { startServer(); }
+        } else {
+            if (mode === 'browser') { stopBrowser(); } else { stopServer(); }
+        }
+    });
+})();
+</script>
+<?php
+echo $OUTPUT->footer();

--- a/soapbox_transcribe.php
+++ b/soapbox_transcribe.php
@@ -1,0 +1,185 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Soapbox long-form speech transcription endpoint.
+ *
+ * Like transcribe.php (the conversational STT proxy) but tuned for a single
+ * multi-minute speech recording: a 300s upstream timeout instead of 30s. The
+ * provider is resolved through voice_registry, which prefers a self-hosted
+ * Whisper server (free; v6.3.0) when stt_selfhosted_url is configured and falls
+ * back to hosted OpenAI/xAI Whisper otherwise. Accepts POST multipart
+ * { audio (file), sesskey, courseid, lang }. Returns JSON { text: "..." }.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2025-2026 Tom Caswell & David Ta / Saylor University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+define('AJAX_SCRIPT', true);
+require_once('../../config.php');
+
+require_login();
+require_sesskey();
+
+\local_ai_course_assistant\security::send_security_headers();
+header('Content-Type: application/json');
+
+$courseid = optional_param('courseid', 0, PARAM_INT);
+$context = $courseid > 0 ? context_course::instance($courseid) : context_system::instance();
+require_capability('local/ai_course_assistant:use', $context);
+
+// Soapbox must be enabled for the course.
+if ($courseid > 0 && !\local_ai_course_assistant\feature_flags::resolve('soapbox', $courseid)) {
+    http_response_code(403);
+    echo json_encode(['error' => get_string('soapbox:disabled', 'local_ai_course_assistant')]);
+    exit;
+}
+
+// Rate limit: 12 long-form transcriptions per 10 minutes per user. A speech is a
+// deliberate, infrequent action; this is generous but stops a tight retry loop.
+if (\local_ai_course_assistant\rate_limiter::is_rate_limited($USER->id, 'soapbox_stt', 12, 600)) {
+    http_response_code(429);
+    header('Retry-After: 120');
+    echo json_encode(['error' => get_string('chat:error_ratelimit', 'local_ai_course_assistant')]);
+    exit;
+}
+
+// Require the uploaded audio file.
+if (empty($_FILES['audio']['tmp_name']) || !is_uploaded_file($_FILES['audio']['tmp_name'])) {
+    http_response_code(400);
+    echo json_encode(['error' => 'No audio file provided.']);
+    exit;
+}
+
+// Enforce a 25 MB max size and an audio MIME allowlist before the file ever
+// reaches the transcription API. Uses finfo so a spoofed Content-Type header
+// cannot smuggle a non-audio payload through. 25 MB bounds duration (and cost).
+$tmp = $_FILES['audio']['tmp_name'];
+$size = filesize($tmp) ?: 0;
+if ($size <= 0 || $size > \local_ai_course_assistant\security::MAX_AUDIO_BYTES) {
+    http_response_code(413);
+    echo json_encode(['error' => get_string('soapbox:audio_too_large', 'local_ai_course_assistant')]);
+    exit;
+}
+$finfo = finfo_open(FILEINFO_MIME_TYPE);
+$sniffed = $finfo ? finfo_file($finfo, $tmp) : '';
+if ($finfo) { finfo_close($finfo); }
+$declaredtype = !empty($_FILES['audio']['type']) ? (string) $_FILES['audio']['type'] : '';
+if (!\local_ai_course_assistant\security::is_allowed_audio_upload((string) $sniffed, $declaredtype)) {
+    http_response_code(415);
+    echo json_encode(['error' => 'Unsupported audio format.']);
+    exit;
+}
+
+// Resolve active STT provider via the voice_providers registry (self-hosted
+// Whisper first when configured, else hosted OpenAI/xAI).
+$cfg = \local_ai_course_assistant\voice_registry::resolve(
+    \local_ai_course_assistant\voice_registry::CAPABILITY_STT);
+if ($cfg === null) {
+    http_response_code(503);
+    echo json_encode(['error' => get_string('soapbox:no_stt', 'local_ai_course_assistant')]);
+    exit;
+}
+
+$lang = optional_param('lang', '', PARAM_ALPHA);
+$tmpfile  = $_FILES['audio']['tmp_name'];
+$mimetype = !empty($_FILES['audio']['type']) ? $_FILES['audio']['type'] : 'audio/webm';
+
+$ext_map = [
+    'audio/webm'  => 'webm',
+    'audio/ogg'   => 'ogg',
+    'audio/mp4'   => 'mp4',
+    'audio/mpeg'  => 'mp3',
+    'audio/wav'   => 'wav',
+    'audio/x-wav' => 'wav',
+];
+$ext = $ext_map[$mimetype] ?? 'webm';
+$filename = 'speech.' . $ext;
+
+if ($cfg['provider'] === 'xai') {
+    $post = ['file' => new CURLFile($tmpfile, $mimetype, $filename)];
+    if (!empty($lang)) {
+        $post['language'] = $lang;
+    }
+    $model = 'grok-stt';
+} else {
+    $model = !empty($cfg['model']) ? $cfg['model'] : 'whisper-1';
+    $post = [
+        'file'  => new CURLFile($tmpfile, $mimetype, $filename),
+        'model' => $model,
+    ];
+    if (!empty($lang)) {
+        $post['language'] = $lang;
+    }
+}
+
+if (!\local_ai_course_assistant\security::is_safe_provider_url($cfg['endpoint'])) {
+    http_response_code(502);
+    echo json_encode(['error' => 'STT endpoint failed SSRF validation']);
+    exit;
+}
+$headers = [];
+if (!empty($cfg['apikey'])) {
+    $headers[] = 'Authorization: Bearer ' . $cfg['apikey'];
+}
+$ch = curl_init($cfg['endpoint']);
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_POST           => true,
+    CURLOPT_POSTFIELDS     => $post,
+    CURLOPT_HTTPHEADER     => $headers,
+    // Long-form: a multi-minute clip can take well over 30s upstream.
+    CURLOPT_TIMEOUT        => 300,
+]);
+$response = curl_exec($ch);
+$httpcode = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+curl_close($ch);
+
+if ($httpcode !== 200) {
+    http_response_code(502);
+    echo json_encode(['error' => 'Transcription API error ' . $httpcode]);
+    exit;
+}
+
+$data = json_decode($response, true);
+if (!isset($data['text'])) {
+    http_response_code(502);
+    echo json_encode(['error' => 'Invalid transcription response.']);
+    exit;
+}
+
+// Log STT usage (approximate tokens from file size; hosted Whisper ~$0.006/min,
+// self-hosted is $0 — the rate card simply has no entry for selfhosted_stt).
+$filesizebytes = filesize($tmpfile) ?: 0;
+$approxminutes = max(0.1, $filesizebytes / 1_000_000);
+$approxtokens = (int) ceil($approxminutes * 1000);
+try {
+    $conv = $DB->get_record('local_ai_course_assistant_convs', [
+        'userid' => $USER->id, 'courseid' => $courseid > 0 ? $courseid : SITEID,
+    ]);
+    if ($conv) {
+        \local_ai_course_assistant\conversation_manager::add_message(
+            $conv->id, $USER->id, $courseid > 0 ? $courseid : SITEID,
+            'system', '[Soapbox STT]',
+            0, $cfg['provider'] . '_stt', $approxtokens, 0, $model
+        );
+    }
+} catch (\Throwable $e) {
+    unset($e);
+}
+
+echo json_encode(['text' => $data['text']]);

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_ai_course_assistant';
-$plugin->version = 2026061017;
+$plugin->version = 2026061500;
 $plugin->requires = 2024100700; // Moodle 4.5+.
 $plugin->supported = [405, 503]; // Tested on Moodle 4.5 through 5.3dev.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '6.6.2';
+$plugin->release = '6.7.0';


### PR DESCRIPTION
## Summary

Adds **Soapbox**, an AI speech-coaching tool for speech and communication courses. A learner optionally sets a name, topic, and target length, records a longer spoken presentation, which is transcribed and scored against a per-course speaking rubric with concrete tips. A personal score history is kept; **audio and transcript text are never stored**, only scores, feedback, and the name/topic/target metadata.

Off by default, gated per course via `feature_flags::resolve('soapbox', $courseid)` (site `soapbox_enabled` default plus a three-way `soapbox_enabled_course_<id>` override). Intended for the handful of courses that need it.

### What's included
- **`soapbox.php`** learner page: setup panel (name/topic/target), record/stop, rubric feedback render, "My Speeches" history. Inline vanilla JS, two STT modes.
- **`soapbox_transcribe.php`** long-form STT endpoint: 300s timeout, 25MB cap, `soapbox_stt` rate bucket (12/600), provider resolved through `voice_registry` (self-hosted Whisper free, else hosted OpenAI).
- **`classes/external/score_speech.php`** scoring web service: scores the transcript against the `speech` rubric and persists score + meta.
- **`rubric_manager`**: new `TYPE_SPEECH` + `DEFAULT_SPEECH_CRITERIA` (Delivery & Fluency, Structure & Organization, Content & Relevance, Language & Vocabulary, Time Management), seeded as a global default; `save_score` gains an optional `$meta` param.
- **Schema**: nullable `session_meta` column on `_practice_scores` (`install.xml` + upgrade savepoint `2026061500`); privacy provider covers it (metadata + export).
- **Settings**: `soapbox_enabled` (pedagogy default, off) and `soapbox_stt_mode` (server / browser). Per-course three-way toggle + tool link on `course_settings.php`.
- **`rubric_admin.php`**: Soapbox Speech rubric tab. **`lib.php`**: learner course-nav link gated on the flag + `:use`.

### Three STT tiers (cost control)
`soapbox_stt_mode` picks the path; server mode auto-selects self-hosted vs hosted via `voice_registry`:
1. **Self-hosted Whisper** (free; needs a server)
2. **Hosted OpenAI Whisper** (~$0.006/min; no infra)
3. **In-browser Web Speech API** (free, no server, no cost; Chrome/Safari)

## Test Plan
- [x] `php -l` clean on all new/changed PHP
- [x] Local Moodle 4.5 upgrade applies (savepoint 2026061500); both settings register
- [x] Global `speech` rubric seeds (5 criteria); `score_speech` service registers; `session_meta` column present
- [x] `save_score($meta)` + `get_user_scores` round-trip (meta + scores decode, duration persists)
- [x] `soapbox.php?courseid=2` renders authenticated (heading, setup fields, record button, history, `data-stt-mode`) with no page error
- [x] Validator suite 36 passed / 0 failed
- [ ] CI green
- [ ] Manual record -> transcribe -> feedback smoke on dev after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)