### PR TITLE
chore(benchmark): domain prompt set + --delay throttle + rate-cards (supersedes #26, #21)

### DIFF
--- a/admin/cli/run_tutor_golden.php
+++ b/admin/cli/run_tutor_golden.php
@@ -69,6 +69,7 @@ $judgeprovider = 'claude';
 $judgemodel = 'claude-sonnet-4-6';
 $limit = 0; // 0 = all prompts
 $promptsfile = ''; // empty = use tutor_prompts.json default
+$delay = 0.0; // seconds to sleep between calls (throttle for rate-limited free tiers)
 
 foreach ($argv as $arg) {
     if (preg_match('/^--mode=(run|judge|report|all)$/', $arg, $m)) {
@@ -89,6 +90,8 @@ foreach ($argv as $arg) {
         $limit = (int) $m[1];
     } else if (preg_match('/^--prompts=(.+)$/', $arg, $m)) {
         $promptsfile = trim($m[1]);
+    } else if (preg_match('/^--delay=([\d.]+)$/', $arg, $m)) {
+        $delay = (float) $m[1];
     } else if ($arg === '--help' || $arg === '-h') {
         $help = <<<TXT
 Usage: php run_tutor_golden.php [--mode=run|judge|report|all] [options]
@@ -104,7 +107,10 @@ Options:
   --limit=N                     Limit run to the first N prompts (for smoke tests).
   --prompts=FILE                Path to a tutor_prompts.json-shaped file (default:
                                 tests/golden/tutor_prompts.json). Use for one-off
-                                fixture sets like the A.10 premium-escalation bake-off.
+                                fixture sets like the A.10 premium-escalation bake-off
+                                or the domain-tagged set (tutor_prompts_domains.json).
+  --delay=N                     Sleep N seconds between calls in run mode (throttle
+                                rate-limited free tiers, e.g. --delay=5 for ~15 RPM).
   --in=run.csv[,judge.csv]      Input CSV(s) for judge/report modes.
   --out=DIR                     Output directory (default: <plugin>/runs).
   --judge-provider=ID           Provider id for the rubric judge (default: claude).
@@ -120,7 +126,7 @@ if (!is_dir($outdir)) {
 }
 
 if ($mode === 'run' || $mode === 'all') {
-    $runin = mode_run($providersfilter, $outdir, $datetag, $limit, $promptsfile);
+    $runin = mode_run($providersfilter, $outdir, $datetag, $limit, $promptsfile, $delay);
 }
 if ($mode === 'judge' || $mode === 'all') {
     if ($runin === '') {
@@ -150,9 +156,10 @@ exit(0);
  * @param string $datetag
  * @param int $limit Max prompts to send, 0 = all.
  * @param string $promptsfile Optional alternate path to a tutor_prompts.json-shaped file.
+ * @param float $delay Seconds to sleep between calls (0 = no throttle).
  * @return string Path to run CSV.
  */
-function mode_run(string $providersfilter, string $outdir, string $datetag, int $limit, string $promptsfile = ''): string {
+function mode_run(string $providersfilter, string $outdir, string $datetag, int $limit, string $promptsfile = '', float $delay = 0.0): string {
     $prompts = load_prompts($promptsfile);
     if ($limit > 0) {
         $prompts = array_slice($prompts, 0, $limit);
@@ -216,6 +223,9 @@ function mode_run(string $providersfilter, string $outdir, string $datetag, int 
             printf("  %s [%s] %s\n", $p['id'],
                 ($result['error'] ?? '') === '' ? 'ok' : 'err',
                 $result['error'] ?? sprintf('%dms', $result['total_latency_ms'] ?? 0));
+            if ($delay > 0) {
+                usleep((int) round($delay * 1_000_000));
+            }
         }
     }
     fclose($fh);

--- a/classes/token_cost_manager.php
+++ b/classes/token_cost_manager.php
@@ -100,6 +100,14 @@ class token_cost_manager {
         'meta-llama/llama-3.1-8b-instruct-turbo'   => ['input' => 0.18, 'output' => 0.18],
         'meta-llama/llama-3.1-70b-instruct-turbo'  => ['input' => 0.88, 'output' => 0.88],
         'meta-llama/llama-3.1-405b-instruct-turbo' => ['input' => 3.50, 'output' => 3.50],
+        // Together Serverless "Lite" tier — Llama 3 8B Instruct Lite. Live rate
+        // from Together /v1/models pricing endpoint (2026-06-03): $0.14/M flat.
+        'meta-llama/meta-llama-3-8b-instruct'      => ['input' => 0.14, 'output' => 0.14],
+
+        // ── OpenRouter (routed open-weight) ───────────────────────────────────
+        // Non-turbo llama-3.1-8b-instruct via OpenRouter default routing. Live
+        // rate from OpenRouter /api/v1/models (2026-06-03): $0.02 in / $0.05 out.
+        'meta-llama/llama-3.1-8b-instruct'         => ['input' => 0.02, 'output' => 0.05],
 
         // ── Groq (open-source models) ─────────────────────────────────────────
         // Groq charges vary by model; these are approximate hosted rates.
@@ -112,6 +120,14 @@ class token_cost_manager {
         'gemma2-9b'         => ['input' =>  0.20, 'output' =>  0.20],
 
         // ── xAI (Grok) ───────────────────────────────────────────────────────
+        // Live rates from xAI /v1/language-models + docs.x.ai (2026-06-03).
+        // NOTE: the API silently aliases the (now-retired) name `grok-4-1-fast`
+        // to grok-4.3, so it bills at grok-4.3 rates ($1.25/$2.50), NOT a cheap
+        // "fast" tier. Benchmark "xai" rows actually ran grok-4.3.
+        'grok-4.3'          => ['input' =>  1.25, 'output' =>  2.50],
+        'grok-4.20'         => ['input' =>  1.25, 'output' =>  2.50],
+        'grok-4-1-fast'     => ['input' =>  1.25, 'output' =>  2.50],
+        'grok-4'            => ['input' =>  1.25, 'output' =>  2.50],
         'grok-3'            => ['input' =>  3.00, 'output' => 15.00],
         'grok-3-mini'       => ['input' =>  0.30, 'output' =>  0.50],
         'grok-2'            => ['input' =>  2.00, 'output' => 10.00],

--- a/tests/golden/tutor_prompts_domains.json
+++ b/tests/golden/tutor_prompts_domains.json
@@ -1,0 +1,54 @@
+{
+  "_meta": {
+    "purpose": "Domain-tagged golden prompt set for SOLA provider benchmarking by subject area.",
+    "design": "5 subject domains x 8 prompts. Each domain holds a balanced mix of 4 tutoring sub-functions (2 each): concept (Socratic explanation of a core idea), worked (step-by-step problem the learner asks to be guided through, not handed), misconception (learner states a wrong belief; model must correct accurately and kindly), apply (transfer a concept to a scenario). Sub-function is encoded in the id so cross-domain differences reflect domain handling at a constant function mix. category = domain, so the existing report groups by subject.",
+    "domains": ["business", "science", "cs_tech", "math", "humanities"],
+    "created": "2026-06-03"
+  },
+  "prompts": [
+    { "id": "bus_concept_01", "category": "business", "function": "concept", "text": "I keep mixing up fixed costs and variable costs in my accounting course. Can you help me really understand the difference without just handing me the definitions?" },
+    { "id": "bus_concept_02", "category": "business", "function": "concept", "text": "My economics professor keeps saying every choice has an opportunity cost. I can repeat the phrase but I don't think I actually get it. Can you help it click?" },
+    { "id": "bus_worked_01", "category": "business", "function": "worked", "text": "A company has 50,000 dollars in fixed costs, sells its product for 20 dollars a unit, and each unit costs 12 dollars to make. I need to find the break-even point in units. Please walk me through the reasoning instead of just giving the number." },
+    { "id": "bus_worked_02", "category": "business", "function": "worked", "text": "I need to find the present value of 1,000 dollars I will receive in 3 years if the discount rate is 5 percent. Can you guide me through how to set this up rather than just stating the answer?" },
+    { "id": "bus_misconception_01", "category": "business", "function": "misconception", "text": "Profit and cash flow are basically the same thing, right? If a company reports a profit it must have plenty of cash on hand." },
+    { "id": "bus_misconception_02", "category": "business", "function": "misconception", "text": "Raising the price of a product always increases total revenue, because you earn more on every sale. That's correct, isn't it?" },
+    { "id": "bus_apply_01", "category": "business", "function": "apply", "text": "I'm planning a small coffee cart business for a class project. How would I actually use a SWOT analysis to think it through?" },
+    { "id": "bus_apply_02", "category": "business", "function": "apply", "text": "My study group is arguing about whether a hypothetical startup should lease or buy its equipment. What factors should drive that decision?" },
+
+    { "id": "sci_concept_01", "category": "science", "function": "concept", "text": "I don't really understand why entropy always increases. Can you help me build some intuition for the second law of thermodynamics rather than just stating it?" },
+    { "id": "sci_concept_02", "category": "science", "function": "concept", "text": "I get the basic idea of natural selection, but how it leads to entirely new species over time still feels hand-wavy to me. Can you help me reason through it?" },
+    { "id": "sci_worked_01", "category": "science", "function": "worked", "text": "How many grams of sodium chloride are in 0.5 liters of a 2 molar solution? Please walk me through the steps instead of just giving the final mass." },
+    { "id": "sci_worked_02", "category": "science", "function": "worked", "text": "A ball is dropped from a height of 20 meters. Ignoring air resistance, how long until it hits the ground? Guide me through setting up the problem rather than just stating the time." },
+    { "id": "sci_misconception_01", "category": "science", "function": "misconception", "text": "Plants get most of their mass from the soil they grow in, right? That's where the material to build the plant comes from." },
+    { "id": "sci_misconception_02", "category": "science", "function": "misconception", "text": "Heavier objects fall faster than lighter ones because they weigh more. In a vacuum that's still true, isn't it?" },
+    { "id": "sci_apply_01", "category": "science", "function": "apply", "text": "If average global temperatures are rising, why do some regions still get more extreme cold snaps? Help me reason through how that can happen." },
+    { "id": "sci_apply_02", "category": "science", "function": "apply", "text": "I want to design a simple experiment to test whether caffeine affects how fast a plant grows. How should I think about controls and variables?" },
+
+    { "id": "cs_concept_01", "category": "cs_tech", "function": "concept", "text": "I understand loops, but I don't see why recursion is useful if a loop can do the same job. Can you help make recursion click for me?" },
+    { "id": "cs_concept_02", "category": "cs_tech", "function": "concept", "text": "What is the actual difference between a stack and a queue, and how would I know which one to reach for in a given situation?" },
+    { "id": "cs_worked_01", "category": "cs_tech", "function": "worked", "text": "I need to write a function that checks whether a string is a palindrome. Please don't give me the code, but walk me through how to approach the problem." },
+    { "id": "cs_worked_02", "category": "cs_tech", "function": "worked", "text": "How do I work out the Big O time complexity of a loop nested inside another loop, where both run over the same array? Guide me through the reasoning." },
+    { "id": "cs_misconception_01", "category": "cs_tech", "function": "misconception", "text": "More lines of code means a more powerful program, so I should write everything out the long way instead of leaning on built-in functions, right?" },
+    { "id": "cs_misconception_02", "category": "cs_tech", "function": "misconception", "text": "If my code runs and produces the right answer once, then it's correct and I don't really need to write tests for it. Do you agree?" },
+    { "id": "cs_apply_01", "category": "cs_tech", "function": "apply", "text": "I'm building a simple to-do list web app. How should I think about what belongs on the front end versus the back end?" },
+    { "id": "cs_apply_02", "category": "cs_tech", "function": "apply", "text": "My login form stores passwords as plain text in the database. A classmate said that's a serious problem. Why is it bad, and what should I do instead?" },
+
+    { "id": "math_concept_01", "category": "math", "function": "concept", "text": "I can compute derivatives mechanically, but I don't understand what a derivative is actually telling me. Can you help me grasp the meaning?" },
+    { "id": "math_concept_02", "category": "math", "function": "concept", "text": "My statistics class keeps repeating that correlation does not imply causation. I want to genuinely understand why, not just memorize the slogan." },
+    { "id": "math_worked_01", "category": "math", "function": "worked", "text": "How do I find the derivative of f of x equals 3 x squared plus 2 x? Please walk me through the rules you're using rather than just giving the answer." },
+    { "id": "math_worked_02", "category": "math", "function": "worked", "text": "For the data set 4, 8, 8, 10, 10, 12, how do I find the mean and the standard deviation step by step?" },
+    { "id": "math_misconception_01", "category": "math", "function": "misconception", "text": "A p-value of 0.05 means there is a 95 percent chance that my hypothesis is true, correct?" },
+    { "id": "math_misconception_02", "category": "math", "function": "misconception", "text": "If I flip a fair coin and get five heads in a row, then tails is now more likely on the next flip to balance things out, right?" },
+    { "id": "math_apply_01", "category": "math", "function": "apply", "text": "How would I use a derivative to find the point that maximizes profit in a business problem? Help me see the connection." },
+    { "id": "math_apply_02", "category": "math", "function": "apply", "text": "I rolled a die 60 times and want to decide whether it's fair. How should I think about testing that?" },
+
+    { "id": "hum_concept_01", "category": "humanities", "function": "concept", "text": "In my history course, what does it actually mean for a source to be primary versus secondary, and why does the distinction matter so much?" },
+    { "id": "hum_concept_02", "category": "humanities", "function": "concept", "text": "My philosophy class distinguishes between a valid argument and a sound one. Aren't those just two words for the same thing?" },
+    { "id": "hum_worked_01", "category": "humanities", "function": "worked", "text": "I have to write a thesis statement for an essay about why a character in a novel changes. Please don't write it for me, but walk me through how to build a strong one." },
+    { "id": "hum_worked_02", "category": "humanities", "function": "worked", "text": "How do I structure a body paragraph so it actually supports my argument, instead of just retelling what happened in the plot? Guide me through it." },
+    { "id": "hum_misconception_01", "category": "humanities", "function": "misconception", "text": "A primary source is always more reliable than a secondary source, because it's a firsthand account. That's right, isn't it?" },
+    { "id": "hum_misconception_02", "category": "humanities", "function": "misconception", "text": "If a famous and respected philosopher made the claim, then it must be a strong argument. Citing a great thinker basically settles the question, doesn't it?" },
+    { "id": "hum_apply_01", "category": "humanities", "function": "apply", "text": "I'm analyzing a political speech for a communications assignment. How do I identify the rhetorical techniques being used to persuade the audience?" },
+    { "id": "hum_apply_02", "category": "humanities", "function": "apply", "text": "I have to compare two historical accounts of the same event that contradict each other. How should I approach deciding what likely happened?" }
+  ]
+}


### PR DESCRIPTION
## Summary
Lands the useful parts of #26 and #21 on top of current main **without reverting the A.10 bake-off logic** that both stale branches would have removed (`parse_comparison_providers()` label disambiguation + `--providers=` prefix matching). Both original branches were cut before that work merged and rewrote the same lines; this re-applies their features additively instead.

- **`tests/golden/tutor_prompts_domains.json`** (from #26): domain-tagged golden prompt set, 5 subject domains × 8 prompts (40 total). Loadable via the `--prompts` flag already in main — no harness change needed for it.
- **`--delay=N` throttle** (from #21): sleeps N seconds between calls in run mode for rate-limited free tiers. Added additively to `run_tutor_golden.php`; A.10 logic untouched.
- **Rate-card entries** (from #21): Together "Lite" llama-3-8b, OpenRouter llama-3.1-8b, and xAI grok-4.x in `token_cost_manager.php` (including the `grok-4-1-fast` → grok-4.3 billing-alias note). `token_cost_manager.php` was unchanged on main since #21's base, so these apply cleanly.

Supersedes #26 and #21 (both will be closed).

## Test Plan
- [x] php -l clean on all three files
- [x] `run_tutor_golden.php` diff vs main is purely additive (zero deletions to A.10 logic; `str_starts_with` prefix match + disambiguation block both still present)
- [x] domains fixture is valid JSON, 40 prompts
- [x] validators 36/0
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)