### PR TITLE
docs: retarget prod upgrade runbook + Catalyst request to v6.7.1

### DIFF
--- a/.drafts/catalyst-prod-deploy-request-2026-06-11.md
+++ b/.drafts/catalyst-prod-deploy-request-2026-06-11.md
@@ -1,27 +1,27 @@
 # Catalyst Production Deploy Request (ready to send)
 
 To: Artem / Catalyst
-Subject: SOLA plugin upgrade request: v5.4.5 to v6.6.0 on Degrees, then Learn
+Subject: SOLA plugin upgrade request: v5.4.5 to v6.7.1 on Degrees, then Learn
 
 Hi Artem,
 
 We would like to schedule an upgrade of the SOLA plugin (local_ai_course_assistant) on production. Details below; the goal is to make this as close to a standard, scriptable deploy as possible for you.
 
-**What:** upgrade the plugin submodule pin from v5.4.5 to tag v6.6.0
-(https://github.com/saylordotorg/moodle-local_ai_course_assistant/releases/tag/v6.6.0).
+**What:** upgrade the plugin submodule pin from v5.4.5 to tag v6.7.1
+(https://github.com/saylordotorg/moodle-local_ai_course_assistant/releases/tag/v6.7.1).
 
 **Where and in what order:** Degrees first, then Learn a few days later once we have confirmed Degrees is healthy. Two small windows rather than one.
 
 **Deploy steps per site (the standard three):**
-1. Update the submodule pin to tag v6.6.0.
+1. Update the submodule pin to tag v6.7.1.
 2. php admin/cli/upgrade.php --non-interactive
 3. Purge caches.
 
-**Migration profile:** small and tested. We tested this exact one jump (v5.4.5 to v6.6.0) on a clone today: the schema check passes, existing conversation data and settings survive, and all 19 scheduled tasks register. The schema delta is one nullable column and two non-unique indexes on the plugin's messages table; on a messages table in the low millions of rows each index build is seconds to low minutes. No maintenance mode needed; a low traffic window is enough.
+**Migration profile:** small and tested. We retested this exact one jump (v5.4.5 to v6.7.1) on a clone on 2026-06-16: the schema check passes, existing conversation data and settings survive, and the scheduled tasks register. The schema delta from v5.4.5 is additive only: two nullable columns (cached_tokens, session_meta) and two non-unique indexes on the plugin's messages table; on a messages table in the low millions of rows each index build is seconds to low minutes and the column adds are instant. No maintenance mode needed; a low traffic window is enough.
 
 **Pre deploy:** your standard DB backup plus a copy of the current plugin directory is all we need for rollback. Clean rollback is restore both; the schema additions are additive, so even a code only rollback to v5.4.5 runs without errors if ever needed in a hurry.
 
-**Release quality:** every tag ships only after our automated gate: validator and jailbreak suites, about 500 PHPUnit tests, Behat, an accessibility audit, CI green on the tagged commit, and deployment plus smoke verification on our five dev sites. v6.6.0 has been through all of it. v6.6.0 also includes a full security review (the report is attached to the GitHub release as a PDF); the two critical findings, both on an analytics export endpoint, are fixed and verified.
+**Release quality:** every tag ships only after our automated gate: validator and jailbreak suites, about 500 PHPUnit tests, Behat, an accessibility audit, CI green on the tagged commit, and deployment plus smoke verification on our five dev sites. v6.7.1 has been through all of it. The v6.6.0 baseline it builds on includes a full security review (the report is attached to that GitHub release as a PDF); the two critical findings, both on an analytics export endpoint, are fixed and verified, and v6.7.1 carries those fixes.
 
 **Post deploy:** we will run our own functional verification within the hour (we have a 10 minute checklist) and will not need anything further from you in the window.
 
@@ -36,8 +36,8 @@ Tom
 
 ## Internal notes (not part of the message)
 
-- Runbook with full detail: `.drafts/sola-prod-upgrade-runbook-v5.4.5-to-v6.6.0.md` (settings deltas, behavior changes, post deploy verification checklist, first week config steps).
-- Post deploy verification (Tom or Claude runs it): plugin version shows 2026061014/6.6.0; BUS101 chat round trip streams with SOLA_NEXT chips; history shows no telemetry rows; analytics + token analytics render; emergency panel shows all flags inactive.
+- Runbook with full detail: `.drafts/sola-prod-upgrade-runbook-v5.4.5-to-v6.7.1.md` (settings deltas, behavior changes, post deploy verification checklist, first week config steps).
+- Post deploy verification (Tom or Claude runs it): plugin version shows 2026061501/6.7.1; BUS101 chat round trip streams with SOLA_NEXT chips; history shows no telemetry rows; analytics + token analytics render; emergency panel shows all flags inactive; Soapbox stays off (no Soapbox link in course nav).
 - First week after both sites are live: set `spend_notify_emails`, run the spend alert self test CLI, then enable `cost_anomaly_enabled` and set `spend_cap_per_course_default` to 30.
 - Policy bundle stays OFF on prod until the dev soak finishes; enabling later is three settings and needs no Catalyst involvement.
-- Why v6.6.0: it carries the v6.0.1 security fix, the v6.2.x RAG and CSP fixes, the policy bundle mechanism that reduces future Catalyst engagements, the avatar engagement probe, and the v6.6.0 security-review fixes (two criticals on the analytics export, plus the IDOR/XSS/hardening set). The only schema change since v6.3.0 is one new non-unique index added in v6.6.0 (courseid, role, timecreated on the messages table) to keep analytics and spend queries fast at production scale; it is additive and the one-jump path is tested.
+- Why v6.7.1: it carries the v6.0.1 security fix, the v6.2.x RAG and CSP fixes, the policy bundle mechanism that reduces future Catalyst engagements, the avatar engagement probe, and the v6.6.0 security-review fixes (two criticals on the analytics export, plus the IDOR/XSS/hardening set). v6.7.0/v6.7.1 add the Soapbox speech-practice tool (off by default; for speech and ESL courses) with full 46-language coverage. Schema changes since v6.3.0 are additive only: the v6.6.0 non-unique index (courseid, role, timecreated on the messages table) for analytics/spend query speed, and the v6.7.0 nullable `session_meta` column on the practice-scores table; the one-jump path is tested.

--- a/.drafts/sola-prod-upgrade-runbook-v5.4.5-to-v6.7.1.md
+++ b/.drafts/sola-prod-upgrade-runbook-v5.4.5-to-v6.7.1.md
@@ -1,12 +1,12 @@
-# SOLA Production Upgrade Runbook: v5.4.5 to v6.6.0
+# SOLA Production Upgrade Runbook: v5.4.5 to v6.7.1
 
-Date prepared: 2026-06-10, retested against v6.6.0 on 2026-06-12
+Date prepared: 2026-06-10, retested against v6.7.1 on 2026-06-16
 Scope: Learn (learn.saylor.org) and Degrees, both currently on v5.4.5 (2026050945).
-Target: v6.6.0 (2026061003), one jump, no intermediate versions needed.
+Target: v6.7.1 (2026061501), one jump, no intermediate versions needed.
 
 ## Upgrade path verification (done)
 
-The exact jump was tested today on local Moodle 4.5.10 + MySQL: clean install of v5.4.5, seeded config and conversation data, then a single upgrade run to v6.6.0.
+The exact jump was retested on 2026-06-16 on local Moodle 4.5.10 + MySQL: a clean install of v5.4.5, seeded config (provider, spend cap) and conversation + message + practice-score data, then a single upgrade run to v6.7.1.
 
 | Check | Result |
 |---|---|
@@ -17,9 +17,10 @@ The exact jump was tested today on local Moodle 4.5.10 + MySQL: clean install of
 | New `cached_tokens` column (v6.1.0) | Created |
 | New `role_timecreated` index (v6.0.1) | Created |
 | New `courseid_role_timecreated` index (v6.6.0) | Created |
-| Scheduled tasks | All 19 registered, including `cost_anomaly_check` and `policy_bundle_sync` |
+| New `session_meta` column on `_practice_scores` (v6.7.0, savepoint 2026061500) | Created; pre-existing rows left NULL |
+| Scheduled tasks | All registered, including `cost_anomaly_check` and `policy_bundle_sync` |
 
-All upgrade steps between 2026050945 and 2026061014 are guarded (`index_exists` / `field_exists`), so a partial rerun is safe.
+The same single-column migration (`session_meta`, savepoint 2026061500) and the v6.7.1 marker (2026061501) also applied cleanly on the 5-site dev fleet spanning Moodle 4.5 / 5.0 / 5.1 / 5.3. All upgrade steps between 2026050945 and 2026061501 are guarded (`index_exists` / `field_exists`), so a partial rerun is safe.
 
 ## Why upgrade (what prod is missing today)
 
@@ -27,7 +28,8 @@ All upgrade steps between 2026050945 and 2026061014 are guarded (`index_exists` 
 2. **Kill switch fix (v5.13.0):** `emergency_control --chat` is a silent no op on v5.4.5. If you ever need to stop chat spend in an incident today, the CLI will not actually do it.
 3. Spend protections: per course default cap, cost anomaly detector, web emergency panel.
 4. Cost optimizations: mastery classifier routed to gpt-4o-mini, prompt cache visibility.
-5. 46 language coverage for every admin surface added since v5.10, and selfhosted Whisper STT support (v6.6.0).
+5. 46 language coverage for every admin surface added since v5.10, and selfhosted Whisper STT support (v6.3.0+).
+6. New opt-in pedagogy tool: Soapbox speech practice (v6.7.0/v6.7.1) for speech and ESL courses. Off by default; nothing changes for prod unless a course turns it on.
 
 ## Behavior changes to be aware of
 
@@ -35,7 +37,8 @@ All upgrade steps between 2026050945 and 2026061014 are guarded (`index_exists` 
 - **Voice STT resolution (v6.3.0 selfhosted Whisper):** when no selfhosted server URL is configured, behavior is identical to v5.4.5. Leave `stt_selfhosted_url` empty on prod for now.
 - **RAG relevance gating (v6.2.0):** retrieval now applies a cosine relevance floor (`rag_min_similarity` 0.25 default) and a small current page bias. Weakly matched chunks are dropped instead of padding the prompt; off topic questions may retrieve fewer or zero passages. This is the intended behavior change and reduces cost and hallucination risk.
 - **Voice upload validation (v6.2.2):** real browser recordings (MediaRecorder containers) now pass STT upload validation; previously every real recording got HTTP 415. Only matters if voice is enabled (it is off on prod).
-- Everything else new ships OFF by default: premium escalation, cost anomaly alerts, rerank, per course default cap, anomaly emails, policy bundle sync.
+- **Soapbox (v6.7.0/v6.7.1):** adds a learner speech-practice page, a long-form STT endpoint, a `score_speech` web service, a new `speech` rubric type, and the `session_meta` column. All gated behind `soapbox_enabled` (off by default), so there is no learner-facing change until a course enables it. Audio and transcript text are never stored.
+- Everything else new ships OFF by default: premium escalation, cost anomaly alerts, rerank, per course default cap, anomaly emails, policy bundle sync, Soapbox.
 
 ## New settings appearing after upgrade (all default safe)
 
@@ -51,30 +54,33 @@ All upgrade steps between 2026050945 and 2026061014 are guarded (`index_exists` 
 | `mastery_classifier_provider` | openai | Keep |
 | `policy_bundle_enabled` | off | Adopt after the dev soak: lets behavior settings update via signed bundle without further Catalyst engagements (`.drafts/sola-upgrade-independence-2026-06-11.md`) |
 | `rag_min_similarity` | 0.25 | Keep (v6.2.0 relevance floor) |
-| `avatar_animation_enabled` | on | Keep (v6.6.0; preserves prior behavior, adds idle blink). Stage 0 A/B uses per-course `avatar_animation_course_<id>` overrides post-upgrade |
+| `avatar_animation_enabled` | on | Keep (v6.5.0; preserves prior behavior, adds idle blink). Stage 0 A/B uses per-course `avatar_animation_course_<id>` overrides post-upgrade |
+| `soapbox_enabled` | off | Leave off site-wide; enable per course (`soapbox_enabled_course_<id>`) only for the speech/ESL courses that want it |
+| `soapbox_stt_mode` | server | Keep. Server uses the configured Whisper provider; only relevant once a course enables Soapbox. Browser mode is free but Chrome/Safari only |
 
 ## Deployment steps
 
 Prod deploys are managed by Catalyst (Artem workflow, git submodule), NOT zip upload and NOT the dev AWS path.
 
-1. Confirm v6.6.0 is tagged and the GitHub release is published with green CI.
-2. Request Catalyst pin the submodule to tag `v6.6.0` for staging first.
+1. Confirm v6.7.1 is tagged and the GitHub release is published with green CI.
+2. Request Catalyst pin the submodule to tag `v6.7.1` for staging first.
 3. On staging after deploy: run `php admin/cli/upgrade.php --non-interactive`, then purge caches, then the 5 minute smoke checklist (`.wiki/Release-Checklist.md`) against BUS101.
-4. Schedule the prod window. The DB migration is small (one column, two indexes on the messages table). On a messages table in the low millions of rows each index build takes seconds to low minutes; no maintenance mode required, but a low traffic window is polite.
+4. Schedule the prod window. The DB migration is small (one nullable column for v6.7.x, plus the two v6.x indexes on the messages table). On a messages table in the low millions of rows each index build takes seconds to low minutes; the `session_meta` column add is instant. No maintenance mode required, but a low traffic window is polite.
 5. Before the prod deploy: database backup plus a copy of the current plugin directory.
 6. Deploy, upgrade, purge caches.
 7. Post deploy verification (10 minutes):
-   - Plugin version shows 2026061003 / 6.2.0 in Site administration, Plugins overview.
+   - Plugin version shows 2026061501 / 6.7.1 in Site administration, Plugins overview.
    - Open BUS101 as a test learner: tab present, drawer opens, ask one question, streamed answer arrives, SOLA_NEXT chips render.
    - Conversation history shows no `[PremiumRouter]` or `[Rerank]` style rows (v6.0.1 fix working).
    - Analytics page renders; token analytics page renders.
    - `php admin/cli/emergency_disable.php --status` (or the new web panel at emergency_control.php) shows all flags inactive.
+   - Confirm `soapbox_enabled` is off (no Soapbox link in course navigation for a test learner).
 8. Within the first week: set `spend_notify_emails`, run `php admin/cli/send_spend_alert_test_email.php`, confirm the email lands, then enable `cost_anomaly_enabled` and set `spend_cap_per_course_default` to 30.
 
 ## Rollback plan
 
 - Code: restore the saved v5.4.5 plugin directory, purge caches. Moodle will not complain about the higher recorded version as long as code paths exist; however the clean rollback is code restore PLUS database restore from the pre upgrade backup.
-- The v6.x schema additions are additive (nullable column, two indexes), so v5.4.5 code runs against a v6.6.0 schema without errors if a fast code only rollback is ever needed; the recorded plugin version in config will be ahead, which blocks future upgrades until corrected. Prefer the full restore.
+- The v6.x schema additions are additive (nullable `cached_tokens` and `session_meta` columns, two indexes), so v5.4.5 code runs against a v6.7.1 schema without errors if a fast code only rollback is ever needed; the recorded plugin version in config will be ahead, which blocks future upgrades until corrected. Prefer the full restore.
 
 ## Open question for Tom
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ SOLA (Saylor Online Learning Assistant) is a Moodle local plugin that provides a
 - **Source folder (canonical):** the git repo at `~/Library/CloudStorage/Dropbox/!Saylor/ai-projects/ai_course_assistant/` (edit and commit here; the older `aicoursetutor/ai_course_assistant` path is a stale remnant, do not deploy from it)
 - **Zip for upload:** built from the repo via `create_fixed_zip.sh`
 - **GitHub:** `https://github.com/saylordotorg/moodle-local_ai_course_assistant` (public)
-- **Saylor production:** v5.4.5 on Learn + Degrees (as of 2026-05-12). Dev sites (dev / dev405 / dev500 / dev501 / dev503) track the latest release. Prod upgrade runbook (one jump v5.4.5 → v6.6.0, path retested locally 2026-06-12): `.drafts/sola-prod-upgrade-runbook-v5.4.5-to-v6.6.0.md`; ready-to-send Catalyst request: `.drafts/catalyst-prod-deploy-request-2026-06-11.md`.
+- **Saylor production:** v5.4.5 on Learn + Degrees (as of 2026-05-12). Dev sites (dev / dev405 / dev500 / dev501 / dev503) track the latest release. Prod upgrade runbook (one jump v5.4.5 → v6.7.1, path retested locally 2026-06-16): `.drafts/sola-prod-upgrade-runbook-v5.4.5-to-v6.7.1.md`; ready-to-send Catalyst request: `.drafts/catalyst-prod-deploy-request-2026-06-11.md`.
 
 ---
 


### PR DESCRIPTION
## Summary
Docs-only. Retargets the production upgrade artifacts from v6.6.0 to v6.7.1, backed by a fresh retest of the one-jump path.

- **Runbook** renamed to `sola-prod-upgrade-runbook-v5.4.5-to-v6.7.1.md`, target v6.7.1 (`2026061501`). Adds the v6.7.0 nullable `session_meta` column to the schema-change table and Soapbox (off by default) to the behavior-changes + new-settings sections. Fixes a stale post-deploy version string.
- **Catalyst request** retargeted to tag v6.7.1 (subject, pin, migration profile, verification version, Soapbox-off check).
- **CLAUDE.md** prod-status line points at the v6.7.1 runbook.

## Retest (real, 2026-06-16)
Clean v5.4.5 install on local Moodle 4.5.10 + MySQL, seeded config + conversation/message/practice-score, single `upgrade.php` run to v6.7.1:
- savepoints applied through `2026061500` (session_meta) + `2026061501`
- `check_database_schema.php`: Database structure is ok
- config (provider, spend cap) + data (conv/msg/score) survived intact
- `session_meta` column created; pre-existing row left NULL
- same single-column migration also verified on the 5-site dev fleet (Moodle 4.5/5.0/5.1/5.3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)