### PR TITLE
v6.7.2: fix voice mode failing with 'reserved special token'

### DIFF
--- a/classes/external/get_realtime_token.php
+++ b/classes/external/get_realtime_token.php
@@ -129,6 +129,14 @@ class get_realtime_token extends external_api {
                     . "they want to discuss.";
             }
             $instructions = $systemprompt . $voicetail;
+            // OpenAI Realtime rejects session.instructions that contain a
+            // reserved special token and fails the whole session with
+            // "instructions contain a reserved special token". The chat
+            // jailbreak-defense line cites one such token (<|im_start|>) as an
+            // example of text to ignore; the chat APIs tolerate it, but Realtime
+            // validates strictly. Neutralize any <|...|> token so voice mode can
+            // start. The surrounding instruction keeps its meaning.
+            $instructions = preg_replace('/<\|[a-zA-Z0-9_\-]+\|>/', '[special token]', $instructions);
         } catch (\Throwable $e) {
             debugging('realtime instructions build failed: ' . $e->getMessage(), DEBUG_DEVELOPER);
             $instructions = '';

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_ai_course_assistant';
-$plugin->version = 2026061501;
+$plugin->version = 2026061600;
 $plugin->requires = 2024100700; // Moodle 4.5+.
 $plugin->supported = [405, 503]; // Tested on Moodle 4.5 through 5.3dev.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '6.7.1';
+$plugin->release = '6.7.2';


### PR DESCRIPTION
## Summary
Voice (Realtime) mode failed at session start on dev with:
> Invalid 'session.instructions': instructions contain a reserved special token.

**Root cause:** the system prompt's jailbreak-defense line (`context_builder.php`) cites the literal `<|im_start|>` as an example of text the model should ignore. OpenAI's chat APIs tolerate that token in content, but the **Realtime** API validates `session.instructions` strictly and rejects any reserved special token, failing the whole session.

**Fix:** `get_realtime_token.php` neutralizes any `<|...|>` token in the assembled realtime instructions (→ `[special token]`) before they're sent. The instruction keeps its meaning; the chat path is untouched (its jailbreak example stays intact).

## Test Plan
- [x] `php -l` clean
- [x] Sanitization verified: `<|im_start|>` → `[special token]`, no `<|` remains; `realtime.js` has no hardcoded reserved tokens
- [ ] CI green
- [ ] Manual: start voice mode on dev — session connects (no reserved-token error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)