### PR TITLE
test: +19 tests (Soapbox/voice/branding) + score_speech Moodle-5.x fix

### DIFF
--- a/.drafts/sola-test-report-v6.8.0-2026-06-16.md
+++ b/.drafts/sola-test-report-v6.8.0-2026-06-16.md
@@ -1,0 +1,56 @@
+# SOLA v6.8.0 — Full Test Report
+
+Date: 2026-06-16. Scope: the v6.8.0 release (white-label branding) on top of the v6.7.x line (Soapbox speech practice + ESL levels, voice reserved-token fix). Run on local Moodle 4.5.10 + MySQL (PHP 8.3) plus the GitHub Actions CI matrix.
+
+## 1. Automated test suites — results
+
+| Suite | Result |
+|---|---|
+| **PHPUnit (full plugin)** | **549 tests, 1306 assertions, 0 failures, 1 skipped** |
+| **Security validator corpus** (`run_validators.php`) | **36 passed, 0 failed** |
+| **i18n completeness** | **46/46 locales, 0 missing keys** (1416 EN keys) |
+| **PHP lint** | clean on every tracked `.php` file (incl. all 46 lang files) |
+| **CI matrix** (on the v6.8.0 merge commit) | green: PHP 8.1 / 8.2 / 8.3 × MySQL/MariaDB + PostgreSQL, Mustache/Grunt/codechecker, Behat |
+| **Live jailbreak suite** (32 prompts) | NOT run locally — needs a live LLM key (the local provider key was unavailable in this environment). The static security corpus (validators, 36/0) passed; the generated system prompt is verified substantively identical for Saylor defaults. Re-run on dev before/with the production decision. |
+
+The 1 skipped PHPUnit test is a pre-existing environment-gated skip (not a failure).
+
+## 2. New tests added this round (+19)
+
+Closing the biggest gaps in the recently-shipped features:
+
+- **`tests/rubric_manager_test.php` (11 tests)** — first coverage for `rubric_manager` at all. `TYPE_SPEECH`, `DEFAULT_SPEECH_CRITERIA` shape, `get_default_criteria` by type, the four `speech_presets()` levels (general / esl_beginner / esl_intermediate / esl_advanced), `speech_preset()` resolution + safe fallback, `ensure_default_rubrics()` seeding the global speech rubric, `get_active_rubric()` global fallback, `save_score()` persisting (and null-defaulting) the v6.7.0 `session_meta` blob, and `get_user_scores()` decoding.
+- **`tests/get_realtime_token_test.php` (2 tests)** — the v6.7.2 voice fix: asserts the realtime `instructions` contain no OpenAI reserved special token (`<|...|>`), that the cited `<|im_start|>` is neutralized to `[special token]`, and that the voice-mode tail + `SOLA_NEXT` marker survive. Uses the built-in `$test_http_response` mock (no network).
+- **`tests/score_speech_test.php` (4 tests)** — the Soapbox scoring gate: returns `disabled` when off, `too_short` under the 40-character boundary, and a stable return shape. (The LLM scoring path needs a live provider and is covered by the functional smoke.)
+- **`tests/context_builder_branding_test.php` (2 tests)** — the v6.8.0 integration: a rebrand (`ZBRANDX` / `Zeta University`) reaches the generated system prompt, the default resolves to SOLA branding, and no `[[token]]` ever leaks into what the LLM receives.
+
+Plus the pre-existing `tests/branding_test.php` leak-guard (every EN lang string resolves with no leftover token after `apply()`).
+
+## 3. Issue found and fixed during testing
+
+- **`score_speech` used the deprecated global `external_api` alias** (`use external_api;` + `require_once externallib.php`) rather than `core_external\external_api`. This failed PHPUnit autoload and risked breaking on Moodle 5.x, where the global aliases are removed. Modernized to `core_external\…` (matching `get_realtime_token`). Confirmed it was the **only** external function with the old alias.
+
+## 4. Functional smoke (HTTP, local Moodle, default SOLA branding)
+
+| Path | Result |
+|---|---|
+| Course page widget (course 2) | 200, `data-shortname="SOLA"`, **0 token leaks** |
+| Soapbox page (feature on) | 200, renders setup panel + record button, **0 leaks** |
+| Soapbox page (feature off) | error page (the off-by-default per-course gate correctly blocks access) |
+| Rubric admin, speech type, `?preset=esl_intermediate` | 200, loads the ESL-intermediate sample criteria, **0 leaks** |
+| Course settings (Soapbox toggle + level select) | 200, **0 leaks** |
+| Admin settings (general section, all brand-bearing descriptions) | renders SOLA resolved, **0 leaks** across every section |
+
+**Rebrand verification**: setting the four branding values to a test brand (Acme University / Acme / Acme Study Buddy / ASB) propagates completely — widget, greeting, admin settings copy, and the system prompt all switch to the new names with zero residual SOLA and zero `[[token]]` leaks. Reverting to unset renders SOLA/Saylor identically.
+
+**Dev fleet**: v6.7.2 and v6.8.0 each deployed to all 5 dev sites (dev / 405 / 500 / 501 / 503) with BUS101 smoke OK; a public dev page (privacy notice) confirmed 0 token leaks.
+
+## 5. Coverage map
+
+Well-covered (unit + functional): branding token system, rubric_manager + Soapbox scoring gate, realtime instruction sanitization, context_builder prompt assembly + branding, spend guard / emergency control / policy bundle / cost anomaly / premium router / voice registry / providers / analytics / privacy (existing suites).
+
+Covered by functional smoke only (need a live LLM or browser): the LLM scoring path in `score_speech`, the in-browser recording → STT → feedback round trip on `soapbox.php`, and the OpenAI Realtime voice session. These are exercised manually on dev.
+
+## 6. Verdict
+
+All automated suites green (549 PHPUnit, 36 validators, 46/46 i18n, lint, CI matrix). One latent Moodle-5.x compatibility bug found and fixed. Functional smoke green with zero brand-token leaks on every surface and the off-by-default gates working. **Recommended GO for the v6.8.0 tag and GitHub release**, with the live jailbreak suite to be re-run on dev as the final pre-production check.

--- a/.drafts/v6.8.0-release-notes-and-walkthrough.md
+++ b/.drafts/v6.8.0-release-notes-and-walkthrough.md
@@ -1,0 +1,58 @@
+# SOLA v6.8.0 — Full white-label rebranding, release notes + admin walkthrough
+
+## Part 1: Release Notes (16 June 2026)
+
+**v6.8.0 makes the entire product rebrandable from four admin settings, with no code or string-file edits. Defaults are unchanged, so existing installs render identically.**
+
+- **Four settings drive the whole product name**: `institution_name` (default "Saylor University"), `institution_short_name` ("Saylor"), `display_name` ("Saylor Online Learning Assistant"), `short_name` ("SOLA"). A different institution rebrands by changing these four values.
+- **`classes/branding.php` is the single source of truth.** `apply($text)` resolves the four brand tokens `[[uniname]]` / `[[unishort]]` / `[[tutorname]]` / `[[tutorshort]]`; `str($key)` = `apply(get_string())`; `token_map()` / `token_map_json()` expose the values to the browser.
+- **All 46 language files are tokenized** — literal Saylor/SOLA names replaced with tokens. Resolution happens at every output boundary: the system prompt (`context_builder` applies after the `{{coursename}}`/`{{institution}}` substitution, so every mention rebrands, including the "## What … Can Help" sections the old code missed), widget JS strings + the personalized greeting (a token map on the widget root, resolved in `chat.js`), the one mustache `{{#str}}` brand label (pre-rendered as `chat_open_label`), admin settings copy (every brand-bearing `get_string` wrapped, including the dynamic pedagogy and talking-avatar persona loops), scheduled-task names, and the standalone learner/admin pages and emails.
+- **Deliberately not tokenized**: copyright headers, the internal `SOLA_NEXT` suggestion-chip protocol marker (never shown to users), and lowercase `saylor.org` emails/URLs (handled by their own branding accessors).
+- **Settings defaults aligned to Saylor/SOLA.** The four settings previously defaulted to generic placeholders ("Assistant" / "Your Institution"); the product only showed "SOLA" because the lang strings hardcoded it. Now that those strings resolve through `branding::`, the defaults were set to the canonical Saylor/SOLA values so a default install renders exactly as before. Installs that set these explicitly are unaffected.
+- **Leak-guard test**: `tests/branding_test.php` asserts no English lang string retains an unresolved `[[token]]` after `apply()` (1416 strings, 0 leaks), alongside `apply()` / `token_map()` / `str()` coverage.
+
+### Also in this release line (carried into the v6.8.0 tag)
+- **v6.7.2 — voice mode fix**: OpenAI Realtime rejected `session.instructions` containing a reserved special token (the jailbreak-defence line cites the literal `<|im_start|>`), failing voice at session start. `get_realtime_token.php` now neutralizes any `<|...|>` token in the realtime instructions; the chat path is unchanged.
+- **v6.7.0 / v6.7.1 — Soapbox speech practice** for speech and ESL courses (off by default): record a longer speech, transcribed and scored against a per-course speaking rubric; four course-type/speaking levels (General + ESL beginner/intermediate/advanced); audio and transcript text are never stored. Three STT tiers (self-hosted Whisper / hosted OpenAI / in-browser Web Speech API).
+
+### Schema
+None new in v6.8.0. (The v6.7.0 `session_meta` column is part of the underlying line.)
+
+### Testing (release gate)
+- PHPUnit full plugin suite **549 tests, 0 failures, 1 skipped** (+19 new this round: rubric_manager, get_realtime_token reserved-token, score_speech gate, context_builder branding).
+- Security validators **36/36**; i18n **46/46**; PHP lint clean; CI matrix green (PHP 8.1/8.2/8.3 × MySQL/pgsql + Behat).
+- Functional smoke green with **zero brand-token leaks** on the widget, Soapbox, rubric admin, course settings, and every admin settings section; a test rebrand (Acme/ASB) propagates completely including the system prompt.
+- Latent bug found + fixed: `score_speech` used the deprecated global `external_api` alias (Moodle-5.x risk) — modernized to `core_external\…`.
+- Live jailbreak (32 prompts, live LLM) to be re-run on dev; the generated prompt is verified substantively identical for Saylor defaults.
+- Full report: `.drafts/sola-test-report-v6.8.0-2026-06-16.md`.
+
+Plugin version `2026061601`, release `6.8.0`.
+
+---
+
+## Part 2: Key SOLA Features
+
+- Multi-provider AI backend with SSE streaming; per-course configuration.
+- **White-label rebranding (v6.8.0)**: the whole product (and operator-facing copy) rebrands from four admin settings.
+- Personalized greeting and coaching; practice quizzes; study plans and reminders.
+- Analytics dashboard (usage, provider comparison, A/B experiment readout).
+- 46-language i18n with auto-detection; 46-language STT/TTS.
+- Voice input (STT) and output (TTS); OpenAI Realtime voice mode.
+- Procedurally-generated SVG avatar with idle animation.
+- RAG semantic search (embedding retrieval; opt-in Voyage rerank).
+- Dynamic SOLA_NEXT suggestion chips; conversation starters overlay.
+- Pedagogy tools, each off by default and gated per course: flashcards, Python sandbox, essay feedback, worked examples, and Soapbox speech practice (speech + ESL courses).
+- Cost governance: per-course and site spend caps with notification thresholds, daily cost-anomaly detection, an emergency kill switch, and a signed policy-bundle channel for behavior-as-data updates.
+- Premium escalation tier (Opus 4.8) for STEM-heavy turns, off by default.
+
+---
+
+## Part 3: Admin walkthrough — rebranding SOLA for your institution (about 5 minutes)
+
+This is the new flow in v6.8.0. For the broader feature walkthroughs (Soapbox, analytics, etc.), see the prior release drafts.
+
+1. **Open the branding settings.** Site administration → Plugins → Local plugins → SOLA, "Branding & UI" section (or jump straight to `admin/settings.php?section=local_ai_course_assistant_general`).
+2. **Set the four names.** Institution Name (full), Institution Short Name, Assistant Display Name (full product name), Assistant Short Name (the compact brand). Defaults are Saylor University / Saylor / Saylor Online Learning Assistant / SOLA.
+3. **Save and purge caches.** The change is instant and complete: the chat widget header, the personalized greeting, the system prompt the AI is given, every admin settings description, the scheduled-task names, and the privacy/consent/email copy all switch to the new names. No code deploy, no string-file edit.
+4. **Verify on a course page.** Open a course as a learner: the tab, drawer, and greeting use the new name. There are no leftover `[[ ]]` placeholders anywhere — if you ever see one, it means a new string was added without a translation; the leak-guard test catches that before release.
+5. **What stays.** Internal identifiers (the Moodle plugin name `local_ai_course_assistant`, the `SOLA_NEXT` chip protocol, config keys) do not change — they are not user-visible. Contact emails and the privacy URL have their own settings if you want to change those too.

--- a/classes/external/score_speech.php
+++ b/classes/external/score_speech.php
@@ -18,13 +18,11 @@ namespace local_ai_course_assistant\external;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->libdir . '/externallib.php');
-
-use external_api;
-use external_function_parameters;
-use external_value;
-use external_single_structure;
-use external_multiple_structure;
+use core_external\external_api;
+use core_external\external_function_parameters;
+use core_external\external_value;
+use core_external\external_single_structure;
+use core_external\external_multiple_structure;
 use local_ai_course_assistant\provider\base_provider;
 use local_ai_course_assistant\rubric_manager;
 use local_ai_course_assistant\feature_flags;

--- a/tests/context_builder_branding_test.php
+++ b/tests/context_builder_branding_test.php
@@ -1,0 +1,67 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+
+/**
+ * Tests that the v6.8.0 brand-token system reaches the generated system
+ * prompt: every [[token]] resolves from the four admin settings and no raw
+ * token ever leaks into what the LLM receives.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Tom Caswell & David Ta / Saylor University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_ai_course_assistant\context_builder
+ */
+final class context_builder_branding_test extends \advanced_testcase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+    }
+
+    public function test_system_prompt_resolves_brand_tokens_and_never_leaks(): void {
+        $course = $this->getDataGenerator()->create_course();
+
+        // Rebrand to a distinctive name no default text would contain.
+        set_config('short_name', 'ZBRANDX', 'local_ai_course_assistant');
+        set_config('display_name', 'Zeta Brand Tutor', 'local_ai_course_assistant');
+        set_config('institution_name', 'Zeta University', 'local_ai_course_assistant');
+
+        $prompt = context_builder::build_system_prompt(
+            (int) $course->id, (int) get_admin()->id, 'en', [], 0, '', '');
+
+        $this->assertStringContainsString('ZBRANDX', $prompt,
+            'The configured short name must appear in the prompt.');
+        $this->assertStringContainsString('Zeta University', $prompt);
+        $this->assertDoesNotMatchRegularExpression('/\[\[(tutorname|tutorshort|uniname|unishort)\]\]/',
+            $prompt, 'No brand token may leak into the system prompt.');
+        // The literal default brand must not survive a rebrand.
+        $this->assertStringNotContainsString('You are SOLA', $prompt);
+    }
+
+    public function test_system_prompt_defaults_to_sola_branding(): void {
+        $course = $this->getDataGenerator()->create_course();
+        // With no branding config, fallbacks apply -> the prompt is SOLA-branded.
+        $prompt = context_builder::build_system_prompt(
+            (int) $course->id, (int) get_admin()->id, 'en', [], 0, '', '');
+
+        $this->assertStringContainsString('SOLA', $prompt);
+        $this->assertDoesNotMatchRegularExpression('/\[\[(tutorname|tutorshort|uniname|unishort)\]\]/',
+            $prompt);
+    }
+}

--- a/tests/get_realtime_token_test.php
+++ b/tests/get_realtime_token_test.php
@@ -1,0 +1,78 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant\external;
+
+/**
+ * Tests for the realtime token endpoint, focused on the v6.7.2 fix: the
+ * session instructions sent to OpenAI Realtime must not contain a reserved
+ * special token (e.g. <|im_start|>, which the system prompt's jailbreak
+ * defence cites as an example). Realtime rejects the whole session otherwise.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Tom Caswell & David Ta / Saylor University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_ai_course_assistant\external\get_realtime_token
+ */
+final class get_realtime_token_test extends \advanced_testcase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest(true);
+        // A configured realtime provider (legacy single-key path resolves to
+        // OpenAI) plus a mocked ephemeral-token HTTP response, so execute()
+        // reaches the return without a real network call.
+        set_config('realtime_apikey', 'sk-test-key', 'local_ai_course_assistant');
+        get_realtime_token::$test_http_response = [
+            'http_code' => 200,
+            'body' => '{"client_secret":{"value":"ek_test_secret"}}',
+        ];
+    }
+
+    protected function tearDown(): void {
+        get_realtime_token::$test_http_response = null;
+        parent::tearDown();
+    }
+
+    public function test_instructions_strip_reserved_special_tokens(): void {
+        $this->setAdminUser();
+        $course = $this->getDataGenerator()->create_course();
+
+        $result = get_realtime_token::execute((int) $course->id, 0, '', 'en');
+
+        $this->assertArrayHasKey('instructions', $result);
+        $instructions = $result['instructions'];
+        $this->assertNotEmpty($instructions);
+        // The core guarantee: no OpenAI reserved special token survives.
+        $this->assertDoesNotMatchRegularExpression('/<\|[a-zA-Z0-9_\-]+\|>/', $instructions,
+            'Realtime instructions must not contain a reserved special token.');
+        // The jailbreak-defence line cited <|im_start|>; it is now neutralized.
+        $this->assertStringContainsString('[special token]', $instructions);
+        $this->assertStringNotContainsString('<|im_start|>', $instructions);
+    }
+
+    public function test_instructions_carry_the_voice_mode_tail(): void {
+        $this->setAdminUser();
+        $course = $this->getDataGenerator()->create_course();
+
+        $result = get_realtime_token::execute((int) $course->id, 0, '', 'en');
+
+        // Voice-mode tail is appended (spoken-style guidance) and the SOLA_NEXT
+        // protocol marker instruction is preserved (it is not a reserved token).
+        $this->assertStringContainsString('Voice mode', $result['instructions']);
+        $this->assertStringContainsString('SOLA_NEXT', $result['instructions']);
+    }
+}

--- a/tests/rubric_manager_test.php
+++ b/tests/rubric_manager_test.php
@@ -1,0 +1,163 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+
+/**
+ * Tests for rubric_manager: practice rubrics + scores, with focus on the
+ * v6.7.0 Soapbox speech rubric type and v6.7.1 ESL level presets.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Tom Caswell & David Ta / Saylor University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_ai_course_assistant\rubric_manager
+ */
+final class rubric_manager_test extends \advanced_testcase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest(true);
+    }
+
+    public function test_type_speech_constant(): void {
+        $this->assertEquals('speech', rubric_manager::TYPE_SPEECH);
+    }
+
+    public function test_default_speech_criteria_shape(): void {
+        $criteria = rubric_manager::DEFAULT_SPEECH_CRITERIA;
+        $this->assertCount(5, $criteria);
+        foreach ($criteria as $c) {
+            $this->assertArrayHasKey('name', $c);
+            $this->assertArrayHasKey('description', $c);
+            $this->assertArrayHasKey('max_score', $c);
+            $this->assertSame(5, $c['max_score']);
+        }
+    }
+
+    public function test_get_default_criteria_by_type(): void {
+        $this->assertSame(rubric_manager::DEFAULT_SPEECH_CRITERIA,
+            rubric_manager::get_default_criteria('speech'));
+        $this->assertSame(rubric_manager::DEFAULT_PRONUNCIATION_CRITERIA,
+            rubric_manager::get_default_criteria('pronunciation'));
+        $this->assertSame(rubric_manager::DEFAULT_CONVERSATION_CRITERIA,
+            rubric_manager::get_default_criteria('conversation'));
+        // Unknown type falls back to conversation.
+        $this->assertSame(rubric_manager::DEFAULT_CONVERSATION_CRITERIA,
+            rubric_manager::get_default_criteria('nonsense'));
+    }
+
+    public function test_speech_presets_has_four_levels(): void {
+        $presets = rubric_manager::speech_presets();
+        $this->assertEqualsCanonicalizing(
+            ['general', 'esl_beginner', 'esl_intermediate', 'esl_advanced'],
+            array_keys($presets));
+        foreach ($presets as $level => $preset) {
+            $this->assertArrayHasKey('label_key', $preset, "$level needs a label_key");
+            $this->assertArrayHasKey('hint', $preset, "$level needs a coaching hint");
+            $this->assertNotEmpty($preset['hint']);
+            $this->assertCount(5, $preset['criteria'], "$level rubric should have 5 criteria");
+        }
+    }
+
+    public function test_speech_preset_general_matches_default_criteria(): void {
+        $this->assertSame(rubric_manager::DEFAULT_SPEECH_CRITERIA,
+            rubric_manager::speech_preset('general')['criteria']);
+    }
+
+    public function test_speech_preset_resolves_levels_and_falls_back(): void {
+        $beginner = rubric_manager::speech_preset('esl_beginner');
+        $this->assertStringContainsStringIgnoringCase('beginner', $beginner['hint']);
+        $advanced = rubric_manager::speech_preset('esl_advanced');
+        $this->assertStringContainsStringIgnoringCase('advanced', $advanced['hint']);
+        // Unknown level falls back to the General preset.
+        $this->assertSame(rubric_manager::speech_preset('general'),
+            rubric_manager::speech_preset('does-not-exist'));
+    }
+
+    public function test_ensure_default_rubrics_seeds_a_global_speech_rubric(): void {
+        rubric_manager::ensure_default_rubrics();
+        $rubric = rubric_manager::get_active_rubric(0, rubric_manager::TYPE_SPEECH);
+        $this->assertNotNull($rubric);
+        $this->assertSame('speech', $rubric->type);
+        $this->assertSame(0, (int) $rubric->courseid);
+        // get_active_rubric returns criteria already decoded to an array.
+        $this->assertIsArray($rubric->criteria);
+        $this->assertCount(5, $rubric->criteria);
+    }
+
+    public function test_get_active_rubric_falls_back_to_global_default(): void {
+        $course = $this->getDataGenerator()->create_course();
+        rubric_manager::ensure_default_rubrics();
+        // No course-specific speech rubric -> falls back to the global one.
+        $rubric = rubric_manager::get_active_rubric((int) $course->id, rubric_manager::TYPE_SPEECH);
+        $this->assertNotNull($rubric);
+        $this->assertSame(0, (int) $rubric->courseid);
+    }
+
+    public function test_save_score_persists_meta_blob(): void {
+        global $DB;
+        $course = $this->getDataGenerator()->create_course();
+        $user = $this->getDataGenerator()->create_user();
+        $rid = rubric_manager::create_rubric(0, rubric_manager::TYPE_SPEECH, 'Speech',
+            rubric_manager::DEFAULT_SPEECH_CRITERIA);
+
+        $scores = [['name' => 'Delivery & Fluency', 'score' => 4, 'feedback' => 'Clear pace.']];
+        $meta = ['name' => 'My speech', 'topic' => 'Climate', 'target' => 180, 'tips' => ['Slow down']];
+        $sid = rubric_manager::save_score($rid, (int) $user->id, (int) $course->id,
+            rubric_manager::TYPE_SPEECH, $scores, 4, 'Nice work.', 95, $meta);
+
+        $this->assertGreaterThan(0, $sid);
+        $row = $DB->get_record('local_ai_course_assistant_practice_scores', ['id' => $sid]);
+        $this->assertSame('speech', $row->session_type);
+        $this->assertSame(95, (int) $row->session_duration);
+        $this->assertSame($meta, json_decode($row->session_meta, true));
+    }
+
+    public function test_save_score_meta_is_null_when_omitted(): void {
+        global $DB;
+        $course = $this->getDataGenerator()->create_course();
+        $user = $this->getDataGenerator()->create_user();
+        $rid = rubric_manager::create_rubric(0, 'conversation', 'Conv',
+            rubric_manager::DEFAULT_CONVERSATION_CRITERIA);
+
+        $sid = rubric_manager::save_score($rid, (int) $user->id, (int) $course->id,
+            'conversation', [], 3, 'ok', 10);
+
+        $row = $DB->get_record('local_ai_course_assistant_practice_scores', ['id' => $sid]);
+        $this->assertNull($row->session_meta);
+    }
+
+    public function test_get_user_scores_returns_decoded_scores_for_speech(): void {
+        $course = $this->getDataGenerator()->create_course();
+        $user = $this->getDataGenerator()->create_user();
+        $rid = rubric_manager::create_rubric(0, rubric_manager::TYPE_SPEECH, 'Speech',
+            rubric_manager::DEFAULT_SPEECH_CRITERIA);
+        $scores = [['name' => 'Delivery & Fluency', 'score' => 5, 'feedback' => 'Great.']];
+        rubric_manager::save_score($rid, (int) $user->id, (int) $course->id,
+            rubric_manager::TYPE_SPEECH, $scores, 5, 'Excellent.', 120,
+            ['name' => 'Speech 1']);
+
+        $rows = rubric_manager::get_user_scores((int) $user->id, (int) $course->id,
+            rubric_manager::TYPE_SPEECH, 5);
+
+        $this->assertCount(1, $rows);
+        $row = reset($rows);
+        $this->assertIsArray($row->scores);
+        $this->assertSame('Delivery & Fluency', $row->scores[0]['name']);
+        // session_meta is left as raw JSON for the caller to decode.
+        $this->assertSame('Speech 1', json_decode($row->session_meta, true)['name']);
+    }
+}

--- a/tests/score_speech_test.php
+++ b/tests/score_speech_test.php
@@ -1,0 +1,78 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant\external;
+
+/**
+ * Tests for the Soapbox score_speech endpoint (v6.7.0): the feature gate and
+ * input-validation paths that run before any LLM call. The scoring path itself
+ * needs a live provider and is exercised by the manual/functional smoke.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Tom Caswell & David Ta / Saylor University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_ai_course_assistant\external\score_speech
+ */
+final class score_speech_test extends \advanced_testcase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+    }
+
+    public function test_returns_disabled_when_soapbox_off_for_course(): void {
+        $course = $this->getDataGenerator()->create_course();
+        // Soapbox is off by default (site + course).
+        $result = score_speech::execute((int) $course->id,
+            str_repeat('word ', 30), 'Name', 'Topic', 180, 120);
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('disabled', $result['message']);
+        $this->assertSame([], $result['criteria']);
+        $this->assertSame(0, $result['scoreid']);
+    }
+
+    public function test_returns_too_short_for_a_tiny_transcript(): void {
+        $course = $this->getDataGenerator()->create_course();
+        set_config('soapbox_enabled', 1, 'local_ai_course_assistant');
+
+        $result = score_speech::execute((int) $course->id, 'too short', '', '', 0, 0);
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('too_short', $result['message']);
+    }
+
+    public function test_too_short_boundary_is_40_characters(): void {
+        $course = $this->getDataGenerator()->create_course();
+        set_config('soapbox_enabled', 1, 'local_ai_course_assistant');
+
+        // 39 chars -> too_short; the gate is mb_strlen < 40.
+        $thirtynine = str_pad('a', 39, 'a');
+        $this->assertSame(39, mb_strlen($thirtynine));
+        $result = score_speech::execute((int) $course->id, $thirtynine, '', '', 0, 0);
+        $this->assertSame('too_short', $result['message']);
+    }
+
+    public function test_execute_returns_structure_is_stable(): void {
+        $course = $this->getDataGenerator()->create_course();
+        $result = score_speech::execute((int) $course->id, 'x', '', '', 0, 0);
+        // Even on an early return, the documented shape is present.
+        foreach (['success', 'message', 'criteria', 'overall', 'tips', 'scoreid'] as $key) {
+            $this->assertArrayHasKey($key, $result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Pre-release test-coverage pass for **v6.8.0**, plus a latent compatibility fix and a full test report. No version bump (rides the v6.8.0 tag).

### New tests (+19)
- **`rubric_manager_test.php` (11)** — first coverage for `rubric_manager`: the four `speech_presets()` ESL levels, `speech_preset()` fallback, `save_score()` `session_meta` persistence (and null default), `ensure_default_rubrics()` speech seeding, `get_active_rubric()` global fallback, `get_user_scores()` decoding.
- **`get_realtime_token_test.php` (2)** — the v6.7.2 voice fix: realtime `instructions` carry no reserved special token (`<|...|>` → `[special token]`); voice tail + `SOLA_NEXT` preserved. Mocked via `$test_http_response`.
- **`score_speech_test.php` (4)** — Soapbox scoring gate (disabled / too_short boundary / stable return shape).
- **`context_builder_branding_test.php` (2)** — v6.8.0: a rebrand reaches the system prompt; default is SOLA; no `[[token]]` leaks to the LLM.

### Fix
`score_speech` used the deprecated **global `external_api`** alias (`use external_api;` + `require externallib.php`), which failed PHPUnit autoload and would break on **Moodle 5.x** where the global aliases are removed. Modernized to `core_external\…` (matching `get_realtime_token`). Confirmed it was the only external function with the old alias.

## Test Plan
- [x] Full PHPUnit suite **549 tests, 0 failures, 1 skipped** (local Moodle 4.5, PHP 8.3)
- [x] Validators **36/0**, i18n **46/46**, PHP lint clean
- [x] Functional smoke green (widget / Soapbox / rubric admin / course + admin settings) with **0 brand-token leaks**; rebrand to Acme/ASB propagates completely
- [ ] CI matrix green
- Full report: `.drafts/sola-test-report-v6.8.0-2026-06-16.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)