### PR TITLE
fix(ci): give the Claude bot write access so its reviews actually post

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -41,4 +41,3 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
@@ -47,4 +47,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr *)'
-


### PR DESCRIPTION
## Problem

The `Claude Code Review` workflow runs on every pull request and the `claude-review` job reports success, but no review ever appears on the PR. Checked #101, #102, and #103: the job ran on each, yet there are zero reviews, comments, or inline comments.

The job log explains why. The workflow `GITHUB_TOKEN` is read only:

```
Contents: read   Issues: read   Metadata: read   PullRequests: read
```

and the run ends with:

```
"permission_denials_count": 42
No buffered inline comments
```

So Claude generates the review but the token cannot post it back. Note this is unrelated to releases: the review fires on `pull_request` events, not on tags.

## Fix

Grant `pull-requests: write` and `issues: write` in both Claude workflows:

- `claude-code-review.yml` (the automatic per-PR review)
- `claude.yml` (the `@claude` responder, which had the same read only token and so could not post replies either)

## Verification

Because same repository pull requests use the head branch's workflow permissions, this PR should exercise the fixed review workflow and Claude's review should post on this PR itself. If it does, the fix is confirmed.

Generated with Claude Code (https://claude.com/claude-code)