### PR TITLE
docs: sync README version header to 6.8.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A comprehensive AI-powered chat widget for Moodle 4.5+ that provides context-aware tutoring, support, and study planning for students.
 
-## Version 5.4.5
+## Version 6.8.5
 
-**Release Date:** May 2026
+**Release Date:** June 2026
 **Requires:** Moodle 4.5+ (2024100700)
 **License:** GPL v3+
 **Maturity:** Stable. In production at saylor.org for a 30-course pilot.


### PR DESCRIPTION
Small docs-only change: the README header still advertised **Version 5.4.5 (May 2026)** while `version.php` on main is at release **6.8.5**. Updates the version number and date in the header.

Also serving as a test that the Claude Code Review workflow now posts its review, following the permissions fix in #108. Expecting a review to appear on this PR.

Generated with Claude Code (https://claude.com/claude-code)