### PR TITLE
ci: allow Claude auto-review on Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Allow Dependabot-authored PRs to be auto-reviewed (bot-initiated
+          # runs are blocked by default). Use '*' to allow all bots.
+          allowed_bots: 'dependabot'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Problem

The automatic `Claude Code Review` workflow errors out on Dependabot PRs. On #105 the job ended with:

```
Action failed with error: Workflow initiated by non-human actor: dependabot (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

`claude-code-action` refuses bot-initiated runs unless `allowed_bots` is set. (Human-initiated `@claude review` comments are unaffected — those already work.)

## Fix

Add `allowed_bots: 'dependabot'` to the `claude-code-action` step in `claude-code-review.yml` so Dependabot PRs get auto-reviewed like any other PR. Use `'*'` instead to allow all bots.

Note: this is the only change; the workflow otherwise matches main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)