### PR TITLE
docs(CLAUDE.md): note Claude review triggers on PRs and the #108 fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,13 @@ The validator suite is corpus-driven (`tests/security/`) and runs in millisecond
 
 ---
 
+## CI and GitHub automation
+
+- **Claude code review triggers on pull requests, not releases.** `.github/workflows/claude-code-review.yml` runs `/code-review` automatically on every PR (opened / synchronize / reopened / ready_for_review); `.github/workflows/claude.yml` runs Claude whenever a comment or issue body contains `@claude`. No tag or release is involved — to get a review, open a PR (or comment `@claude`).
+- **Both workflows need write scope to post their output.** They originally shipped with a read-only `GITHUB_TOKEN` (`pull-requests: read`), so the review job ran and reported success but posted nothing — the job log showed `permission_denials_count` and `No buffered inline comments`. Fixed in **PR #108 (2026-07-03)** by granting `pull-requests: write` + `issues: write` in both files; verified by PR #109. If Claude reviews or `@claude` replies ever stop appearing, check these workflow permissions first.
+
+---
+
 ## Local Development
 
 - **Moodle 4.5** at `~/Sites/moodle/`, moodledata at `~/Sites/moodledata/`


### PR DESCRIPTION
Adds a short "CI and GitHub automation" section to CLAUDE.md documenting:

- The Claude code review triggers on pull requests (and `@claude` comments), not releases.
- Both Claude workflows needed `pull-requests: write` to post their output; this was the cause of the silent no-op reviews, fixed in #108 and verified by #109. Includes a pointer to check those permissions first if reviews ever stop appearing.

Docs only, no code changes.

Generated with Claude Code (https://claude.com/claude-code)