### PR TITLE
docs(CLAUDE.md): mark the v5.4.5 to v6.8.2 prod upgrade as landed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ SOLA (Saylor Online Learning Assistant) is a Moodle local plugin that provides a
 - **Source folder (canonical):** the git repo at `~/Library/CloudStorage/Dropbox/!Saylor/ai-projects/ai_course_assistant/` (edit and commit here; the older `aicoursetutor/ai_course_assistant` path is a stale remnant, do not deploy from it)
 - **Zip for upload:** built from the repo via `create_fixed_zip.sh`
 - **GitHub:** `https://github.com/saylordotorg/moodle-local_ai_course_assistant` (public)
-- **Saylor production:** v5.4.5 on Learn + Degrees (as of 2026-05-12); **v6.8.2 sent to Catalyst for the prod upgrade on 2026-06-17**. Dev sites (dev / dev405 / dev500 / dev501 / dev503) track the latest release. Prod upgrade runbook stays at v6.8.2 (matches the Catalyst submission): one jump v5.4.5 → v6.8.2 (`.drafts/sola-prod-upgrade-runbook-v5.4.5-to-v6.8.2.md`); Catalyst request: `.drafts/catalyst-prod-deploy-request-2026-06-11.md`. NOTE: the Moodle plugin **directory** track is a separate version (v6.8.3, the CONTRIB-10574 29/29 resubmission); the directory listing and the prod pin need not match. Resubmission email: `.drafts/moodle-directory-resubmission-email-v6.8.3.md`.
+- **Saylor production:** **v6.8.2 on Learn + Degrees as of 2026-06-24** (the Catalyst upgrade from v5.4.5 landed; the v5.4.5 → v6.8.2 jump is complete). Dev sites (dev / dev405 / dev500 / dev501 / dev503) track the latest release. Upgrade runbook (now historical): `.drafts/sola-prod-upgrade-runbook-v5.4.5-to-v6.8.2.md`; Catalyst request: `.drafts/catalyst-prod-deploy-request-2026-06-11.md`. NOTE: the Moodle plugin **directory** track is a separate version (v6.8.3, the CONTRIB-10574 29/29 resubmission); the directory listing and the prod pin need not match. Resubmission email: `.drafts/moodle-directory-resubmission-email-v6.8.3.md`.
 
 ---
 
@@ -256,7 +256,7 @@ rsync -a --exclude=.git \
 
 ## Upcoming Work
 
-1. Prod upgrade decision: v5.4.5 → v6.8.2 on Learn + Degrees (Tom's call; runbook ready at `.drafts/sola-prod-upgrade-runbook-v5.4.5-to-v6.8.2.md`; Catalyst/Artem workflow, stagger Degrees-first recommended). v6.8.2 is merged to main (4326003) and on the full dev fleet; the v6.8.2 git tag + GitHub release still need to be cut before the Catalyst engagement.
+1. Prod upgrade v5.4.5 → v6.8.2 on Learn + Degrees: DONE (landed 2026-06-24 via Catalyst). Prod now runs v6.8.2. Next prod consideration: whether/when to move prod from v6.8.2 toward the current head (Tom's call via Catalyst; do not nag).
 2. Mistral training-opt-out + ZDR (external action — Saylor portal). Currently NOT in Saylor's `spend_failover_chain`; provider class stays available so non-Saylor sites can opt in.
 3. Vendor enterprise commits (Vertex Tier 3+, OpenAI Tier 4, Anthropic Tier 3, Voyage enterprise). 2-4 week procurement window; only matters past 50K MAU.
 4. RAG rerank: MEASURED GO (2026-06-11). Both arms run on dev with Tom's Voyage key (payment method on file lifts free-tier rate limits; spend stays in free tokens). Recall@3 55% → 72.5% (+17.5pp, identical at candidate pool 50 and 30); P50 added latency 306ms at pool 30. Recommended: `rerank_candidates=30` + `rerank_enabled=1` on dev (Tom's call), revisit cost model before prod scale (measured ~$0.97/1k queries, 4x projection — ~$485/mo at 100k MAU usage model). Report: `.drafts/sola-rag-fixture-benchmark-2026-06-10.md` section 6-7.


### PR DESCRIPTION
Prod on Learn + Degrees moved to v6.8.2 via Catalyst on 2026-06-24, but CLAUDE.md still described it as "sent to Catalyst" and listed the upgrade as a pending decision. Updates two lines:

- The **Saylor production** status line, to "v6.8.2 on Learn + Degrees as of 2026-06-24 (landed)."
- **Upcoming Work #1**, from "prod upgrade decision" to "DONE (landed 2026-06-24)."

Docs only, no code changes.

Generated with Claude Code (https://claude.com/claude-code)