### PR TITLE
release: v6.8.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A comprehensive AI-powered chat widget for Moodle 4.5+ that provides context-aware tutoring, support, and study planning for students.
 
-## Version 6.8.5
+## Version 6.8.6
 
-**Release Date:** June 2026
+**Release Date:** July 2026
 **Requires:** Moodle 4.5+ (2024100700)
 **License:** GPL v3+
 **Maturity:** Stable. In production at saylor.org for a 30-course pilot.

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_ai_course_assistant';
-$plugin->version = 2026061801;
+$plugin->version = 2026070500;
 $plugin->requires = 2024100700; // Moodle 4.5+.
 $plugin->supported = [405, 503]; // Tested on Moodle 4.5 through 5.3dev.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '6.8.5';
+$plugin->release = '6.8.6';


### PR DESCRIPTION
## v6.8.6 — patch release

Bumps `version.php` (`version` → `2026070500`, `release` → `6.8.6`) and syncs the README version header.

### Changes since 6.8.5
- **CI:** fixed Claude review bot posting permissions (#108); allow-listed Dependabot for auto-review (#110)
- **Deps:** `actions/checkout` v6 → v7 (#104); `rollup` 4.62.0 → 4.62.2 in `/cdn` (#105)
- **Docs:** README version header sync

No functional plugin code changed — this is a housekeeping/maintenance release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)