### PR TITLE
test(smoke): treat quota errors on session.created as SKIP, not FAIL

### DIFF
--- a/tests/smoke_api.py
+++ b/tests/smoke_api.py
@@ -164,8 +164,16 @@ async def _ws_session_update(apikey):
     subprotocols = ["realtime", f"openai-insecure-api-key.{token}"]
 
     async with websockets.connect(uri, subprotocols=subprotocols, open_timeout=20) as ws:
-        # Expect session.created
+        # Expect session.created. If the very first event is an error (e.g. the
+        # key is out of quota), surface the error body so _is_quota_error() can
+        # classify quota/429 outages as SKIP rather than a hard FAIL — matching
+        # every other test in this suite.
         msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=10))
+        if msg.get("type") == "error":
+            err = msg.get("error", {}) or {}
+            raise AssertionError(
+                "Realtime session failed to open: "
+                f"{err.get('type', '')} {err.get('message') or msg}".strip())
         assert msg.get("type") == "session.created", \
             f"Expected session.created, got: {msg.get('type')}"
 


### PR DESCRIPTION
## Problem
The nightly API smoke test filed false-alarm issues (#106, #107) on Jun 29–30. Root cause was the **OpenAI key hitting its quota limit**, not an API change — 4 of 6 tests correctly SKIPped on quota, but `session.update GA format accepted` hard-FAILed with `Expected session.created, got: error`.

When the key is out of quota, the Realtime WebSocket's **first** event is an `error`, and the assertion message only included the event *type* (`error`) — not the error body — so `_is_quota_error()` couldn't see the `insufficient_quota` / 429 marker and the run failed + auto-filed an issue.

## Fix
In `_ws_session_update`, if the first event is `type == "error"`, raise with the error's `type` + `message` included, so `_is_quota_error()` classifies quota/429 outages as **SKIP** — matching every other test in the suite. No behavior change when the key has quota.

## Notes
- The failures already self-resolved (6 green runs Jul 1–5) once quota reset; this just stops the false alarms recurring.
- `python3 -m py_compile tests/smoke_api.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)