### PR TITLE
feat(rag): document-scoped retrieval so answers ground on the current page

### DIFF
--- a/classes/rag_retriever.php
+++ b/classes/rag_retriever.php
@@ -42,9 +42,10 @@ class rag_retriever {
      * @param int    $courseid
      * @param string $query    The user's message / question.
      * @param int    $topk     Number of chunks to return.
-     * @param int    $currentcmid Course-module id of the page the learner is on
-     *                            (0 if none); its chunks get a small ordering
-     *                            boost so "explain this" grounds on the page.
+     * @param int    $currentcmid Course-module id of the document the learner is
+     *                            on (0 if none). Drives the current-page ordering
+     *                            boost and, when `rag_scope` constrains to the
+     *                            document, filters retrieval to that document.
      * @return array Array of [
      *                  'content'    => string,
      *                  'score'      => float,
@@ -73,6 +74,17 @@ class rag_retriever {
         $minscore = ($rawfloor === false || $rawfloor === '') ? 0.25 : (float) $rawfloor;
         $rawboost = get_config('local_ai_course_assistant', 'rag_currentpage_boost');
         $boost = ($rawboost === false || $rawboost === '') ? 0.05 : (float) $rawboost;
+
+        // v6.8.7: retrieval scope. When the learner is viewing a specific
+        // document ($currentcmid > 0), 'document_first' grounds the answer on
+        // that document's chunks when it has any that clear the floor, and falls
+        // back to the whole course otherwise; 'document_only' never falls back
+        // (no relevant chunk on the page means retrieve nothing, so the tutor
+        // answers from general knowledge rather than citing unrelated pages);
+        // 'course' keeps the legacy course-wide search (the current page still
+        // gets the ordering boost). Default document_first.
+        $rawscope = get_config('local_ai_course_assistant', 'rag_scope');
+        $scope = ($rawscope === false || $rawscope === '') ? 'document_first' : (string) $rawscope;
 
         // Embed the query. When the configured embedding provider is Voyage,
         // ask for the asymmetric "query" projection so the vector pairs
@@ -142,6 +154,13 @@ class rag_retriever {
         // genuinely irrelevant chunks never reach the (more expensive) reranker
         // and an off-topic query returns fewer (or zero) passages.
         $scored = self::filter_and_rank($scored, $minscore, $currentcmid, $boost);
+        if (empty($scored)) {
+            return [];
+        }
+
+        // Constrain to the current document when the learner is viewing one.
+        // Applied before reranking, so the reranker only sees the scoped set.
+        $scored = self::scope_to_document($scored, $currentcmid, $scope);
         if (empty($scored)) {
             return [];
         }
@@ -221,6 +240,41 @@ class rag_retriever {
         };
         usort($scored, fn($a, $b) => $rank($b) <=> $rank($a));
         return $scored;
+    }
+
+    /**
+     * Constrain floor-passed, rank-sorted chunks to the current document.
+     *
+     * Pure function (no DB or provider) so it is unit-testable. When the learner
+     * is viewing a specific document ($currentcmid > 0):
+     *  - 'document_first': if that document contributed any chunks to the set,
+     *    return only those; otherwise return the full set (course-wide fallback).
+     *  - 'document_only': return only that document's chunks, or an empty array if
+     *    it contributed none (no fallback — the caller then grounds on general
+     *    knowledge rather than citing unrelated pages).
+     *  - 'course' (or $currentcmid <= 0): return the set unchanged.
+     *
+     * Input is assumed already sorted by descending rank; the returned subset
+     * preserves that order.
+     *
+     * @param array  $ranked      Rows with at least 'cmid' (int|null), rank-sorted.
+     * @param int    $currentcmid Current document course-module id (0 = none).
+     * @param string $scope       'document_first' | 'document_only' | 'course'.
+     * @return array The scoped rows (same shape as input).
+     */
+    public static function scope_to_document(array $ranked, int $currentcmid, string $scope): array {
+        if ($currentcmid <= 0 || $scope === 'course') {
+            return $ranked;
+        }
+        $docchunks = array_values(array_filter(
+            $ranked,
+            fn($r) => (int) ($r['cmid'] ?? 0) === $currentcmid
+        ));
+        if (!empty($docchunks)) {
+            return $docchunks;
+        }
+        // The current document contributed no chunks to the set.
+        return $scope === 'document_only' ? [] : $ranked;
     }
 
     /**

--- a/lang/en/local_ai_course_assistant.php
+++ b/lang/en/local_ai_course_assistant.php
@@ -323,6 +323,11 @@ $string['settings:rag_min_similarity'] = 'Minimum Relevance (cosine)';
 $string['settings:rag_min_similarity_desc'] = 'Drop retrieved chunks whose cosine similarity to the question is below this value, so an off-topic or sparse question injects fewer (or zero) passages instead of always padding to Top-K with weak matches. Range 0 to 1; 0 disables the gate. The right value depends on the embedding model: 0.25 suits text-embedding-3-small. Raise it to be stricter (less, more on-topic context), lower it to be more permissive.';
 $string['settings:rag_currentpage_boost'] = 'Current-Page Boost';
 $string['settings:rag_currentpage_boost_desc'] = 'A small bonus added to the relevance score of chunks from the page the learner is currently viewing, so questions like "explain this" prefer the visible page when scores are close. Ordering only: it does not force an irrelevant page chunk past the minimum-relevance gate. Set 0 to disable.';
+$string['settings:rag_scope'] = 'Retrieval scope';
+$string['settings:rag_scope_desc'] = 'When a learner is viewing a specific document (a page, book, or PDF), whether to constrain retrieval to that document. <b>Document-first</b> grounds the answer on the current document when it has relevant chunks and falls back to the whole course otherwise. <b>Document-only</b> never falls back: if the current document has no relevant chunk it retrieves nothing, so the tutor answers from general knowledge rather than citing unrelated pages. <b>Course-wide</b> searches all course content (the current page still gets the ordering boost above). Document-first is recommended, so an answer about the page a learner is reading is grounded on that page.';
+$string['settings:rag_scope_document_first'] = 'Document-first (prefer the current document, fall back to the course)';
+$string['settings:rag_scope_document_only'] = 'Document-only (restrict to the current document)';
+$string['settings:rag_scope_course'] = 'Course-wide (search all course content)';
 $string['settings:rag_chunksize'] = 'Chunk Size (words)';
 $string['settings:rag_chunksize_desc'] = 'Target number of words per content chunk when indexing course material. Smaller chunks are more precise; larger chunks provide more context.';
 

--- a/settings.php
+++ b/settings.php
@@ -654,6 +654,19 @@ if ($hassiteconfig) {
         PARAM_FLOAT
     ));
 
+    // v6.8.7: retrieval scope when the learner is viewing a specific document.
+    $settings->add(new admin_setting_configselect(
+        'local_ai_course_assistant/rag_scope',
+        get_string('settings:rag_scope', 'local_ai_course_assistant'),
+        get_string('settings:rag_scope_desc', 'local_ai_course_assistant'),
+        'document_first',
+        [
+            'document_first' => get_string('settings:rag_scope_document_first', 'local_ai_course_assistant'),
+            'document_only'  => get_string('settings:rag_scope_document_only', 'local_ai_course_assistant'),
+            'course'         => get_string('settings:rag_scope_course', 'local_ai_course_assistant'),
+        ]
+    ));
+
     $settings->add(new admin_setting_configtext(
         'local_ai_course_assistant/rag_chunksize',
         get_string('settings:rag_chunksize', 'local_ai_course_assistant'),

--- a/tests/rag_retriever_test.php
+++ b/tests/rag_retriever_test.php
@@ -19,15 +19,18 @@ namespace local_ai_course_assistant;
 defined('MOODLE_INTERNAL') || die();
 
 /**
- * Unit tests for rag_retriever relevance gate + current-page bias (v6.2.0).
+ * Unit tests for rag_retriever relevance gate, current-page bias (v6.2.0), and
+ * document scoping (v6.8.7).
  *
- * Exercises the pure filter_and_rank() seam (no DB/provider) that retrieve()
- * delegates the floor and ordering boost to.
+ * Exercises the pure filter_and_rank() and scope_to_document() seams (no
+ * DB/provider) that retrieve() delegates the floor, ordering boost, and
+ * document constraint to.
  *
  * @package    local_ai_course_assistant
  * @copyright  2026 Saylor
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @covers     \local_ai_course_assistant\rag_retriever::filter_and_rank
+ * @covers     \local_ai_course_assistant\rag_retriever::scope_to_document
  */
 final class rag_retriever_test extends \advanced_testcase {
 
@@ -80,5 +83,51 @@ final class rag_retriever_test extends \advanced_testcase {
         $out = rag_retriever::filter_and_rank($scored, 0.25, 31, 0.05);
         $this->assertCount(1, $out);
         $this->assertSame('good', $out[0]['content']);
+    }
+
+    public function test_scope_document_first_restricts_to_current_document(): void {
+        // Current document (cmid 11) contributed a chunk -> return only it.
+        $ranked = [
+            ['content' => 'other', 'score' => 0.62, 'cmid' => 10, 'modtype' => 'page', 'chunkindex' => 0],
+            ['content' => 'page',  'score' => 0.30, 'cmid' => 11, 'modtype' => 'page', 'chunkindex' => 0],
+        ];
+        $out = rag_retriever::scope_to_document($ranked, 11, 'document_first');
+        $this->assertCount(1, $out);
+        $this->assertSame('page', $out[0]['content']);
+    }
+
+    public function test_scope_document_first_falls_back_when_document_absent(): void {
+        // Current document (cmid 99) contributed nothing -> full course-wide set.
+        $ranked = [
+            ['content' => 'a', 'score' => 0.62, 'cmid' => 10, 'modtype' => 'page', 'chunkindex' => 0],
+            ['content' => 'b', 'score' => 0.30, 'cmid' => 11, 'modtype' => 'page', 'chunkindex' => 0],
+        ];
+        $out = rag_retriever::scope_to_document($ranked, 99, 'document_first');
+        $this->assertCount(2, $out);
+    }
+
+    public function test_scope_document_only_returns_empty_when_document_absent(): void {
+        // document_only never falls back: no page chunk -> retrieve nothing.
+        $ranked = [
+            ['content' => 'a', 'score' => 0.62, 'cmid' => 10, 'modtype' => 'page', 'chunkindex' => 0],
+        ];
+        $out = rag_retriever::scope_to_document($ranked, 99, 'document_only');
+        $this->assertSame([], $out);
+    }
+
+    public function test_scope_document_only_restricts_and_preserves_order(): void {
+        $ranked = [
+            ['content' => 'other', 'score' => 0.62, 'cmid' => 10, 'modtype' => 'page', 'chunkindex' => 0],
+            ['content' => 'p1',    'score' => 0.40, 'cmid' => 11, 'modtype' => 'page', 'chunkindex' => 0],
+            ['content' => 'p2',    'score' => 0.35, 'cmid' => 11, 'modtype' => 'page', 'chunkindex' => 1],
+        ];
+        $out = rag_retriever::scope_to_document($ranked, 11, 'document_only');
+        $this->assertSame(['p1', 'p2'], array_column($out, 'content'));
+    }
+
+    public function test_scope_course_and_no_cmid_leave_set_unchanged(): void {
+        $ranked = $this->sample();
+        $this->assertCount(3, rag_retriever::scope_to_document($ranked, 10, 'course'));
+        $this->assertCount(3, rag_retriever::scope_to_document($ranked, 0, 'document_first'));
     }
 }

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_ai_course_assistant';
-$plugin->version = 2026070500;
+$plugin->version = 2026070700;
 $plugin->requires = 2024100700; // Moodle 4.5+.
 $plugin->supported = [405, 503]; // Tested on Moodle 4.5 through 5.3dev.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '6.8.6';
+$plugin->release = '6.8.7';


### PR DESCRIPTION
## Problem (reported by Tomi)

Asking SOLA about a specific page returned an answer grounded on unrelated pages. Root causes:

1. **`rag_retriever::retrieve()` searches the whole course.** It scores every embedded chunk in the course by cosine. The current page's `cmid` is passed in but only adds a small ordering **boost** (default 0.05), not a filter, so unrelated chunks can still win.
2. **Missing chunk = wrong grounding.** When the current page has no chunk at all (an indexing/extraction gap), retrieval still returns the closest matches from the rest of the course above the relevance floor, producing a confidently wrong answer.

The chunks table **already** stores `cmid` (the page/book/PDF module id) and `modtype`, indexed, so no schema change is needed. The missing piece was a filter.

## Change

New `rag_scope` setting, default **document_first**:

- **document_first** (default): when the learner is on a specific document, retrieve only that document's chunks if it has any that clear the floor; otherwise fall back to the whole course.
- **document_only**: never falls back. If the page has no relevant chunk, retrieve nothing, so the tutor answers from general knowledge rather than citing unrelated pages.
- **course**: legacy course-wide search (the current page still gets the ordering boost).

Implemented as a pure `scope_to_document()` seam (no DB/provider), applied after the floor/boost and before reranking. `sse.php` already passes the current `cmid`, so the main chat path is covered.

## Tests

Extends `rag_retriever_test.php` with six cases covering document_first restrict/fallback, document_only restrict/empty, order preservation, and the course / no-cmid passthrough. Pure-function logic sanity-checked standalone (6/6) and lint-clean on PHP 8.3.

## Notes

- No DB migration; version bumped to 6.8.7.
- i18n: English strings added; translation sync into the other 45 locales is a follow-up.
- Follow-up (separate): the non-streaming `send_message.php` path does not yet pass the current cmid, and the Non Serviam indexing gap (why that page produced no chunk) is an extraction issue to investigate separately.

Generated with Claude Code (https://claude.com/claude-code)