### PR TITLE
fix(privacy): export mastery attempts and struggle signals for SAR (v6.8.11)

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -562,6 +562,48 @@ class provider implements
                     ]
                 );
             }
+
+            // Export mastery attempts (per-objective mastery signal, including the
+            // conversation-derived signal written with source = conversation).
+            $attempts = $DB->get_records('local_ai_course_assistant_obj_att', [
+                'userid' => $userid,
+                'courseid' => $context->instanceid,
+            ]);
+            foreach ($attempts as $attempt) {
+                writer::with_context($context)->export_data(
+                    [get_string('pluginname', 'local_ai_course_assistant'), 'mastery_attempts', $attempt->id],
+                    (object) [
+                        'objectiveid' => $attempt->objectiveid,
+                        'source' => $attempt->source,
+                        'msgid' => $attempt->msgid,
+                        'iscorrect' => $attempt->iscorrect,
+                        'weight' => $attempt->weight,
+                        'confidence' => $attempt->confidence,
+                        'timecreated' => transform::datetime($attempt->timecreated),
+                    ]
+                );
+            }
+
+            // Export struggle signals (short-lived engagement signal used only to
+            // adjust tutor tone; 7-day TTL, never surfaced to instructors).
+            $struggles = $DB->get_records('local_ai_course_assistant_struggle_signal', [
+                'userid' => $userid,
+                'courseid' => $context->instanceid,
+            ]);
+            foreach ($struggles as $signal) {
+                writer::with_context($context)->export_data(
+                    [get_string('pluginname', 'local_ai_course_assistant'), 'struggle_signals', $signal->id],
+                    (object) [
+                        'session_id' => $signal->session_id,
+                        'topic_hint' => $signal->topic_hint,
+                        'stage1_score' => $signal->stage1_score,
+                        'stage2_label' => $signal->stage2_label,
+                        'followup_sent_at' => empty($signal->followup_sent_at)
+                            ? null : transform::datetime($signal->followup_sent_at),
+                        'timecreated' => transform::datetime($signal->timecreated),
+                    ]
+                );
+            }
         }
     }
 

--- a/tests/privacy/provider_export_test.php
+++ b/tests/privacy/provider_export_test.php
@@ -1,0 +1,86 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant\privacy;
+
+use core_privacy\local\request\approved_contextlist;
+use core_privacy\local\request\writer;
+
+/**
+ * Privacy provider export-coverage tests (v6.8.11).
+ *
+ * The mastery-attempt (obj_att) and struggle-signal tables were declared in
+ * the privacy metadata and purged on erasure, but were missing from
+ * export_user_data(), so a subject-access request (Article 15) omitted them.
+ * This test locks in their inclusion in the export.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_ai_course_assistant\privacy\provider::export_user_data
+ */
+final class provider_export_test extends \advanced_testcase {
+
+    public function test_export_includes_mastery_attempts_and_struggle_signals(): void {
+        $this->resetAfterTest();
+        global $DB;
+
+        $course = $this->getDataGenerator()->create_course();
+        $user = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->enrol_user($user->id, $course->id, 'student');
+        $now = time();
+
+        $objectiveid = $DB->insert_record('local_ai_course_assistant_objs', (object) [
+            'courseid' => $course->id, 'title' => 'Solve linear equations',
+            'code' => 'ALG-1', 'description' => '', 'source' => 'seed',
+            'prereq_ids' => '', 'timecreated' => $now, 'timemodified' => $now,
+        ]);
+        $attid = $DB->insert_record('local_ai_course_assistant_obj_att', (object) [
+            'userid' => $user->id, 'courseid' => $course->id,
+            'objectiveid' => $objectiveid, 'source' => 'conversation',
+            'msgid' => 0, 'iscorrect' => 1, 'weight' => 0.3,
+            'confidence' => 0.9, 'timecreated' => $now,
+        ]);
+        $sigid = $DB->insert_record('local_ai_course_assistant_struggle_signal', (object) [
+            'userid' => $user->id, 'courseid' => $course->id,
+            'session_id' => 'sess-1', 'topic_hint' => 'algebra',
+            'stage1_score' => 2, 'stage2_label' => 'frustrated',
+            'followup_sent_at' => 0, 'timecreated' => $now,
+        ]);
+
+        $context = \context_course::instance($course->id);
+        $this->setUser($user);
+
+        $writer = writer::with_context($context);
+        $this->assertFalse($writer->has_any_data());
+
+        $contextlist = new approved_contextlist($user, 'local_ai_course_assistant', [$context->id]);
+        provider::export_user_data($contextlist);
+
+        $this->assertTrue($writer->has_any_data());
+        $plugin = get_string('pluginname', 'local_ai_course_assistant');
+
+        $mastery = $writer->get_data([$plugin, 'mastery_attempts', $attid]);
+        $this->assertNotEmpty($mastery);
+        $this->assertEquals('conversation', $mastery->source);
+        $this->assertEquals($objectiveid, $mastery->objectiveid);
+
+        $struggle = $writer->get_data([$plugin, 'struggle_signals', $sigid]);
+        $this->assertNotEmpty($struggle);
+        $this->assertEquals('frustrated', $struggle->stage2_label);
+        $this->assertEquals('algebra', $struggle->topic_hint);
+    }
+}

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_ai_course_assistant';
-$plugin->version = 2026070800;
+$plugin->version = 2026071000;
 $plugin->requires = 2024100700; // Moodle 4.5+.
 $plugin->supported = [405, 503]; // Tested on Moodle 4.5 through 5.3dev.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '6.8.10';
+$plugin->release = '6.8.11';


### PR DESCRIPTION
## Problem

The privacy provider declared `local_ai_course_assistant_obj_att` (per-objective mastery signal, including the conversation-derived signal) and `local_ai_course_assistant_struggle_signal` in its metadata, and purged both on erasure, but neither appeared in `export_user_data()`. A learner subject-access request served through Moodle's privacy API (**GDPR Article 15, right of access**) therefore returned their chat history, plans, feedback, and practice scores, but silently omitted their mastery attempts and struggle signals.

This was surfaced by the SOLA profiling characterization / DPIA (risk R3, the highest-likelihood risk in the register).

## Fix

- Add `obj_att` and `struggle_signal` to `export_user_data()`, mirroring the existing per-table export pattern (subcontext + `transform::datetime`). `followup_sent_at` is emitted only when set.
- Pin the coverage with `tests/privacy/provider_export_test.php`: seeds an objective, a mastery attempt, and a struggle signal, runs the export, and asserts both categories are present with the right values.

Metadata declaration and erasure were already correct and are unchanged; this closes only the export (access) gap. No behavior change outside the privacy export. v6.8.10 to v6.8.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)