### PR TITLE
feat(soapbox): video assignment data model, admin caps, and data layer (v6.8.12)

### DIFF
--- a/classes/soapbox_assignment_manager.php
+++ b/classes/soapbox_assignment_manager.php
@@ -1,0 +1,261 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+
+use context_course;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * CRUD for Soapbox video/audio presentation assignments and their topics
+ * (v6.8.12). All writes require the course-level :manage capability and route
+ * instructor-supplied values through soapbox_config::clamp_assignment so the
+ * editor and the upload validator enforce identical bounds.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class soapbox_assignment_manager {
+
+    /** @var string Assignments table. */
+    const T_ASSIGN = 'local_ai_course_assistant_sbx_assign';
+
+    /** @var string Topics table. */
+    const T_TOPIC = 'local_ai_course_assistant_sbx_topic';
+
+    /** @var string Recordings table. */
+    const T_REC = 'local_ai_course_assistant_sbx_rec';
+
+    /**
+     * Fetch one assignment.
+     *
+     * @param int $id
+     * @return \stdClass|null
+     */
+    public static function get_assignment(int $id): ?\stdClass {
+        global $DB;
+        $rec = $DB->get_record(self::T_ASSIGN, ['id' => $id]);
+        return $rec ?: null;
+    }
+
+    /**
+     * All assignments in a course, name-ordered.
+     *
+     * @param int $courseid
+     * @param bool $includehidden Include assignments with visible = 0.
+     * @return \stdClass[]
+     */
+    public static function get_course_assignments(int $courseid, bool $includehidden = true): array {
+        global $DB;
+        $select = 'courseid = :courseid';
+        if (!$includehidden) {
+            $select .= ' AND visible = 1';
+        }
+        return array_values($DB->get_records_select(
+            self::T_ASSIGN, $select, ['courseid' => $courseid], 'name ASC'));
+    }
+
+    /**
+     * Require the course-level manage capability.
+     *
+     * @param int $courseid
+     */
+    private static function require_manage(int $courseid): void {
+        require_capability('local/ai_course_assistant:manage', context_course::instance($courseid));
+    }
+
+    /**
+     * Create an assignment. Clamps to admin caps; requires :manage.
+     *
+     * @param int $courseid
+     * @param array $data
+     * @return int New assignment id.
+     */
+    public static function create_assignment(int $courseid, array $data): int {
+        global $DB, $USER;
+        self::require_manage($courseid);
+
+        $name = trim((string) ($data['name'] ?? ''));
+        if ($name === '') {
+            throw new \moodle_exception('required');
+        }
+
+        $clamped = soapbox_config::clamp_assignment($data);
+        $now = time();
+        $rec = (object) [
+            'courseid'        => $courseid,
+            'name'            => $name,
+            'intro'           => (string) ($data['intro'] ?? ''),
+            'introformat'     => (int) ($data['introformat'] ?? FORMAT_HTML),
+            'ptype'           => $clamped['ptype'],
+            'mode'            => $clamped['mode'],
+            'min_seconds'     => $clamped['min_seconds'],
+            'max_seconds'     => $clamped['max_seconds'],
+            'max_attempts'    => $clamped['max_attempts'],
+            'stored_attempts' => $clamped['stored_attempts'],
+            'rubricid'        => !empty($data['rubricid']) ? (int) $data['rubricid'] : null,
+            'speaking_level'  => isset($data['speaking_level']) ? (string) $data['speaking_level'] : null,
+            'visible'         => isset($data['visible']) ? (int) (bool) $data['visible'] : 1,
+            'usermodified'    => (int) $USER->id,
+            'timecreated'     => $now,
+            'timemodified'    => $now,
+        ];
+        return (int) $DB->insert_record(self::T_ASSIGN, $rec);
+    }
+
+    /**
+     * Update an assignment. Missing keys keep their existing value; provided
+     * keys are re-clamped. Requires :manage.
+     *
+     * @param int $id
+     * @param array $data
+     */
+    public static function update_assignment(int $id, array $data): void {
+        global $DB, $USER;
+        $existing = self::get_assignment($id);
+        if (!$existing) {
+            throw new \moodle_exception('invalidrecord', 'error');
+        }
+        self::require_manage((int) $existing->courseid);
+
+        // Clamp against the merged view so an untouched min/max/stored is still valid.
+        $clamped = soapbox_config::clamp_assignment(array_merge((array) $existing, $data));
+        $name = array_key_exists('name', $data) ? trim((string) $data['name']) : $existing->name;
+        if ($name === '') {
+            $name = $existing->name;
+        }
+        $rec = (object) [
+            'id'              => $id,
+            'name'            => $name,
+            'intro'           => array_key_exists('intro', $data) ? (string) $data['intro'] : $existing->intro,
+            'introformat'     => (int) ($data['introformat'] ?? $existing->introformat),
+            'ptype'           => $clamped['ptype'],
+            'mode'            => $clamped['mode'],
+            'min_seconds'     => $clamped['min_seconds'],
+            'max_seconds'     => $clamped['max_seconds'],
+            'max_attempts'    => $clamped['max_attempts'],
+            'stored_attempts' => $clamped['stored_attempts'],
+            'rubricid'        => array_key_exists('rubricid', $data)
+                ? (!empty($data['rubricid']) ? (int) $data['rubricid'] : null) : $existing->rubricid,
+            'speaking_level'  => array_key_exists('speaking_level', $data)
+                ? (string) $data['speaking_level'] : $existing->speaking_level,
+            'visible'         => array_key_exists('visible', $data)
+                ? (int) (bool) $data['visible'] : $existing->visible,
+            'usermodified'    => (int) $USER->id,
+            'timemodified'    => time(),
+        ];
+        $DB->update_record(self::T_ASSIGN, $rec);
+    }
+
+    /**
+     * Delete an assignment and its topics and recording rows. Requires :manage.
+     *
+     * Storage objects for any recordings are removed by the retention cleanup /
+     * storage layer (later Phase 1 PR); this drops the DB rows only.
+     *
+     * @param int $id
+     */
+    public static function delete_assignment(int $id): void {
+        global $DB;
+        $existing = self::get_assignment($id);
+        if (!$existing) {
+            return;
+        }
+        self::require_manage((int) $existing->courseid);
+        $DB->delete_records(self::T_REC, ['assignid' => $id]);
+        $DB->delete_records(self::T_TOPIC, ['assignid' => $id]);
+        $DB->delete_records(self::T_ASSIGN, ['id' => $id]);
+    }
+
+    /**
+     * Topics for an assignment, in display order.
+     *
+     * @param int $assignid
+     * @return \stdClass[]
+     */
+    public static function get_topics(int $assignid): array {
+        global $DB;
+        return array_values($DB->get_records(
+            self::T_TOPIC, ['assignid' => $assignid], 'sortorder ASC, id ASC'));
+    }
+
+    /**
+     * Create or update a topic (id in $data updates). Requires :manage on the
+     * owning assignment's course.
+     *
+     * @param int $assignid
+     * @param array $data
+     * @return int Topic id.
+     */
+    public static function save_topic(int $assignid, array $data): int {
+        global $DB;
+        $assign = self::get_assignment($assignid);
+        if (!$assign) {
+            throw new \moodle_exception('invalidrecord', 'error');
+        }
+        self::require_manage((int) $assign->courseid);
+
+        $title = trim((string) ($data['title'] ?? ''));
+        if ($title === '') {
+            throw new \moodle_exception('required');
+        }
+        $now = time();
+        if (!empty($data['id'])) {
+            $rec = (object) [
+                'id'                 => (int) $data['id'],
+                'title'              => $title,
+                'instructions'       => (string) ($data['instructions'] ?? ''),
+                'instructionsformat' => (int) ($data['instructionsformat'] ?? FORMAT_HTML),
+                'pdf_itemid'         => (int) ($data['pdf_itemid'] ?? 0),
+                'sortorder'          => (int) ($data['sortorder'] ?? 0),
+                'timemodified'       => $now,
+            ];
+            $DB->update_record(self::T_TOPIC, $rec);
+            return (int) $data['id'];
+        }
+        $rec = (object) [
+            'assignid'           => $assignid,
+            'title'              => $title,
+            'instructions'       => (string) ($data['instructions'] ?? ''),
+            'instructionsformat' => (int) ($data['instructionsformat'] ?? FORMAT_HTML),
+            'pdf_itemid'         => (int) ($data['pdf_itemid'] ?? 0),
+            'sortorder'          => (int) ($data['sortorder'] ?? 0),
+            'timecreated'        => $now,
+            'timemodified'       => $now,
+        ];
+        return (int) $DB->insert_record(self::T_TOPIC, $rec);
+    }
+
+    /**
+     * Delete a topic. Requires :manage on the owning assignment's course.
+     *
+     * @param int $id
+     */
+    public static function delete_topic(int $id): void {
+        global $DB;
+        $topic = $DB->get_record(self::T_TOPIC, ['id' => $id]);
+        if (!$topic) {
+            return;
+        }
+        $assign = self::get_assignment((int) $topic->assignid);
+        if ($assign) {
+            self::require_manage((int) $assign->courseid);
+        }
+        $DB->delete_records(self::T_TOPIC, ['id' => $id]);
+    }
+}

--- a/classes/soapbox_config.php
+++ b/classes/soapbox_config.php
@@ -157,8 +157,8 @@ class soapbox_config {
         $maxrec = self::max_recordings();
         $out = $in;
 
-        $out['mode'] = in_array($in['mode'] ?? 'video', self::MODES, true)
-            ? $in['mode'] : 'video';
+        $mode = $in['mode'] ?? 'video';
+        $out['mode'] = in_array($mode, self::MODES, true) ? $mode : 'video';
 
         $ptype = strtolower(trim((string) ($in['ptype'] ?? 'informative')));
         $out['ptype'] = ($ptype !== '') ? $ptype : 'informative';

--- a/classes/soapbox_config.php
+++ b/classes/soapbox_config.php
@@ -1,0 +1,188 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Soapbox video assignment configuration: admin caps, quality presets, and the
+ * pure clamp that keeps instructor-supplied assignment settings within the
+ * admin caps and valid ranges (v6.8.12).
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class soapbox_config {
+
+    /** @var int Fallback ceiling on recording length (12 minutes). */
+    const DEFAULT_MAX_SECONDS = 720;
+
+    /** @var int Fallback ceiling on recordings per student per assignment. */
+    const DEFAULT_MAX_RECORDINGS = 3;
+
+    /** @var int Fallback retention window in days. */
+    const DEFAULT_RETENTION_DAYS = 7;
+
+    /** @var int Hard maximum retention window in days. */
+    const RETENTION_MAX_DAYS = 28;
+
+    /** @var string Default video quality preset key. */
+    const DEFAULT_QUALITY = 'standard_480p';
+
+    /** @var string[] Recording modes. */
+    const MODES = ['video', 'audio'];
+
+    /**
+     * Video quality presets. Cost scales with MB/min, so this is the main cost
+     * and bandwidth dial. Bitrates in kbps; the recorder caps MediaRecorder to
+     * these values.
+     *
+     * @var array<string, array{width:int, height:int, video_kbps:int, audio_kbps:int, label:string}>
+     */
+    const QUALITY_PRESETS = [
+        'low_360p' => [
+            'width' => 640, 'height' => 360, 'video_kbps' => 350, 'audio_kbps' => 32,
+            'label' => 'Low (360p)',
+        ],
+        'standard_480p' => [
+            'width' => 854, 'height' => 480, 'video_kbps' => 500, 'audio_kbps' => 40,
+            'label' => 'Standard (480p)',
+        ],
+        'high_720p' => [
+            'width' => 1280, 'height' => 720, 'video_kbps' => 1200, 'audio_kbps' => 48,
+            'label' => 'High (720p)',
+        ],
+    ];
+
+    /**
+     * Admin ceiling on any assignment's recording length, in seconds.
+     *
+     * @return int
+     */
+    public static function max_seconds(): int {
+        $v = (int) get_config('local_ai_course_assistant', 'soapbox_max_seconds');
+        return $v > 0 ? $v : self::DEFAULT_MAX_SECONDS;
+    }
+
+    /**
+     * Admin ceiling on recordings per student per assignment.
+     *
+     * @return int
+     */
+    public static function max_recordings(): int {
+        $v = (int) get_config('local_ai_course_assistant', 'soapbox_max_recordings');
+        return $v > 0 ? $v : self::DEFAULT_MAX_RECORDINGS;
+    }
+
+    /**
+     * Effective retention window in days, clamped to [1, RETENTION_MAX_DAYS].
+     *
+     * @return int
+     */
+    public static function retention_days(): int {
+        $raw = get_config('local_ai_course_assistant', 'soapbox_retention_days');
+        $v = ($raw === false || $raw === '') ? self::DEFAULT_RETENTION_DAYS : (int) $raw;
+        return self::clamp_retention_days($v);
+    }
+
+    /**
+     * Clamp a retention day count to [1, RETENTION_MAX_DAYS]. Pure.
+     *
+     * @param int $days
+     * @return int
+     */
+    public static function clamp_retention_days(int $days): int {
+        if ($days < 1) {
+            return 1;
+        }
+        if ($days > self::RETENTION_MAX_DAYS) {
+            return self::RETENTION_MAX_DAYS;
+        }
+        return $days;
+    }
+
+    /**
+     * The configured video quality preset (falls back to the default).
+     *
+     * @return array{width:int, height:int, video_kbps:int, audio_kbps:int, label:string}
+     */
+    public static function quality(): array {
+        $key = (string) get_config('local_ai_course_assistant', 'soapbox_video_quality');
+        return self::QUALITY_PRESETS[$key] ?? self::QUALITY_PRESETS[self::DEFAULT_QUALITY];
+    }
+
+    /**
+     * How many recordings a student may actually make for an assignment: the
+     * per-assignment attempts value (0 = unlimited) bounded by the admin max.
+     *
+     * @param int $maxattempts Per-assignment attempts (0 = unlimited).
+     * @return int
+     */
+    public static function effective_recording_cap(int $maxattempts): int {
+        $maxrec = self::max_recordings();
+        if ($maxattempts <= 0) {
+            return $maxrec;
+        }
+        return min($maxattempts, $maxrec);
+    }
+
+    /**
+     * Clamp instructor-supplied assignment settings to the admin caps and valid
+     * ranges. Pure (reads admin caps via the static getters, no other IO), so
+     * the editor and the upload validator both enforce identical bounds.
+     *
+     * Recognized keys: mode, ptype, min_seconds, max_seconds, max_attempts,
+     * stored_attempts. Unknown keys pass through untouched.
+     *
+     * @param array $in
+     * @return array
+     */
+    public static function clamp_assignment(array $in): array {
+        $maxsec = self::max_seconds();
+        $maxrec = self::max_recordings();
+        $out = $in;
+
+        $out['mode'] = in_array($in['mode'] ?? 'video', self::MODES, true)
+            ? $in['mode'] : 'video';
+
+        $ptype = strtolower(trim((string) ($in['ptype'] ?? 'informative')));
+        $out['ptype'] = ($ptype !== '') ? $ptype : 'informative';
+
+        $min = max(1, (int) ($in['min_seconds'] ?? 300));
+        $max = max(1, (int) ($in['max_seconds'] ?? 420));
+        if ($max > $maxsec) {
+            $max = $maxsec;
+        }
+        if ($min > $max) {
+            $min = $max;
+        }
+        $out['min_seconds'] = $min;
+        $out['max_seconds'] = $max;
+
+        // 0 = unlimited (still bounded by the admin max recordings at record time).
+        $out['max_attempts'] = max(0, (int) ($in['max_attempts'] ?? 0));
+
+        $stored = max(1, (int) ($in['stored_attempts'] ?? 2));
+        if ($stored > $maxrec) {
+            $stored = $maxrec;
+        }
+        $out['stored_attempts'] = $stored;
+
+        return $out;
+    }
+}

--- a/db/install.xml
+++ b/db/install.xml
@@ -668,5 +668,81 @@
         <KEY NAME="pair_uniq" TYPE="unique" FIELDS="objectiveida, objectiveidb"/>
       </KEYS>
     </TABLE>
+    <TABLE NAME="local_ai_course_assistant_sbx_assign" COMMENT="Soapbox video/audio presentation assignments (v6.8.12). Per-course, instructor-configured.">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="courseid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="name" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="intro" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="introformat" TYPE="int" LENGTH="4" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
+        <FIELD NAME="ptype" TYPE="char" LENGTH="20" NOTNULL="true" DEFAULT="informative" SEQUENCE="false" COMMENT="Presentation type, e.g. informative or persuasive"/>
+        <FIELD NAME="mode" TYPE="char" LENGTH="10" NOTNULL="true" DEFAULT="video" SEQUENCE="false" COMMENT="video | audio"/>
+        <FIELD NAME="min_seconds" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="300" SEQUENCE="false"/>
+        <FIELD NAME="max_seconds" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="420" SEQUENCE="false"/>
+        <FIELD NAME="max_attempts" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="0 = unlimited (still bounded by the admin max recordings)"/>
+        <FIELD NAME="stored_attempts" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="2" SEQUENCE="false"/>
+        <FIELD NAME="rubricid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Custom rubric; null uses the level preset"/>
+        <FIELD NAME="speaking_level" TYPE="char" LENGTH="20" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="visible" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
+        <FIELD NAME="usermodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="courseid_fk_sbxa" TYPE="foreign" FIELDS="courseid" REFTABLE="course" REFFIELDS="id"/>
+        <KEY NAME="rubricid_fk_sbxa" TYPE="foreign" FIELDS="rubricid" REFTABLE="local_ai_course_assistant_rubrics" REFFIELDS="id"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="course_visible" UNIQUE="false" FIELDS="courseid, visible"/>
+      </INDEXES>
+    </TABLE>
+    <TABLE NAME="local_ai_course_assistant_sbx_topic" COMMENT="Student-selectable topics per Soapbox assignment (v6.8.12).">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="assignid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="title" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="instructions" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="instructionsformat" TYPE="int" LENGTH="4" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
+        <FIELD NAME="pdf_itemid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="File API itemid of the uploaded PDF case; 0 = none"/>
+        <FIELD NAME="sortorder" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="assignid_fk_sbxt" TYPE="foreign" FIELDS="assignid" REFTABLE="local_ai_course_assistant_sbx_assign" REFFIELDS="id"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="assign_sort" UNIQUE="false" FIELDS="assignid, sortorder"/>
+      </INDEXES>
+    </TABLE>
+    <TABLE NAME="local_ai_course_assistant_sbx_rec" COMMENT="Soapbox recording attempts (v6.8.12). Video auto-deleted after retention; transcript and score retained.">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="assignid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="topicid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="mode" TYPE="char" LENGTH="10" NOTNULL="true" DEFAULT="video" SEQUENCE="false"/>
+        <FIELD NAME="storage_key" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="Object-storage key for the recording; null once deleted"/>
+        <FIELD NAME="duration_seconds" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="size_bytes" TYPE="int" LENGTH="19" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="status" TYPE="char" LENGTH="20" NOTNULL="true" DEFAULT="uploading" SEQUENCE="false" COMMENT="uploading | uploaded | scored | deleted | failed"/>
+        <FIELD NAME="transcript" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="scoreid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="expires_at" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="assignid_fk_sbxr" TYPE="foreign" FIELDS="assignid" REFTABLE="local_ai_course_assistant_sbx_assign" REFFIELDS="id"/>
+        <KEY NAME="userid_fk_sbxr" TYPE="foreign" FIELDS="userid" REFTABLE="user" REFFIELDS="id"/>
+        <KEY NAME="scoreid_fk_sbxr" TYPE="foreign" FIELDS="scoreid" REFTABLE="local_ai_course_assistant_practice_scores" REFFIELDS="id"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="assign_user" UNIQUE="false" FIELDS="assignid, userid"/>
+        <INDEX NAME="status_expires" UNIQUE="false" FIELDS="status, expires_at"/>
+      </INDEXES>
+    </TABLE>
   </TABLES>
 </XMLDB>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1115,5 +1115,89 @@ function xmldb_local_ai_course_assistant_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2026061500, 'local', 'ai_course_assistant');
     }
 
+    if ($oldversion < 2026071001) {
+        // v6.8.12 (Soapbox video): the per-assignment framework tables. Video/
+        // audio presentation assignments, their student-selectable topics, and
+        // the per-attempt recording rows (video auto-deleted after retention;
+        // transcript and score kept). Created only when absent so a fresh
+        // install (which gets them from install.xml) is untouched.
+
+        // Assignments.
+        $table = new xmldb_table('local_ai_course_assistant_sbx_assign');
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('courseid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('name', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('intro', XMLDB_TYPE_TEXT, null, null, null, null, null);
+        $table->add_field('introformat', XMLDB_TYPE_INTEGER, '4', null, XMLDB_NOTNULL, null, '1');
+        $table->add_field('ptype', XMLDB_TYPE_CHAR, '20', null, XMLDB_NOTNULL, null, 'informative');
+        $table->add_field('mode', XMLDB_TYPE_CHAR, '10', null, XMLDB_NOTNULL, null, 'video');
+        $table->add_field('min_seconds', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '300');
+        $table->add_field('max_seconds', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '420');
+        $table->add_field('max_attempts', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('stored_attempts', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '2');
+        $table->add_field('rubricid', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+        $table->add_field('speaking_level', XMLDB_TYPE_CHAR, '20', null, null, null, null);
+        $table->add_field('visible', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1');
+        $table->add_field('usermodified', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('timecreated', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('timemodified', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+        $table->add_key('courseid_fk_sbxa', XMLDB_KEY_FOREIGN, ['courseid'], 'course', ['id']);
+        $table->add_key('rubricid_fk_sbxa', XMLDB_KEY_FOREIGN, ['rubricid'],
+            'local_ai_course_assistant_rubrics', ['id']);
+        $table->add_index('course_visible', XMLDB_INDEX_NOTUNIQUE, ['courseid', 'visible']);
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+
+        // Topics.
+        $table = new xmldb_table('local_ai_course_assistant_sbx_topic');
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('assignid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('title', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('instructions', XMLDB_TYPE_TEXT, null, null, null, null, null);
+        $table->add_field('instructionsformat', XMLDB_TYPE_INTEGER, '4', null, XMLDB_NOTNULL, null, '1');
+        $table->add_field('pdf_itemid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('sortorder', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('timecreated', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('timemodified', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+        $table->add_key('assignid_fk_sbxt', XMLDB_KEY_FOREIGN, ['assignid'],
+            'local_ai_course_assistant_sbx_assign', ['id']);
+        $table->add_index('assign_sort', XMLDB_INDEX_NOTUNIQUE, ['assignid', 'sortorder']);
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+
+        // Recordings.
+        $table = new xmldb_table('local_ai_course_assistant_sbx_rec');
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('assignid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('userid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('topicid', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+        $table->add_field('mode', XMLDB_TYPE_CHAR, '10', null, XMLDB_NOTNULL, null, 'video');
+        $table->add_field('storage_key', XMLDB_TYPE_CHAR, '255', null, null, null, null);
+        $table->add_field('duration_seconds', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('size_bytes', XMLDB_TYPE_INTEGER, '19', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('status', XMLDB_TYPE_CHAR, '20', null, XMLDB_NOTNULL, null, 'uploading');
+        $table->add_field('transcript', XMLDB_TYPE_TEXT, null, null, null, null, null);
+        $table->add_field('scoreid', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+        $table->add_field('expires_at', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('timecreated', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+        $table->add_key('assignid_fk_sbxr', XMLDB_KEY_FOREIGN, ['assignid'],
+            'local_ai_course_assistant_sbx_assign', ['id']);
+        $table->add_key('userid_fk_sbxr', XMLDB_KEY_FOREIGN, ['userid'], 'user', ['id']);
+        $table->add_key('scoreid_fk_sbxr', XMLDB_KEY_FOREIGN, ['scoreid'],
+            'local_ai_course_assistant_practice_scores', ['id']);
+        $table->add_index('assign_user', XMLDB_INDEX_NOTUNIQUE, ['assignid', 'userid']);
+        $table->add_index('status_expires', XMLDB_INDEX_NOTUNIQUE, ['status', 'expires_at']);
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+
+        upgrade_plugin_savepoint(true, 2026071001, 'local', 'ai_course_assistant');
+    }
+
     return true;
 }

--- a/settings.php
+++ b/settings.php
@@ -1500,6 +1500,42 @@ if ($hassiteconfig) {
         . '" class="btn btn-sm btn-outline-primary ml-2">Open rubric editor &rarr;</a>'
     ));
 
+    // v6.8.12 Soapbox video: site-wide caps and defaults for the video/audio
+    // presentation assignments. Instructors set per-assignment values within
+    // these caps; the caps are clamped server-side in soapbox_config.
+    $settings->add(new admin_setting_configtext(
+        'local_ai_course_assistant/soapbox_max_seconds',
+        'Soapbox max recording length (seconds)',
+        'Hard ceiling on any assignment\'s recording length. Instructors may set a shorter range. Default 720 (12 minutes).',
+        720,
+        PARAM_INT
+    ));
+    $settings->add(new admin_setting_configtext(
+        'local_ai_course_assistant/soapbox_max_recordings',
+        'Soapbox max recordings per student per assignment',
+        'Hard ceiling on how many recordings a student may make for one assignment, regardless of the per-assignment attempts setting. Default 3.',
+        3,
+        PARAM_INT
+    ));
+    $settings->add(new admin_setting_configtext(
+        'local_ai_course_assistant/soapbox_retention_days',
+        'Soapbox recording retention (days)',
+        'How long a recording is stored before automatic deletion; the transcript, score, and feedback are kept. Clamped to 1 to 28 days. Shorter is better data minimization. Default 7.',
+        7,
+        PARAM_INT
+    ));
+    $settings->add(new admin_setting_configselect(
+        'local_ai_course_assistant/soapbox_video_quality',
+        'Soapbox video quality',
+        'Recording resolution and bitrate. This is the main cost and bandwidth lever; a talking-head presenter is legible at Standard. Low suits weak connections; High only when visual detail matters.',
+        'standard_480p',
+        [
+            'low_360p'      => 'Low (360p, ~3 MB/min)',
+            'standard_480p' => 'Standard (480p, ~4 MB/min)',
+            'high_720p'     => 'High (720p, ~9 MB/min)',
+        ]
+    ));
+
     // Student Survey.
     $settings->add(new admin_setting_heading(
         'local_ai_course_assistant/survey_heading',

--- a/tests/schema_consistency_test.php
+++ b/tests/schema_consistency_test.php
@@ -107,10 +107,16 @@ final class schema_consistency_test extends \basic_testcase {
             "/new\s+xmldb_table\(['\"](local_ai_course_assistant[^'\"]+)['\"]\)/",
             $body, $m)) {
             foreach ($m[1] as $candidate) {
-                // Find the surrounding block (1500-char window) and check
-                // for create_table on the same table object.
+                // Window = from this table-name occurrence up to the NEXT
+                // `new xmldb_table(` (or end of file), i.e. this table's own
+                // block. A fixed char cap truncates large tables (a 16-field
+                // table's create_table sits well past 1500 chars) and could
+                // also leak a later block's create_table in; the block
+                // boundary avoids both.
                 $idx = strpos($body, $candidate);
-                $window = substr($body, $idx, 1500);
+                $after = substr($body, $idx);
+                $next = strpos($after, 'new xmldb_table(');
+                $window = ($next !== false) ? substr($after, 0, $next) : $after;
                 if (strpos($window, 'create_table') !== false) {
                     $tables[] = $candidate;
                 }

--- a/tests/soapbox_assignment_manager_test.php
+++ b/tests/soapbox_assignment_manager_test.php
@@ -1,0 +1,122 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Soapbox assignment manager CRUD, clamp-on-write, and capability gating.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_ai_course_assistant\soapbox_assignment_manager
+ */
+final class soapbox_assignment_manager_test extends \advanced_testcase {
+
+    /** @var \stdClass */
+    private $course;
+
+    /** @var \stdClass */
+    private $teacher;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+        set_config('soapbox_max_seconds', 720, 'local_ai_course_assistant');
+        set_config('soapbox_max_recordings', 3, 'local_ai_course_assistant');
+        $this->course = $this->getDataGenerator()->create_course();
+        $this->teacher = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->enrol_user($this->teacher->id, $this->course->id, 'editingteacher');
+    }
+
+    public function test_create_clamps_and_persists(): void {
+        $this->setUser($this->teacher);
+        $id = soapbox_assignment_manager::create_assignment($this->course->id, [
+            'name' => 'Elevator pitch',
+            'ptype' => 'Persuasive',
+            'mode' => 'video',
+            'min_seconds' => 300,
+            'max_seconds' => 3000, // above the 720 cap
+            'max_attempts' => 0,
+            'stored_attempts' => 9, // above the 3 cap
+        ]);
+        $this->assertGreaterThan(0, $id);
+
+        $a = soapbox_assignment_manager::get_assignment($id);
+        $this->assertSame('Elevator pitch', $a->name);
+        $this->assertSame('persuasive', $a->ptype);
+        $this->assertEquals(720, $a->max_seconds);
+        $this->assertEquals(3, $a->stored_attempts);
+        $this->assertEquals(0, $a->max_attempts);
+        $this->assertEquals(1, $a->visible);
+    }
+
+    public function test_create_requires_name(): void {
+        $this->setUser($this->teacher);
+        $this->expectException(\moodle_exception::class);
+        soapbox_assignment_manager::create_assignment($this->course->id, ['name' => '  ']);
+    }
+
+    public function test_update_reclamps_changed_fields(): void {
+        $this->setUser($this->teacher);
+        $id = soapbox_assignment_manager::create_assignment($this->course->id, [
+            'name' => 'Case brief', 'max_seconds' => 400, 'stored_attempts' => 2,
+        ]);
+        soapbox_assignment_manager::update_assignment($id, ['max_seconds' => 5000, 'name' => 'Case brief v2']);
+        $a = soapbox_assignment_manager::get_assignment($id);
+        $this->assertSame('Case brief v2', $a->name);
+        $this->assertEquals(720, $a->max_seconds); // re-clamped
+        $this->assertEquals(2, $a->stored_attempts); // untouched, still valid
+    }
+
+    public function test_topics_crud(): void {
+        $this->setUser($this->teacher);
+        $aid = soapbox_assignment_manager::create_assignment($this->course->id, ['name' => 'Debate']);
+        $t1 = soapbox_assignment_manager::save_topic($aid, ['title' => 'Free trade', 'sortorder' => 1]);
+        $t2 = soapbox_assignment_manager::save_topic($aid, ['title' => 'Tariffs', 'sortorder' => 0]);
+        $topics = soapbox_assignment_manager::get_topics($aid);
+        $this->assertCount(2, $topics);
+        $this->assertSame('Tariffs', $topics[0]->title); // sortorder 0 first
+
+        soapbox_assignment_manager::save_topic($aid, ['id' => $t1, 'title' => 'Free trade (rev)', 'sortorder' => 2]);
+        $this->assertSame('Free trade (rev)',
+            soapbox_assignment_manager::get_topics($aid)[1]->title);
+
+        soapbox_assignment_manager::delete_topic($t2);
+        $this->assertCount(1, soapbox_assignment_manager::get_topics($aid));
+    }
+
+    public function test_delete_assignment_cascades_topics(): void {
+        global $DB;
+        $this->setUser($this->teacher);
+        $aid = soapbox_assignment_manager::create_assignment($this->course->id, ['name' => 'Gone soon']);
+        soapbox_assignment_manager::save_topic($aid, ['title' => 't']);
+        soapbox_assignment_manager::delete_assignment($aid);
+        $this->assertNull(soapbox_assignment_manager::get_assignment($aid));
+        $this->assertEquals(0, $DB->count_records(
+            soapbox_assignment_manager::T_TOPIC, ['assignid' => $aid]));
+    }
+
+    public function test_student_cannot_create(): void {
+        $student = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->enrol_user($student->id, $this->course->id, 'student');
+        $this->setUser($student);
+        $this->expectException(\required_capability_exception::class);
+        soapbox_assignment_manager::create_assignment($this->course->id, ['name' => 'Nope']);
+    }
+}

--- a/tests/soapbox_config_test.php
+++ b/tests/soapbox_config_test.php
@@ -1,0 +1,105 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Soapbox video config: admin caps, quality presets, and the clamp (v6.8.12).
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_ai_course_assistant\soapbox_config
+ */
+final class soapbox_config_test extends \advanced_testcase {
+
+    public function test_retention_clamp_bounds(): void {
+        $this->assertSame(1, soapbox_config::clamp_retention_days(0));
+        $this->assertSame(1, soapbox_config::clamp_retention_days(-5));
+        $this->assertSame(7, soapbox_config::clamp_retention_days(7));
+        $this->assertSame(28, soapbox_config::clamp_retention_days(28));
+        $this->assertSame(28, soapbox_config::clamp_retention_days(40));
+    }
+
+    public function test_retention_days_reads_and_clamps_config(): void {
+        $this->resetAfterTest();
+        set_config('soapbox_retention_days', 60, 'local_ai_course_assistant');
+        $this->assertSame(28, soapbox_config::retention_days());
+        set_config('soapbox_retention_days', '', 'local_ai_course_assistant');
+        $this->assertSame(7, soapbox_config::retention_days());
+    }
+
+    public function test_quality_falls_back_and_resolves(): void {
+        $this->resetAfterTest();
+        // Unknown / unset resolves to the default preset.
+        set_config('soapbox_video_quality', 'nonsense', 'local_ai_course_assistant');
+        $this->assertSame(480, soapbox_config::quality()['height']);
+        set_config('soapbox_video_quality', 'low_360p', 'local_ai_course_assistant');
+        $this->assertSame(360, soapbox_config::quality()['height']);
+        // Every preset carries the fields the recorder needs.
+        foreach (soapbox_config::QUALITY_PRESETS as $preset) {
+            $this->assertArrayHasKey('video_kbps', $preset);
+            $this->assertArrayHasKey('audio_kbps', $preset);
+        }
+    }
+
+    public function test_clamp_assignment_enforces_admin_caps(): void {
+        $this->resetAfterTest();
+        set_config('soapbox_max_seconds', 600, 'local_ai_course_assistant');
+        set_config('soapbox_max_recordings', 3, 'local_ai_course_assistant');
+
+        $clamped = soapbox_config::clamp_assignment([
+            'mode' => 'video',
+            'ptype' => 'Persuasive',
+            'min_seconds' => 900,   // above the 600 cap
+            'max_seconds' => 1200,  // above the 600 cap
+            'max_attempts' => 0,
+            'stored_attempts' => 9, // above the 3 cap
+        ]);
+
+        $this->assertSame(600, $clamped['max_seconds']);
+        $this->assertSame(600, $clamped['min_seconds']); // min pulled down to max
+        $this->assertSame(3, $clamped['stored_attempts']);
+        $this->assertSame('persuasive', $clamped['ptype']); // lowercased
+        $this->assertSame(0, $clamped['max_attempts']);     // unlimited preserved
+    }
+
+    public function test_clamp_assignment_defaults_invalid_mode_and_min_over_max(): void {
+        $this->resetAfterTest();
+        set_config('soapbox_max_seconds', 720, 'local_ai_course_assistant');
+
+        $clamped = soapbox_config::clamp_assignment([
+            'mode' => 'hologram',
+            'min_seconds' => 400,
+            'max_seconds' => 300, // min > max
+        ]);
+
+        $this->assertSame('video', $clamped['mode']);
+        $this->assertSame(300, $clamped['max_seconds']);
+        $this->assertSame(300, $clamped['min_seconds']);
+        $this->assertSame('informative', $clamped['ptype']); // default when absent
+    }
+
+    public function test_effective_recording_cap(): void {
+        $this->resetAfterTest();
+        set_config('soapbox_max_recordings', 3, 'local_ai_course_assistant');
+        $this->assertSame(3, soapbox_config::effective_recording_cap(0));  // unlimited -> admin cap
+        $this->assertSame(2, soapbox_config::effective_recording_cap(2));  // below cap -> honored
+        $this->assertSame(3, soapbox_config::effective_recording_cap(10)); // above cap -> clamped
+    }
+}

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_ai_course_assistant';
-$plugin->version = 2026071000;
+$plugin->version = 2026071001;
 $plugin->requires = 2024100700; // Moodle 4.5+.
 $plugin->supported = [405, 503]; // Tested on Moodle 4.5 through 5.3dev.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '6.8.11';
+$plugin->release = '6.8.12';


### PR DESCRIPTION
First PR of the Soapbox video Phase 1 build (see `.drafts/soapbox-video-build-plan-2026-07-10.md`, issue 1 of 10). The foundation everything else builds on; no student-facing surface yet.

## What

- **Three tables** (install.xml + idempotent upgrade step):
  - `sbx_assign` — per-course assignment: presentation type, mode (video/audio), length range, attempts, stored attempts, rubric, speaking level, visibility.
  - `sbx_topic` — student-selectable topics with instructions and an optional PDF-case file itemid.
  - `sbx_rec` — per-attempt recording: storage key, duration/size, status (uploading/uploaded/scored/deleted/failed), transcript, scoreid, expires_at.
- **Admin settings:** `soapbox_max_seconds` (720), `soapbox_max_recordings` (3), `soapbox_retention_days` (7, clamped 1..28), `soapbox_video_quality` (low_360p / standard_480p / high_720p, default standard).
- **`classes/soapbox_config.php`:** admin-cap getters, quality presets, and a pure `clamp_assignment()` so the (future) editor and upload validator enforce identical bounds; retention clamp; `effective_recording_cap()`.
- Reuses the existing course-level `:manage` capability for instructors; no new capability.
- `tests/soapbox_config_test.php` pins the clamps, retention bounds, quality resolution, and caps.

## Validation

Beyond lint and XML well-formedness: deployed to local Moodle 4.5 and ran the plugin upgrade — the 2026071001 step succeeds and all three tables are created with the expected columns; the four settings register.

## Not in this PR (later Phase 1 PRs)

Browser recorder, presigned upload + finalize, retention cleanup task, instructor assignment editor, student page, transcription + scoring wiring, course-link helper, audio-only surface, and privacy/i18n. v6.8.11 to v6.8.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)