### PR TITLE
feat(soapbox): instructor assignment editor (v6.8.13)

### DIFF
--- a/classes/form/soapbox_assignment_form.php
+++ b/classes/form/soapbox_assignment_form.php
@@ -1,0 +1,115 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant\form;
+
+use local_ai_course_assistant\soapbox_config;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($GLOBALS['CFG']->libdir . '/formslib.php');
+
+/**
+ * Create/edit form for a Soapbox video/audio presentation assignment (v6.8.12).
+ *
+ * Labels are literal English here; full 46-language i18n is a later Phase 1
+ * item. Values are re-clamped server-side by soapbox_assignment_manager, so
+ * this form's ranges are guidance, not the security boundary.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class soapbox_assignment_form extends \moodleform {
+
+    /**
+     * Form definition.
+     */
+    protected function definition() {
+        $mform = $this->_form;
+
+        $mform->addElement('hidden', 'id');
+        $mform->setType('id', PARAM_INT);
+        $mform->addElement('hidden', 'courseid');
+        $mform->setType('courseid', PARAM_INT);
+
+        $mform->addElement('text', 'name', 'Assignment name', ['size' => 60]);
+        $mform->setType('name', PARAM_TEXT);
+        $mform->addRule('name', 'This field is required', 'required', null, 'client');
+
+        $mform->addElement('editor', 'intro', 'Instructions', null, ['maxfiles' => 0]);
+        $mform->setType('intro', PARAM_RAW);
+
+        $mform->addElement('select', 'mode', 'Recording type', [
+            'video' => 'Video',
+            'audio' => 'Audio only',
+        ]);
+        $mform->setDefault('mode', 'video');
+
+        $mform->addElement('select', 'ptype', 'Presentation type', [
+            'informative' => 'Informative (explain or teach)',
+            'persuasive'  => 'Persuasive (convince)',
+        ]);
+        $mform->setDefault('ptype', 'informative');
+
+        $maxsec = soapbox_config::max_seconds();
+        $mform->addElement('text', 'min_seconds', 'Minimum length (seconds)', ['size' => 8]);
+        $mform->setType('min_seconds', PARAM_INT);
+        $mform->setDefault('min_seconds', 300);
+        $mform->addElement('text', 'max_seconds', 'Maximum length (seconds)', ['size' => 8]);
+        $mform->setType('max_seconds', PARAM_INT);
+        $mform->setDefault('max_seconds', min(420, $maxsec));
+        $mform->addElement('static', 'seccap', '',
+            'Site maximum length: ' . $maxsec . ' seconds.');
+
+        $mform->addElement('text', 'max_attempts', 'Attempts allowed (0 = unlimited)', ['size' => 6]);
+        $mform->setType('max_attempts', PARAM_INT);
+        $mform->setDefault('max_attempts', 0);
+
+        $maxrec = soapbox_config::max_recordings();
+        $mform->addElement('text', 'stored_attempts', 'Recordings kept per student', ['size' => 6]);
+        $mform->setType('stored_attempts', PARAM_INT);
+        $mform->setDefault('stored_attempts', 2);
+        $mform->addElement('static', 'reccap', '',
+            'Site maximum recordings kept per student: ' . $maxrec . '.');
+
+        $mform->addElement('advcheckbox', 'visible', 'Visible to students');
+        $mform->setDefault('visible', 1);
+
+        $this->add_action_buttons();
+    }
+
+    /**
+     * Server-side validation (client rules are advisory).
+     *
+     * @param array $data
+     * @param array $files
+     * @return array
+     */
+    public function validation($data, $files) {
+        $errors = parent::validation($data, $files);
+        if (trim((string) $data['name']) === '') {
+            $errors['name'] = 'This field is required';
+        }
+        if ((int) $data['min_seconds'] < 1) {
+            $errors['min_seconds'] = 'Enter at least 1 second';
+        }
+        if ((int) $data['min_seconds'] > (int) $data['max_seconds']) {
+            $errors['min_seconds'] = 'Minimum length cannot exceed the maximum';
+        }
+        return $errors;
+    }
+}

--- a/soapbox_assign.php
+++ b/soapbox_assign.php
@@ -1,0 +1,104 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Instructor list of Soapbox presentation assignments in a course (v6.8.12).
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once(__DIR__ . '/../../config.php');
+
+use local_ai_course_assistant\soapbox_assignment_manager;
+
+require_login();
+
+$courseid = required_param('courseid', PARAM_INT);
+$action = optional_param('action', '', PARAM_ALPHA);
+$id = optional_param('id', 0, PARAM_INT);
+
+$course = get_course($courseid);
+$context = context_course::instance($courseid);
+require_capability('local/ai_course_assistant:manage', $context);
+
+$pageurl = new moodle_url('/local/ai_course_assistant/soapbox_assign.php', ['courseid' => $courseid]);
+$PAGE->set_url($pageurl);
+$PAGE->set_context($context);
+$PAGE->set_pagelayout('incourse');
+$PAGE->set_course($course);
+$PAGE->set_title('Soapbox assignments');
+$PAGE->set_heading($course->fullname);
+
+// Delete action (sesskey-protected, with a confirm step).
+if ($action === 'delete' && $id) {
+    $assign = soapbox_assignment_manager::get_assignment($id);
+    if (!$assign || (int) $assign->courseid !== $courseid) {
+        throw new \moodle_exception('invalidrecord', 'error');
+    }
+    if (optional_param('confirm', 0, PARAM_BOOL) && confirm_sesskey()) {
+        soapbox_assignment_manager::delete_assignment($id);
+        redirect($pageurl, 'Assignment deleted.', null, \core\output\notification::NOTIFY_SUCCESS);
+    }
+    echo $OUTPUT->header();
+    $confirmurl = new moodle_url($pageurl, ['action' => 'delete', 'id' => $id, 'confirm' => 1, 'sesskey' => sesskey()]);
+    echo $OUTPUT->confirm(
+        'Delete "' . format_string($assign->name) . '" and all its recordings? This cannot be undone.',
+        $confirmurl, $pageurl);
+    echo $OUTPUT->footer();
+    exit;
+}
+
+$assignments = soapbox_assignment_manager::get_course_assignments($courseid);
+
+echo $OUTPUT->header();
+echo $OUTPUT->heading('Soapbox assignments');
+
+echo html_writer::div(
+    $OUTPUT->single_button(
+        new moodle_url('/local/ai_course_assistant/soapbox_assign_edit.php', ['courseid' => $courseid]),
+        'Add assignment', 'get'),
+    'mb-3');
+
+if (empty($assignments)) {
+    echo $OUTPUT->notification('No Soapbox assignments yet.', 'info');
+} else {
+    $table = new html_table();
+    $table->head = ['Name', 'Type', 'Recording', 'Length', 'Kept', 'Visible', 'Actions'];
+    $table->attributes['class'] = 'generaltable';
+    foreach ($assignments as $a) {
+        $editurl = new moodle_url('/local/ai_course_assistant/soapbox_assign_edit.php',
+            ['courseid' => $courseid, 'id' => $a->id]);
+        $delurl = new moodle_url($pageurl, ['action' => 'delete', 'id' => $a->id]);
+        $actions = html_writer::link($editurl, 'Edit')
+            . ' &middot; '
+            . html_writer::link($delurl, 'Delete');
+        $length = ((int) $a->min_seconds) . '-' . ((int) $a->max_seconds) . 's';
+        $table->data[] = [
+            format_string($a->name),
+            s($a->ptype),
+            $a->mode === 'audio' ? 'Audio' : 'Video',
+            $length,
+            (int) $a->stored_attempts,
+            $a->visible ? 'Yes' : 'No',
+            $actions,
+        ];
+    }
+    echo html_writer::table($table);
+}
+
+echo $OUTPUT->footer();

--- a/soapbox_assign_edit.php
+++ b/soapbox_assign_edit.php
@@ -1,0 +1,108 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Create or edit a Soapbox presentation assignment (v6.8.12).
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once(__DIR__ . '/../../config.php');
+
+use local_ai_course_assistant\soapbox_assignment_manager;
+use local_ai_course_assistant\form\soapbox_assignment_form;
+
+require_login();
+
+$courseid = required_param('courseid', PARAM_INT);
+$id = optional_param('id', 0, PARAM_INT);
+
+$course = get_course($courseid);
+$context = context_course::instance($courseid);
+require_capability('local/ai_course_assistant:manage', $context);
+
+$listurl = new moodle_url('/local/ai_course_assistant/soapbox_assign.php', ['courseid' => $courseid]);
+$pageurl = new moodle_url('/local/ai_course_assistant/soapbox_assign_edit.php',
+    ['courseid' => $courseid, 'id' => $id]);
+$PAGE->set_url($pageurl);
+$PAGE->set_context($context);
+$PAGE->set_pagelayout('incourse');
+$PAGE->set_course($course);
+$PAGE->set_title('Soapbox assignment');
+$PAGE->set_heading($course->fullname);
+
+$existing = null;
+if ($id) {
+    $existing = soapbox_assignment_manager::get_assignment($id);
+    if (!$existing || (int) $existing->courseid !== $courseid) {
+        throw new \moodle_exception('invalidrecord', 'error');
+    }
+}
+
+$form = new soapbox_assignment_form($pageurl->out(false));
+
+if ($form->is_cancelled()) {
+    redirect($listurl);
+}
+
+if ($data = $form->get_data()) {
+    $payload = [
+        'name'            => $data->name,
+        'intro'           => $data->intro['text'] ?? '',
+        'introformat'     => $data->intro['format'] ?? FORMAT_HTML,
+        'ptype'           => $data->ptype,
+        'mode'            => $data->mode,
+        'min_seconds'     => $data->min_seconds,
+        'max_seconds'     => $data->max_seconds,
+        'max_attempts'    => $data->max_attempts,
+        'stored_attempts' => $data->stored_attempts,
+        'visible'         => $data->visible,
+    ];
+    if ($id) {
+        soapbox_assignment_manager::update_assignment($id, $payload);
+        $notice = 'Assignment updated.';
+    } else {
+        soapbox_assignment_manager::create_assignment($courseid, $payload);
+        $notice = 'Assignment created.';
+    }
+    redirect($listurl, $notice, null, \core\output\notification::NOTIFY_SUCCESS);
+}
+
+// Pre-fill for editing.
+if ($existing) {
+    $form->set_data([
+        'id'              => $existing->id,
+        'courseid'        => $courseid,
+        'name'            => $existing->name,
+        'intro'           => ['text' => (string) $existing->intro, 'format' => (int) $existing->introformat],
+        'ptype'           => $existing->ptype,
+        'mode'            => $existing->mode,
+        'min_seconds'     => $existing->min_seconds,
+        'max_seconds'     => $existing->max_seconds,
+        'max_attempts'    => $existing->max_attempts,
+        'stored_attempts' => $existing->stored_attempts,
+        'visible'         => $existing->visible,
+    ]);
+} else {
+    $form->set_data(['courseid' => $courseid]);
+}
+
+echo $OUTPUT->header();
+echo $OUTPUT->heading($id ? 'Edit Soapbox assignment' : 'New Soapbox assignment');
+$form->display();
+echo $OUTPUT->footer();

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_ai_course_assistant';
-$plugin->version = 2026071001;
+$plugin->version = 2026071002;
 $plugin->requires = 2024100700; // Moodle 4.5+.
 $plugin->supported = [405, 503]; // Tested on Moodle 4.5 through 5.3dev.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '6.8.12';
+$plugin->release = '6.8.13';


### PR DESCRIPTION
Phase 1, issue 2 (UI). The instructor-facing editor on top of the assignment data layer from #121.

## What
- `classes/form/soapbox_assignment_form.php` — a `moodleform` for the assignment core fields (name, instructions, recording type video/audio, presentation type informative/persuasive, length range, attempts, stored attempts, visibility). CSRF, client + server validation; values are re-clamped server-side by `soapbox_assignment_manager` so the form ranges are guidance, not the boundary.
- `soapbox_assign.php` — course list of assignments (`:manage`-gated) with add / edit / sesskey-confirmed delete.
- `soapbox_assign_edit.php` — create/edit page wiring the form to the manager.

First `moodleform` in the plugin (the rest of the pages are manual); used here for the CSRF + validation it gives a create/edit form for free.

## Validation
- Form `definition()` instantiated under Moodle CLI: all elements build, including the CSRF `sesskey`; `soapbox_config` caps resolve.
- All three files lint clean. The two pages will get a browser smoke on dev after merge.

## Not in this PR (follow-ups)
Per-topic editor + PDF-case upload (filemanager), the rubric picker, the course-nav link, and i18n (labels are literal English for now; i18n is Phase 1 issue 10). v6.8.12 to v6.8.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)