### PR TITLE
feat(soapbox): retention + stored-attempts cleanup task (v6.8.18)

### DIFF
--- a/classes/soapbox_storage.php
+++ b/classes/soapbox_storage.php
@@ -190,6 +190,34 @@ class soapbox_storage {
     }
 
     /**
+     * Delete an object from storage. Returns true on a 2xx/404 (already gone),
+     * false on any other failure so the caller can leave the row for retry.
+     * A bucket lifecycle rule on the prefix is the backstop for anything missed.
+     *
+     * @param string $key
+     * @return bool
+     */
+    public function delete_object(string $key): bool {
+        global $CFG;
+        require_once($CFG->libdir . '/filelib.php');
+        $url = self::presign_url([
+            'host'      => self::host(),
+            'region'    => self::region(),
+            'service'   => 's3',
+            'accesskey' => (string) get_config('local_ai_course_assistant', 'soapbox_storage_key'),
+            'secretkey' => (string) get_config('local_ai_course_assistant', 'soapbox_storage_secret'),
+            'method'    => 'DELETE',
+            'uri'       => self::encode_key_path($key),
+            'expires'   => 300,
+            'timestamp' => time(),
+        ]);
+        $curl = new \curl();
+        $curl->delete($url);
+        $code = (int) ($curl->get_info()['http_code'] ?? 0);
+        return ($code >= 200 && $code < 300) || $code === 404;
+    }
+
+    /**
      * URI-encode an object key path, preserving slashes between segments.
      *
      * @param string $key

--- a/classes/task/soapbox_cleanup.php
+++ b/classes/task/soapbox_cleanup.php
@@ -1,0 +1,108 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant\task;
+
+use local_ai_course_assistant\soapbox_storage;
+
+/**
+ * Daily Soapbox recording cleanup (v6.8.18):
+ *  1. Retention: delete the stored object for any recording past its
+ *     expires_at, and mark the row 'deleted' (transcript + score are kept).
+ *  2. Stored-attempts pruning: for each learner/assignment, keep only the
+ *     newest N recordings (the assignment's stored_attempts), deleting older
+ *     objects. A bucket lifecycle rule on the prefix is the backstop.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class soapbox_cleanup extends \core\task\scheduled_task {
+
+    /**
+     * @return string
+     */
+    public function get_name() {
+        return get_string('task:soapbox_cleanup', 'local_ai_course_assistant');
+    }
+
+    /**
+     * Run retention deletion + stored-attempts pruning.
+     */
+    public function execute() {
+        global $DB;
+
+        if (!soapbox_storage::is_configured()) {
+            return;
+        }
+        $storage = new soapbox_storage();
+        $now = time();
+
+        // 1. Retention: objects past expiry (not already deleted).
+        $expired = $DB->get_records_select(
+            'local_ai_course_assistant_sbx_rec',
+            'status <> :deleted AND expires_at > 0 AND expires_at <= :now',
+            ['deleted' => 'deleted', 'now' => $now]);
+        foreach ($expired as $rec) {
+            $this->drop_object($storage, $rec);
+        }
+
+        // 2. Stored-attempts pruning: keep newest N per (assignid, userid).
+        $pairs = $DB->get_records_sql(
+            "SELECT DISTINCT assignid, userid
+               FROM {local_ai_course_assistant_sbx_rec}
+              WHERE status <> :deleted",
+            ['deleted' => 'deleted']);
+        foreach ($pairs as $p) {
+            $assign = $DB->get_record('local_ai_course_assistant_sbx_assign',
+                ['id' => $p->assignid], 'id, stored_attempts');
+            if (!$assign) {
+                continue;
+            }
+            $keep = max(1, (int) $assign->stored_attempts);
+            $recs = $DB->get_records_select(
+                'local_ai_course_assistant_sbx_rec',
+                'assignid = :a AND userid = :u AND status <> :deleted',
+                ['a' => $p->assignid, 'u' => $p->userid, 'deleted' => 'deleted'],
+                'timecreated DESC');
+            $extra = array_slice(array_values($recs), $keep);
+            foreach ($extra as $rec) {
+                $this->drop_object($storage, $rec);
+            }
+        }
+    }
+
+    /**
+     * Delete one recording's object and mark the row deleted. Leaves the row
+     * untouched (for retry next run) if the object delete fails.
+     *
+     * @param soapbox_storage $storage
+     * @param \stdClass $rec
+     */
+    private function drop_object(soapbox_storage $storage, \stdClass $rec): void {
+        global $DB;
+        if (!empty($rec->storage_key)) {
+            if (!$storage->delete_object($rec->storage_key)) {
+                return;
+            }
+        }
+        $DB->update_record('local_ai_course_assistant_sbx_rec', (object) [
+            'id' => $rec->id,
+            'status' => 'deleted',
+            'storage_key' => null,
+        ]);
+    }
+}

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -89,6 +89,18 @@ $tasks = [
         'dayofweek' => '*',
     ],
     [
+        // v6.8.18 Soapbox: delete recording objects past their retention window
+        // and prune to the per-assignment stored-attempts cap. Transcript and
+        // score are retained; only the heavy video/audio object is removed.
+        'classname' => \local_ai_course_assistant\task\soapbox_cleanup::class,
+        'blocking' => 0,
+        'minute' => '50',
+        'hour' => '4',       // Daily at 4:50 AM server time.
+        'day' => '*',
+        'month' => '*',
+        'dayofweek' => '*',
+    ],
+    [
         // Weekly digest email to course authors / instructional designers
         // for every course with the per-course digest toggle on.
         'classname' => \local_ai_course_assistant\task\instructor_weekly_digest::class,

--- a/lang/en/local_ai_course_assistant.php
+++ b/lang/en/local_ai_course_assistant.php
@@ -854,6 +854,7 @@ $string['chat:consent_privacy_link'] = 'Read the full privacy notice';
 // Scheduled tasks (v3.9.12).
 $string['task:audit_cleanup'] = 'AI Course Assistant audit table cleanup';
 $string['task:conversation_retention'] = 'AI Course Assistant conversation retention sweeper';
+$string['task:soapbox_cleanup'] = 'Soapbox recording retention and cleanup';
 $string['settings:audit_retention_days'] = 'Audit log retention (days)';
 $string['settings:audit_retention_days_desc'] = 'Daily scheduled task purges audit rows older than this. 0 disables. Default 365.';
 $string['settings:conversation_retention_days'] = 'Conversation retention (days)';

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_ai_course_assistant';
-$plugin->version = 2026071006;
+$plugin->version = 2026071007;
 $plugin->requires = 2024100700; // Moodle 4.5+.
 $plugin->supported = [405, 503]; // Tested on Moodle 4.5 through 5.3dev.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '6.8.17';
+$plugin->release = '6.8.18';


### PR DESCRIPTION
Phase 1, issue 7. Enforces the retention window and the stored-attempts cap in-app; a bucket lifecycle rule on the prefix is the backstop.

## What
- **`task\soapbox_cleanup`** (daily, 4:50am): (1) deletes the stored object for any recording past its `expires_at` and marks the row `deleted` — transcript and score are kept, only the heavy video/audio object goes; (2) prunes each learner/assignment to the newest N recordings (the assignment's `stored_attempts`), deleting older objects. Leaves a row untouched (for next-run retry) if the object delete fails.
- **`soapbox_storage::delete_object`** — SigV4-signed S3 DELETE; treats 2xx and 404 (already gone) as success.
- Registered in `db/tasks.php`; task-name string added.

## Validation
- Retention and pruning SELECTs verified against the real schema: 5 seeded rows → 1 retention-expired selected, newest-2 kept, older 3 pruned (exact keys matched).
- Task registers under Moodle with its resolved name; plugin upgrade clean; all files lint.

v6.8.17 to v6.8.18. Remaining Phase 1: course links (8), audio-only polish (9), privacy/i18n (10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)