### PR TITLE
docs: v6.8.20 release notes + changelog (Soapbox video/audio)

### DIFF
--- a/.drafts/v6.8.20-release-notes-and-walkthrough.md
+++ b/.drafts/v6.8.20-release-notes-and-walkthrough.md
@@ -1,0 +1,34 @@
+# SOLA v6.8.20 — Soapbox video and audio presentations
+
+## Part 1: Changelog
+
+### Headline
+Soapbox grows from spoken-practice into a full **video and audio presentation activity**: instructors create per-course assignments with topics, PDF cases, a custom rubric, and length/attempt limits; students record in the browser, upload straight to object storage, and get an AI rubric score from the transcript; recordings are viewable and downloadable, then auto-deleted after a retention window. Also folds in the RAG document-scoping fix, the embedding-width fix, and the Article 15 privacy-export fix shipped since v6.8.5.
+
+### Soapbox video/audio presentations (v6.8.12 - v6.8.20)
+- **Per-assignment framework** (v6.8.12): three tables (`sbx_assign` / `sbx_topic` / `sbx_rec`); admin caps (max length default 12 min, max recordings per student default 3, retention default 7 days clamped to 28, video-quality preset low_360p / standard_480p / high_720p); `soapbox_config` clamp shared by the editor and the upload validator; reuses the course `:manage` capability.
+- **Instructor editor** (v6.8.13): create/edit assignments (name, instructions, video or audio mode, informative/persuasive type, length range, attempts, stored attempts, visibility) and student-selectable topics with an optional uploaded PDF case; a custom rubric per assignment.
+- **Presigned upload pipeline** (v6.8.14): browser uploads recordings directly to S3 via an AWS SigV4 presigned URL (no AWS SDK; the signer is pinned to AWS's published test vector); the PHP server never handles the bytes. Bucket/region/prefix/credentials are admin settings, defaulting to the shared archive bucket under a `soapbox/` prefix.
+- **Browser recorder** (v6.8.15): `getUserMedia` + `MediaRecorder` at a capped bitrate (per the quality preset), MP4 preferred with WebM fallback, min/max timer with a hard stop, resumable upload with retry.
+- **Student page** (v6.8.16): topic picker, recorder, and a "My recordings" list with presigned view/download links and the retention notice.
+- **Scoring** (v6.8.17): an adhoc task transcribes the recording via the configured Whisper path (self-hosted preferred) and scores the transcript against the course speech rubric with the assignment's presentation type, reusing the existing `score_speech` flow.
+- **Retention + pruning** (v6.8.18): a daily task deletes recording objects past their retention window and prunes to the stored-attempts cap; transcript and score are kept. A bucket lifecycle rule on the prefix is the backstop.
+- **Course links** (v6.8.19): course-nav links (instructor manager link; a per-assignment link for learners) and a copyable student URL per assignment on the instructor list.
+- **Privacy + audio polish** (v6.8.20): `sbx_rec` (including the stored transcript) covered by the privacy provider — metadata, context discovery, export, and erasure (erasure also deletes the storage object); audio-only assignments show a pulsing mic indicator with a "camera not used" label.
+
+### RAG and privacy fixes since v6.8.5
+- **RAG document-scoped retrieval** (v6.8.7 - v6.8.8): retrieval defaults to the current document and only falls back to course-wide when the page has nothing relevant (new `rag_scope` setting); the non-streaming path honors the same scoping; the reindex screen now warns about documents that index to nothing.
+- **Embedding width fix** (v6.8.10): an unset embedding width now means provider-native instead of a hard 1536 (which broke any Voyage embedding); Voyage output width guarded against invalid values.
+- **Article 15 export fix** (v6.8.11): mastery attempts and struggle signals, already erasable, are now also included in a subject-access export.
+
+### Notes
+- i18n: the new Soapbox-video strings are English-only pending a translation batch into the other 45 languages.
+- Deployment: needs a self-hosted Whisper endpoint (STT) and object-storage credentials configured before the record → score loop is live. Embeddings remain on OpenAI (measured A/B: Voyage did not beat OpenAI on our corpus); Voyage rerank remains the opt-in win pending its DPA.
+
+Plugin version `2026071009`, release `6.8.20`.
+
+## Part 2: Key SOLA Features
+(Carried forward from v6.8.5; add Soapbox video/audio presentations to the feature list.)
+
+## Part 3: Admin Walkthrough
+(Carried forward from v6.8.5; add: enabling Soapbox per course, creating a presentation assignment with topics and a rubric, and configuring the storage + Whisper endpoints.)


### PR DESCRIPTION
Docs-only: consolidated changelog + release-notes for the Soapbox video/audio feature.

- .wiki/Changelog.md: one v6.8.20 entry summarizing the Soapbox video/audio presentation activity (v6.8.12-6.8.20) and catching up the RAG document-scoping, embedding-width, and Article 15 export fixes shipped since the last changelog entry (v6.8.5).
- .drafts/v6.8.20-release-notes-and-walkthrough.md: the release-notes draft (Part 1 changelog filled; Parts 2-3 carry forward from v6.8.5).

No code change. Documents work already merged in #115-#129.

Generated with Claude Code
