### PR TITLE
feat(soapbox): Phase 2 foundation — slides data model + timeline normalizer (v6.8.21)

### DIFF
--- a/classes/form/soapbox_assignment_form.php
+++ b/classes/form/soapbox_assignment_form.php
@@ -86,6 +86,10 @@ class soapbox_assignment_form extends \moodleform {
         $mform->addElement('static', 'reccap', '',
             'Site maximum recordings kept per student: ' . $maxrec . '.');
 
+        $mform->addElement('advcheckbox', 'slides_enabled',
+            'Slides', 'Let students upload a PDF deck and advance slides while recording');
+        $mform->setDefault('slides_enabled', 0);
+
         $mform->addElement('advcheckbox', 'visible', 'Visible to students');
         $mform->setDefault('visible', 1);
 

--- a/classes/soapbox_assignment_manager.php
+++ b/classes/soapbox_assignment_manager.php
@@ -110,6 +110,7 @@ class soapbox_assignment_manager {
             'stored_attempts' => $clamped['stored_attempts'],
             'rubricid'        => !empty($data['rubricid']) ? (int) $data['rubricid'] : null,
             'speaking_level'  => isset($data['speaking_level']) ? (string) $data['speaking_level'] : null,
+            'slides_enabled'  => $clamped['slides_enabled'],
             'visible'         => isset($data['visible']) ? (int) (bool) $data['visible'] : 1,
             'usermodified'    => (int) $USER->id,
             'timecreated'     => $now,
@@ -154,6 +155,7 @@ class soapbox_assignment_manager {
                 ? (!empty($data['rubricid']) ? (int) $data['rubricid'] : null) : $existing->rubricid,
             'speaking_level'  => array_key_exists('speaking_level', $data)
                 ? (string) $data['speaking_level'] : $existing->speaking_level,
+            'slides_enabled'  => $clamped['slides_enabled'],
             'visible'         => array_key_exists('visible', $data)
                 ? (int) (bool) $data['visible'] : $existing->visible,
             'usermodified'    => (int) $USER->id,

--- a/classes/soapbox_config.php
+++ b/classes/soapbox_config.php
@@ -183,6 +183,55 @@ class soapbox_config {
         }
         $out['stored_attempts'] = $stored;
 
+        // v6.8.21: slides on/off (student uploads a PDF deck and advances it).
+        $out['slides_enabled'] = !empty($in['slides_enabled']) ? 1 : 0;
+
+        return $out;
+    }
+
+    /** @var int Max slide-advance events kept in a timeline (guards absurd input). */
+    const MAX_TIMELINE_EVENTS = 500;
+
+    /**
+     * Normalize a slide-advance timeline to a clean, bounded, sorted list of
+     * {t, i} entries (t = seconds into the recording, i = 0-based slide index).
+     * Pure so the recorder's captured timeline can be sanitized identically on
+     * the way in. Drops malformed entries, clamps negatives, sorts by time, and
+     * caps the count.
+     *
+     * @param mixed $raw Decoded JSON (array) or a JSON string.
+     * @param int $slidecount Number of slides in the deck (0 = unknown, no upper clamp on index).
+     * @return array List of ['t' => int, 'i' => int].
+     */
+    public static function normalize_slide_timeline($raw, int $slidecount = 0): array {
+        if (is_string($raw)) {
+            $raw = json_decode($raw, true);
+        }
+        if (!is_array($raw)) {
+            return [];
+        }
+        $out = [];
+        foreach ($raw as $entry) {
+            if (!is_array($entry) || !array_key_exists('t', $entry) || !array_key_exists('i', $entry)) {
+                continue;
+            }
+            $t = (int) round((float) $entry['t']);
+            $i = (int) $entry['i'];
+            if ($t < 0) {
+                $t = 0;
+            }
+            if ($i < 0) {
+                $i = 0;
+            }
+            if ($slidecount > 0 && $i > $slidecount - 1) {
+                $i = $slidecount - 1;
+            }
+            $out[] = ['t' => $t, 'i' => $i];
+        }
+        usort($out, fn($a, $b) => $a['t'] <=> $b['t']);
+        if (count($out) > self::MAX_TIMELINE_EVENTS) {
+            $out = array_slice($out, 0, self::MAX_TIMELINE_EVENTS);
+        }
         return $out;
     }
 }

--- a/db/install.xml
+++ b/db/install.xml
@@ -683,6 +683,7 @@
         <FIELD NAME="stored_attempts" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="2" SEQUENCE="false"/>
         <FIELD NAME="rubricid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Custom rubric; null uses the level preset"/>
         <FIELD NAME="speaking_level" TYPE="char" LENGTH="20" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="slides_enabled" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="v6.8.21: student uploads a PDF deck and advances slides while recording"/>
         <FIELD NAME="visible" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
         <FIELD NAME="usermodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
@@ -729,6 +730,8 @@
         <FIELD NAME="size_bytes" TYPE="int" LENGTH="19" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="status" TYPE="char" LENGTH="20" NOTNULL="true" DEFAULT="uploading" SEQUENCE="false" COMMENT="uploading | uploaded | scored | deleted | failed"/>
         <FIELD NAME="transcript" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="deck_key" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="v6.8.21: object-storage key for the uploaded PDF slide deck; null if none / deleted"/>
+        <FIELD NAME="slide_timeline" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="v6.8.21: JSON [{t:seconds, i:slideindex}] of slide advances during the recording"/>
         <FIELD NAME="scoreid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="expires_at" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1199,5 +1199,30 @@ function xmldb_local_ai_course_assistant_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2026071001, 'local', 'ai_course_assistant');
     }
 
+    if ($oldversion < 2026071010) {
+        // v6.8.21 (Soapbox slides, Phase 2): a slides flag on the assignment and
+        // the deck key + slide-advance timeline on the recording.
+        $table = new xmldb_table('local_ai_course_assistant_sbx_assign');
+        $field = new xmldb_field('slides_enabled', XMLDB_TYPE_INTEGER, '1', null,
+            XMLDB_NOTNULL, null, '0', 'speaking_level');
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        $table = new xmldb_table('local_ai_course_assistant_sbx_rec');
+        $field = new xmldb_field('deck_key', XMLDB_TYPE_CHAR, '255', null,
+            null, null, null, 'transcript');
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+        $field = new xmldb_field('slide_timeline', XMLDB_TYPE_TEXT, null, null,
+            null, null, null, 'deck_key');
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        upgrade_plugin_savepoint(true, 2026071010, 'local', 'ai_course_assistant');
+    }
+
     return true;
 }

--- a/soapbox_assign_edit.php
+++ b/soapbox_assign_edit.php
@@ -71,6 +71,7 @@ if ($data = $form->get_data()) {
         'max_seconds'     => $data->max_seconds,
         'max_attempts'    => $data->max_attempts,
         'stored_attempts' => $data->stored_attempts,
+        'slides_enabled'  => $data->slides_enabled,
         'visible'         => $data->visible,
     ];
     if ($id) {
@@ -96,6 +97,7 @@ if ($existing) {
         'max_seconds'     => $existing->max_seconds,
         'max_attempts'    => $existing->max_attempts,
         'stored_attempts' => $existing->stored_attempts,
+        'slides_enabled'  => $existing->slides_enabled,
         'visible'         => $existing->visible,
     ]);
 } else {

--- a/tests/soapbox_config_test.php
+++ b/tests/soapbox_config_test.php
@@ -102,4 +102,45 @@ final class soapbox_config_test extends \advanced_testcase {
         $this->assertSame(2, soapbox_config::effective_recording_cap(2));  // below cap -> honored
         $this->assertSame(3, soapbox_config::effective_recording_cap(10)); // above cap -> clamped
     }
+
+    public function test_clamp_assignment_slides_flag(): void {
+        $this->resetAfterTest();
+        $this->assertSame(1, soapbox_config::clamp_assignment(['slides_enabled' => 1])['slides_enabled']);
+        $this->assertSame(1, soapbox_config::clamp_assignment(['slides_enabled' => '1'])['slides_enabled']);
+        $this->assertSame(0, soapbox_config::clamp_assignment(['slides_enabled' => 0])['slides_enabled']);
+        $this->assertSame(0, soapbox_config::clamp_assignment([])['slides_enabled']); // default off
+    }
+
+    public function test_normalize_slide_timeline(): void {
+        // Sorts by time, drops malformed, clamps negatives, and clamps index to slidecount.
+        $raw = [
+            ['t' => 30, 'i' => 2],
+            ['t' => 0, 'i' => 0],
+            ['t' => -5, 'i' => -1],        // negatives clamped to 0
+            ['t' => 10, 'i' => 99],        // index clamped to slidecount-1
+            ['nope' => 1],                 // malformed, dropped
+            'garbage',                     // malformed, dropped
+        ];
+        $out = soapbox_config::normalize_slide_timeline($raw, 5);
+        $this->assertCount(4, $out);
+        $this->assertSame(['t' => 0, 'i' => 0], $out[0]);   // the -5 entry, clamped and sorted first
+        $this->assertSame(0, $out[1]['t']);                 // original t=0
+        $this->assertSame(10, $out[2]['t']);
+        $this->assertSame(4, $out[2]['i']);                 // 99 clamped to slidecount-1 = 4
+        $this->assertSame(30, $out[3]['t']);
+    }
+
+    public function test_normalize_slide_timeline_accepts_json_string_and_caps(): void {
+        $this->assertSame([], soapbox_config::normalize_slide_timeline('not json'));
+        $this->assertSame([], soapbox_config::normalize_slide_timeline(null));
+        $json = json_encode([['t' => 1, 'i' => 0], ['t' => 2, 'i' => 1]]);
+        $this->assertCount(2, soapbox_config::normalize_slide_timeline($json));
+        // Cap enforced.
+        $big = [];
+        for ($k = 0; $k < 600; $k++) {
+            $big[] = ['t' => $k, 'i' => 0];
+        }
+        $this->assertCount(soapbox_config::MAX_TIMELINE_EVENTS,
+            soapbox_config::normalize_slide_timeline($big));
+    }
 }

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_ai_course_assistant';
-$plugin->version = 2026071009;
+$plugin->version = 2026071010;
 $plugin->requires = 2024100700; // Moodle 4.5+.
 $plugin->supported = [405, 503]; // Tested on Moodle 4.5 through 5.3dev.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '6.8.20';
+$plugin->release = '6.8.21';


### PR DESCRIPTION
First PR of Phase 2 (student-advanced slides). Schema + config foundation only; deck upload, in-recording slide capture, synced playback, and slide-aware scoring are follow-up PRs.

## What
- Schema: `sbx_assign.slides_enabled` (per-assignment flag); `sbx_rec.deck_key` (object key for the uploaded PDF deck) and `sbx_rec.slide_timeline` (JSON slide-advance timeline). install.xml + idempotent upgrade step.
- `soapbox_config`: `clamp_assignment` now carries `slides_enabled`; new pure `normalize_slide_timeline()` sanitizes the recorder's captured timeline — drops malformed entries, clamps negatives and the slide index to the deck's slide count, sorts by time, and caps at 500 events.
- `soapbox_assignment_manager` persists `slides_enabled` (preserved on update when not supplied, via the merge-then-clamp path); the editor form and edit page expose a "Slides" checkbox.
- Tests for the slides clamp and the timeline normalizer.

## Validation
Fresh install + upgrade both add the three columns on Moodle 4.5; the manager round-trips the flag (create sets it, update without the key preserves it, explicit 0 clears it); the normalizer sorts and clamps as specified. All files lint; XML valid.

v6.8.20 to v6.8.21.

Generated with Claude Code
