### PR TITLE
feat(soapbox): slide deck upload + finalize wiring (Phase 2, v6.8.22)

### DIFF
--- a/classes/external/soapbox_finalize_recording.php
+++ b/classes/external/soapbox_finalize_recording.php
@@ -48,6 +48,8 @@ class soapbox_finalize_recording extends external_api {
             'objectkey' => new external_value(PARAM_RAW, 'Object key returned by get_upload_url'),
             'topicid' => new external_value(PARAM_INT, 'Chosen topic id (0 = none)', VALUE_DEFAULT, 0),
             'durationseconds' => new external_value(PARAM_INT, 'Recorded duration in seconds', VALUE_DEFAULT, 0),
+            'deckkey' => new external_value(PARAM_RAW, 'Object key of the uploaded PDF deck (slides mode)', VALUE_DEFAULT, ''),
+            'slidetimeline' => new external_value(PARAM_RAW, 'JSON slide-advance timeline', VALUE_DEFAULT, ''),
         ]);
     }
 
@@ -56,15 +58,18 @@ class soapbox_finalize_recording extends external_api {
      * @param string $objectkey
      * @param int $topicid
      * @param int $durationseconds
+     * @param string $deckkey
+     * @param string $slidetimeline
      * @return array
      */
     public static function execute(int $assignid, string $objectkey, int $topicid = 0,
-            int $durationseconds = 0): array {
+            int $durationseconds = 0, string $deckkey = '', string $slidetimeline = ''): array {
         global $USER, $DB;
 
         $params = self::validate_parameters(self::execute_parameters(), [
             'assignid' => $assignid, 'objectkey' => $objectkey,
             'topicid' => $topicid, 'durationseconds' => $durationseconds,
+            'deckkey' => $deckkey, 'slidetimeline' => $slidetimeline,
         ]);
 
         $assign = soapbox_assignment_manager::get_assignment((int) $params['assignid']);
@@ -97,6 +102,24 @@ class soapbox_finalize_recording extends external_api {
             $topicid = 0;
         }
 
+        // Slides (only for slides-enabled assignments): validate the deck key is
+        // under this learner's own path and the object landed; normalize the
+        // slide-advance timeline. A missing/foreign deck is dropped rather than
+        // failing the whole recording.
+        $deckkeystored = null;
+        $timelinejson = null;
+        if (!empty($assign->slides_enabled)) {
+            $deckkey = (string) $params['deckkey'];
+            if ($deckkey !== '' && strpos($deckkey, $expectedprefix) === 0
+                    && $storage->object_size($deckkey) !== null) {
+                $deckkeystored = $deckkey;
+            }
+            $timeline = soapbox_config::normalize_slide_timeline((string) $params['slidetimeline']);
+            if (!empty($timeline)) {
+                $timelinejson = json_encode($timeline);
+            }
+        }
+
         $now = time();
         $rec = (object) [
             'assignid'         => (int) $assign->id,
@@ -104,6 +127,8 @@ class soapbox_finalize_recording extends external_api {
             'topicid'          => $topicid ?: null,
             'mode'             => $assign->mode,
             'storage_key'      => $key,
+            'deck_key'         => $deckkeystored,
+            'slide_timeline'   => $timelinejson,
             'duration_seconds' => max(0, (int) $params['durationseconds']),
             'size_bytes'       => $size,
             'status'           => 'uploaded',

--- a/classes/external/soapbox_get_upload_url.php
+++ b/classes/external/soapbox_get_upload_url.php
@@ -50,19 +50,21 @@ class soapbox_get_upload_url extends external_api {
         return new external_function_parameters([
             'assignid' => new external_value(PARAM_INT, 'Soapbox assignment id'),
             'ext' => new external_value(PARAM_ALPHANUM, 'Recording file extension', VALUE_DEFAULT, 'mp4'),
+            'kind' => new external_value(PARAM_ALPHA, 'recording | deck', VALUE_DEFAULT, 'recording'),
         ]);
     }
 
     /**
      * @param int $assignid
      * @param string $ext
+     * @param string $kind
      * @return array
      */
-    public static function execute(int $assignid, string $ext = 'mp4'): array {
+    public static function execute(int $assignid, string $ext = 'mp4', string $kind = 'recording'): array {
         global $USER, $DB;
 
         $params = self::validate_parameters(self::execute_parameters(),
-            ['assignid' => $assignid, 'ext' => $ext]);
+            ['assignid' => $assignid, 'ext' => $ext, 'kind' => $kind]);
 
         $assign = soapbox_assignment_manager::get_assignment((int) $params['assignid']);
         if (!$assign || !$assign->visible) {
@@ -79,7 +81,26 @@ class soapbox_get_upload_url extends external_api {
             throw new \moodle_exception('soapbox:storage_unconfigured', 'local_ai_course_assistant');
         }
 
-        // Enforce the recording cap (per-assignment attempts, bounded by the admin max).
+        $storage = new soapbox_storage();
+
+        // Deck upload: only for slides-enabled assignments; a PDF under the
+        // learner's own deck/ path. No recording-cap check (a deck is not an
+        // attempt), and decks are pruned with their recording / on erasure.
+        if (($params['kind'] ?? 'recording') === 'deck') {
+            if (empty($assign->slides_enabled)) {
+                throw new \moodle_exception('soapbox:slides_disabled', 'local_ai_course_assistant');
+            }
+            $key = soapbox_storage::make_deck_key((int) $assign->courseid, (int) $USER->id);
+            return [
+                'uploadurl' => $storage->presign_put($key),
+                'objectkey' => $key,
+                'method'    => 'PUT',
+                'expiresin' => soapbox_storage::DEFAULT_EXPIRY,
+            ];
+        }
+
+        // Recording upload: enforce the recording cap (per-assignment attempts,
+        // bounded by the admin max).
         $made = $DB->count_records_select(
             'local_ai_course_assistant_sbx_rec',
             'assignid = :a AND userid = :u AND status <> :d',
@@ -93,7 +114,6 @@ class soapbox_get_upload_url extends external_api {
             $ext = ($assign->mode === 'audio') ? 'm4a' : 'mp4';
         }
         $key = soapbox_storage::make_object_key((int) $assign->courseid, (int) $USER->id, $ext);
-        $storage = new soapbox_storage();
 
         return [
             'uploadurl' => $storage->presign_put($key),

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -425,7 +425,7 @@ class provider implements
         global $DB;
         try {
             $recs = $DB->get_records_sql(
-                "SELECT r.id, r.storage_key
+                "SELECT r.id, r.storage_key, r.deck_key
                    FROM {local_ai_course_assistant_sbx_rec} r
                    JOIN {local_ai_course_assistant_sbx_assign} a ON a.id = r.assignid
                   WHERE r.userid = :userid AND a.courseid = :courseid",
@@ -439,10 +439,14 @@ class provider implements
         $storage = \local_ai_course_assistant\soapbox_storage::is_configured()
             ? new \local_ai_course_assistant\soapbox_storage() : null;
         foreach ($recs as $rec) {
-            if ($storage && !empty($rec->storage_key)) {
-                try {
-                    $storage->delete_object($rec->storage_key);
-                } catch (\Throwable $e) { /* backstop: bucket lifecycle rule */ }
+            if ($storage) {
+                foreach ([$rec->storage_key, $rec->deck_key] as $objkey) {
+                    if (!empty($objkey)) {
+                        try {
+                            $storage->delete_object($objkey);
+                        } catch (\Throwable $e) { /* backstop: bucket lifecycle rule */ }
+                    }
+                }
             }
             $DB->delete_records('local_ai_course_assistant_sbx_rec', ['id' => $rec->id]);
         }

--- a/classes/soapbox_storage.php
+++ b/classes/soapbox_storage.php
@@ -115,6 +115,20 @@ class soapbox_storage {
     }
 
     /**
+     * Build a unique object key for a slide deck (PDF), under the learner's own
+     * path so the finalize ownership check (prefix + courseid/userid/) still
+     * holds. The extra deck/ segment keeps decks distinguishable from recordings.
+     *
+     * @param int $courseid
+     * @param int $userid
+     * @return string
+     */
+    public static function make_deck_key(int $courseid, int $userid): string {
+        $token = random_string(24);
+        return self::prefix() . $courseid . '/' . $userid . '/deck/' . $token . '.pdf';
+    }
+
+    /**
      * Presigned PUT URL for uploading an object (browser -> S3 directly).
      *
      * @param string $key Object key (no leading slash).

--- a/classes/task/soapbox_cleanup.php
+++ b/classes/task/soapbox_cleanup.php
@@ -99,10 +99,16 @@ class soapbox_cleanup extends \core\task\scheduled_task {
                 return;
             }
         }
+        // Also drop the slide deck, if any (best-effort; the bucket lifecycle
+        // rule on the prefix is the backstop for a failed delete).
+        if (!empty($rec->deck_key)) {
+            $storage->delete_object($rec->deck_key);
+        }
         $DB->update_record('local_ai_course_assistant_sbx_rec', (object) [
             'id' => $rec->id,
             'status' => 'deleted',
             'storage_key' => null,
+            'deck_key' => null,
         ]);
     }
 }

--- a/lang/en/local_ai_course_assistant.php
+++ b/lang/en/local_ai_course_assistant.php
@@ -1632,6 +1632,7 @@ $string['soapbox:disabled']         = 'Soapbox is not enabled for this course.';
 $string['soapbox:cap_reached']      = 'You have reached the maximum number of recordings for this assignment.';
 $string['soapbox:storage_unconfigured'] = 'Recording storage is not set up yet. Please contact your administrator.';
 $string['soapbox:bad_key']          = 'That upload does not belong to you.';
+$string['soapbox:slides_disabled']  = 'Slides are not enabled for this assignment.';
 $string['soapbox:upload_missing']   = 'The upload could not be found. Please try recording again.';
 $string['soapbox:intro']            = 'Give a speech and get coaching. Optionally set a name, topic, and target length, then record yourself speaking. Soapbox transcribes your speech, scores it against a speaking rubric, and gives you concrete tips. Your audio and the transcript are never stored, only your scores and feedback.';
 $string['soapbox:optional']         = 'optional';

--- a/tests/soapbox_storage_test.php
+++ b/tests/soapbox_storage_test.php
@@ -90,4 +90,15 @@ final class soapbox_storage_test extends \advanced_testcase {
         $this->assertStringStartsWith('soapbox/7/42/', $key);
         $this->assertStringEndsWith('.mp4', $key);
     }
+
+    public function test_make_deck_key_under_learner_path(): void {
+        $this->resetAfterTest();
+        set_config('soapbox_storage_prefix', 'soapbox/', 'local_ai_course_assistant');
+        $key = soapbox_storage::make_deck_key(7, 42);
+        // Starts with the learner's own path (so the finalize ownership check
+        // passes) and is a PDF under a deck/ segment.
+        $this->assertStringStartsWith('soapbox/7/42/', $key);
+        $this->assertStringContainsString('/deck/', $key);
+        $this->assertStringEndsWith('.pdf', $key);
+    }
 }

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_ai_course_assistant';
-$plugin->version = 2026071010;
+$plugin->version = 2026071011;
 $plugin->requires = 2024100700; // Moodle 4.5+.
 $plugin->supported = [405, 503]; // Tested on Moodle 4.5 through 5.3dev.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '6.8.21';
+$plugin->release = '6.8.22';


### PR DESCRIPTION
Phase 2, deck upload. Server-side handling of the student's PDF slide deck. Client-side deck render (pdf.js) and in-recording slide-advance capture are the next PRs.

## What
- `get_upload_url` gains a `kind` param (`recording` | `deck`). A deck request issues a presigned PUT for a PDF under the learner's own `deck/` path, gated on the assignment's `slides_enabled`, with no recording-cap check (a deck is not an attempt). New `soapbox_storage::make_deck_key`.
- `finalize_recording` accepts optional `deckkey` + `slidetimeline`: it validates the deck key is under the learner's own path and the object actually landed (a foreign or missing deck is dropped rather than failing the recording), normalizes the timeline through `soapbox_config::normalize_slide_timeline`, and stores `deck_key` + `slide_timeline` on the row.
- Retention cleanup and privacy erasure now also delete the deck object, alongside the recording.
- `soapbox:slides_disabled` string; `make_deck_key` test.

## Validation
Under Moodle: both external functions instantiate with the extended param counts (3 and 6); the deck key has the correct shape under the learner path (so the finalize ownership check passes); the string resolves. All files lint.

v6.8.21 to v6.8.22.

Generated with Claude Code
