### PR TITLE
feat(soapbox): server-side deck render via Ghostscript (Phase 2, v6.8.24)

### DIFF
--- a/classes/external/soapbox_render_deck.php
+++ b/classes/external/soapbox_render_deck.php
@@ -1,0 +1,113 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant\external;
+
+use core_external\external_api;
+use core_external\external_function_parameters;
+use core_external\external_single_structure;
+use core_external\external_multiple_structure;
+use core_external\external_value;
+use local_ai_course_assistant\soapbox_storage;
+use local_ai_course_assistant\soapbox_deck_renderer;
+use local_ai_course_assistant\soapbox_assignment_manager;
+use local_ai_course_assistant\feature_flags;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Render an uploaded slide deck (PDF) to page images for the recorder's slide
+ * viewer (v6.8.23). Fetches the deck from storage, rasterizes it server-side
+ * with Ghostscript, and returns the pages as data URIs (not persisted), so the
+ * browser can display and advance slides while recording.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class soapbox_render_deck extends external_api {
+
+    /**
+     * @return external_function_parameters
+     */
+    public static function execute_parameters(): external_function_parameters {
+        return new external_function_parameters([
+            'assignid' => new external_value(PARAM_INT, 'Soapbox assignment id'),
+            'deckkey' => new external_value(PARAM_RAW, 'Deck object key from get_upload_url(kind=deck)'),
+        ]);
+    }
+
+    /**
+     * @param int $assignid
+     * @param string $deckkey
+     * @return array
+     */
+    public static function execute(int $assignid, string $deckkey): array {
+        global $USER, $CFG;
+
+        $params = self::validate_parameters(self::execute_parameters(),
+            ['assignid' => $assignid, 'deckkey' => $deckkey]);
+
+        $assign = soapbox_assignment_manager::get_assignment((int) $params['assignid']);
+        if (!$assign || !$assign->visible) {
+            throw new \moodle_exception('invalidrecord', 'error');
+        }
+        $context = \context_course::instance((int) $assign->courseid);
+        self::validate_context($context);
+        require_capability('local/ai_course_assistant:use', $context);
+
+        if (!feature_flags::resolve('soapbox', (int) $assign->courseid)
+                || empty($assign->slides_enabled)) {
+            throw new \moodle_exception('soapbox:slides_disabled', 'local_ai_course_assistant');
+        }
+        if (!soapbox_deck_renderer::is_available()) {
+            return ['pagecount' => 0, 'pages' => []];
+        }
+
+        // The deck key must be under this learner's own path for this course.
+        $key = (string) $params['deckkey'];
+        $expectedprefix = soapbox_storage::prefix() . (int) $assign->courseid . '/' . (int) $USER->id . '/';
+        if (strpos($key, $expectedprefix) !== 0) {
+            throw new \moodle_exception('soapbox:bad_key', 'local_ai_course_assistant');
+        }
+
+        // Download the deck to a per-request temp file.
+        require_once($CFG->libdir . '/filelib.php');
+        $storage = new soapbox_storage();
+        $tmp = make_request_directory() . '/deck.pdf';
+        $curl = new \curl();
+        $curl->download_one($storage->presign_get($key, 900), null,
+            ['filepath' => $tmp, 'timeout' => 120, 'followlocation' => true]);
+        if (!is_file($tmp) || filesize($tmp) === 0) {
+            throw new \moodle_exception('soapbox:upload_missing', 'local_ai_course_assistant');
+        }
+
+        $pages = soapbox_deck_renderer::render_to_datauris($tmp);
+        return ['pagecount' => count($pages), 'pages' => $pages];
+    }
+
+    /**
+     * @return external_single_structure
+     */
+    public static function execute_returns(): external_single_structure {
+        return new external_single_structure([
+            'pagecount' => new external_value(PARAM_INT, 'Number of pages rendered'),
+            'pages' => new external_multiple_structure(
+                new external_value(PARAM_RAW, 'Page image as a data URI'),
+                'Ordered page images'),
+        ]);
+    }
+}

--- a/classes/soapbox_deck_renderer.php
+++ b/classes/soapbox_deck_renderer.php
@@ -1,0 +1,109 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Rasterizes an uploaded PDF slide deck to page PNG images with Ghostscript
+ * (v6.8.23). Reuses Moodle's core Ghostscript path ($CFG->pathtogs, the same
+ * binary assign editpdf relies on), so no new server dependency is introduced.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class soapbox_deck_renderer {
+
+    /** @var int Hard cap on rendered pages (bounds cost / response size). */
+    const MAX_PAGES = 60;
+
+    /** @var int Render resolution in DPI. */
+    const DPI = 110;
+
+    /**
+     * Whether Ghostscript is configured and executable.
+     *
+     * @return bool
+     */
+    public static function is_available(): bool {
+        global $CFG;
+        $gs = (string) ($CFG->pathtogs ?? '');
+        return $gs !== '' && file_is_executable($gs);
+    }
+
+    /**
+     * Render a PDF file to page PNGs. Returns the ordered list of PNG file paths
+     * in a per-request temp dir (cleaned up automatically at request end).
+     *
+     * @param string $pdfpath Local path to the PDF.
+     * @param int $maxpages Cap on pages (clamped to MAX_PAGES).
+     * @return string[] Ordered PNG file paths (empty on failure / no Ghostscript).
+     */
+    public static function render(string $pdfpath, int $maxpages = self::MAX_PAGES): array {
+        global $CFG;
+        if (!self::is_available() || !is_readable($pdfpath)) {
+            return [];
+        }
+        $maxpages = max(1, min($maxpages, self::MAX_PAGES));
+        $outdir = make_request_directory();
+        $pattern = $outdir . '/page-%d.png';
+
+        $cmd = escapeshellarg($CFG->pathtogs)
+            . ' -q -dNOPAUSE -dBATCH -dSAFER'
+            . ' -sDEVICE=png16m'
+            . ' -r' . self::DPI
+            . ' -dTextAlphaBits=4 -dGraphicsAlphaBits=4'
+            . ' -dFirstPage=1 -dLastPage=' . $maxpages
+            . ' -sOutputFile=' . escapeshellarg($pattern)
+            . ' ' . escapeshellarg($pdfpath)
+            . ' 2>&1';
+
+        exec($cmd, $output, $status);
+
+        // Collect produced pages in numeric order (page-1.png, page-2.png, ...).
+        $pages = [];
+        for ($i = 1; $i <= $maxpages; $i++) {
+            $file = $outdir . '/page-' . $i . '.png';
+            if (is_file($file) && filesize($file) > 0) {
+                $pages[] = $file;
+            } else {
+                break; // No gaps: the first missing page ends the deck.
+            }
+        }
+        return $pages;
+    }
+
+    /**
+     * Render a PDF to page images encoded as data URIs, ready to hand to the
+     * browser slide viewer without persisting page images to storage.
+     *
+     * @param string $pdfpath
+     * @param int $maxpages
+     * @return string[] data:image/png;base64,... strings, one per page.
+     */
+    public static function render_to_datauris(string $pdfpath, int $maxpages = self::MAX_PAGES): array {
+        $uris = [];
+        foreach (self::render($pdfpath, $maxpages) as $file) {
+            $data = file_get_contents($file);
+            if ($data !== false) {
+                $uris[] = 'data:image/png;base64,' . base64_encode($data);
+            }
+        }
+        return $uris;
+    }
+}

--- a/db/services.php
+++ b/db/services.php
@@ -355,4 +355,11 @@ $functions = [
         'ajax'         => true,
         'capabilities' => 'local/ai_course_assistant:use',
     ],
+    'local_ai_course_assistant_soapbox_render_deck' => [
+        'classname'    => \local_ai_course_assistant\external\soapbox_render_deck::class,
+        'description'  => 'Soapbox slides: render an uploaded PDF deck to page images for the recorder.',
+        'type'         => 'read',
+        'ajax'         => true,
+        'capabilities' => 'local/ai_course_assistant:use',
+    ],
 ];

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_ai_course_assistant';
-$plugin->version = 2026071012;
+$plugin->version = 2026071013;
 $plugin->requires = 2024100700; // Moodle 4.5+.
 $plugin->supported = [405, 503]; // Tested on Moodle 4.5 through 5.3dev.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '6.8.23';
+$plugin->release = '6.8.24';


### PR DESCRIPTION
Phase 2 slide render. Turns an uploaded PDF deck into page images for the recorder's slide viewer, with no new server dependency.

## What
- `soapbox_deck_renderer`: rasterizes a PDF to page PNGs via Ghostscript, reusing Moodle's core `$CFG->pathtogs` (the same binary assign editpdf relies on). Caps at 60 pages / 110 DPI; `render_to_datauris()` returns the pages as base64 data URIs so nothing extra is persisted to storage. `is_available()` gates on a configured, executable Ghostscript.
- `external\soapbox_render_deck`: validates deck ownership + `slides_enabled`, downloads the deck from storage, renders, and returns `{pagecount, pages[]}`. Degrades to an empty page list when Ghostscript is absent (the deck is still saved; the page just records without a slide preview).

## Validation
Verified end to end with a real 3-page PDF (installed Ghostscript locally): the exact `gs` command rasterizes it; the renderer class returns 3 pages and 3 base64 data URIs; the external function's returns validate.

No new infra dependency: Ghostscript is already a Moodle requirement (the same `pathtogs` used by assign PDF feedback). v6.8.23 to v6.8.24.

Generated with Claude Code
