### PR TITLE
feat(soapbox): slide-aware scoring (Phase 2, v6.8.27)

### DIFF
--- a/classes/external/score_speech.php
+++ b/classes/external/score_speech.php
@@ -51,6 +51,8 @@ class score_speech extends external_api {
             'targetsec'  => new external_value(PARAM_INT, 'Target speech length in seconds (0 = none)', VALUE_DEFAULT, 0),
             'durationsec' => new external_value(PARAM_INT, 'Actual recorded duration in seconds', VALUE_DEFAULT, 0),
             'mode'       => new external_value(PARAM_ALPHA, 'Presentation type: informative | persuasive', VALUE_DEFAULT, 'informative'),
+            'slidecontext' => new external_value(PARAM_RAW, 'Slide-by-slide text + pacing context (slides mode)', VALUE_DEFAULT, ''),
+            'slidecount' => new external_value(PARAM_INT, 'Number of slides (0 = no slides)', VALUE_DEFAULT, 0),
         ]);
     }
 
@@ -62,14 +64,18 @@ class score_speech extends external_api {
      * @param int $targetsec
      * @param int $durationsec
      * @param string $mode
+     * @param string $slidecontext
+     * @param int $slidecount
      * @return array
      */
     public static function execute(int $courseid, string $transcript, string $name = '',
-            string $topic = '', int $targetsec = 0, int $durationsec = 0, string $mode = 'informative'): array {
+            string $topic = '', int $targetsec = 0, int $durationsec = 0, string $mode = 'informative',
+            string $slidecontext = '', int $slidecount = 0): array {
         global $USER;
         $params = self::validate_parameters(self::execute_parameters(), [
             'courseid' => $courseid, 'transcript' => $transcript, 'name' => $name,
             'topic' => $topic, 'targetsec' => $targetsec, 'durationsec' => $durationsec, 'mode' => $mode,
+            'slidecontext' => $slidecontext, 'slidecount' => $slidecount,
         ]);
         $courseid = (int) $params['courseid'];
         $context = \context_course::instance($courseid);
@@ -140,6 +146,16 @@ class score_speech extends external_api {
         $mode = strtolower((string) $params['mode']);
         $contextline .= self::mode_hint($mode);
 
+        // Slides: when the presentation had a deck, give the coach the slide
+        // text and pacing so feedback can address slide design, slide-to-speech
+        // alignment, and time per slide (in addition to the spoken rubric).
+        $slidecount = (int) ($params['slidecount'] ?? 0);
+        $slideblock = '';
+        if ($slidecount > 0 && trim((string) ($params['slidecontext'] ?? '')) !== '') {
+            $slideblock = "\n\nSLIDES:\n" . mb_substr((string) $params['slidecontext'], 0, 8000);
+            $contextline .= ' This was a slide presentation, so also weigh how well the delivery uses the slides.';
+        }
+
         $sysprompt = "You are a supportive public-speaking coach giving formative feedback on a learner's spoken "
             . "presentation. You are reading a speech-to-text transcript, so ignore transcription artefacts "
             . "(missing punctuation, homophone errors, '[inaudible]') and do not penalise them. {$contextline} "
@@ -148,7 +164,7 @@ class score_speech extends external_api {
             . "highest-leverage improvement. Then give a short overall comment and three concrete next-time tips ordered "
             . "by impact. Be encouraging; this is practice. Respond with JSON only, in this shape:\n"
             . '{"criteria":[{"name":"...","score":3,"feedback":"..."}], "overall":"...", "tips":["...","...","..."]}'
-            . "\n\nRUBRIC:\n{$rubrictext}\n\nTRANSCRIPT:\n{$speech}";
+            . "\n\nRUBRIC:\n{$rubrictext}{$slideblock}\n\nTRANSCRIPT:\n{$speech}";
 
         try {
             $provider = base_provider::create_from_config($courseid);

--- a/classes/soapbox_deck_renderer.php
+++ b/classes/soapbox_deck_renderer.php
@@ -89,6 +89,48 @@ class soapbox_deck_renderer {
     }
 
     /**
+     * Extract the text of each page with Ghostscript's txtwrite device (same
+     * binary as the raster render, so no extra dependency). Returns one string
+     * per page, index 0 = page 1. Empty pages yield an empty string. Used to
+     * give the AI the slide content for slide-aware scoring.
+     *
+     * @param string $pdfpath
+     * @param int $maxpages
+     * @return string[] Per-page text (page 1..N).
+     */
+    public static function extract_text(string $pdfpath, int $maxpages = self::MAX_PAGES): array {
+        global $CFG;
+        if (!self::is_available() || !is_readable($pdfpath)) {
+            return [];
+        }
+        $maxpages = max(1, min($maxpages, self::MAX_PAGES));
+        // Render one page range in a single call to a per-page text pattern.
+        $outdir = make_request_directory();
+        $pattern = $outdir . '/text-%d.txt';
+        $cmd = escapeshellarg($CFG->pathtogs)
+            . ' -q -dNOPAUSE -dBATCH -dSAFER'
+            . ' -sDEVICE=txtwrite'
+            . ' -dFirstPage=1 -dLastPage=' . $maxpages
+            . ' -sOutputFile=' . escapeshellarg($pattern)
+            . ' ' . escapeshellarg($pdfpath)
+            . ' 2>&1';
+        exec($cmd, $output, $status);
+
+        $texts = [];
+        for ($i = 1; $i <= $maxpages; $i++) {
+            $file = $outdir . '/text-' . $i . '.txt';
+            if (!is_file($file)) {
+                break;
+            }
+            $t = (string) file_get_contents($file);
+            // Collapse whitespace runs to keep the prompt compact.
+            $t = trim(preg_replace('/\s+/u', ' ', $t));
+            $texts[] = $t;
+        }
+        return $texts;
+    }
+
+    /**
      * Render a PDF to page images encoded as data URIs, ready to hand to the
      * browser slide viewer without persisting page images to storage.
      *

--- a/classes/soapbox_scorer.php
+++ b/classes/soapbox_scorer.php
@@ -116,6 +116,21 @@ class soapbox_scorer {
                 ['id' => $rec->topicid]);
         }
 
+        // Slides: extract the deck text and build a slide-by-slide context with
+        // pacing, so the AI can judge slide design, slide-to-speech alignment,
+        // and time spent per slide.
+        $slidecontext = '';
+        $slidecount = 0;
+        if (!empty($assign->slides_enabled) && !empty($rec->deck_key)
+                && soapbox_deck_renderer::is_available()) {
+            $texts = self::deck_text($rec->deck_key);
+            if (!empty($texts)) {
+                $timeline = soapbox_config::normalize_slide_timeline((string) ($rec->slide_timeline ?? ''));
+                $slidecontext = self::build_slide_context($texts, $timeline, (int) $rec->duration_seconds);
+                $slidecount = count($texts);
+            }
+        }
+
         // Score as the recording owner (score_speech saves to $USER's history and
         // checks the course :use capability, which the learner holds).
         $user = $DB->get_record('user', ['id' => (int) $rec->userid]);
@@ -126,7 +141,8 @@ class soapbox_scorer {
 
         $result = score_speech::execute(
             (int) $assign->courseid, $transcript, '', $topictitle,
-            (int) $assign->max_seconds, (int) $rec->duration_seconds, (string) $assign->ptype);
+            (int) $assign->max_seconds, (int) $rec->duration_seconds, (string) $assign->ptype,
+            $slidecontext, $slidecount);
 
         $update = (object) [
             'id'         => $recid,
@@ -135,5 +151,65 @@ class soapbox_scorer {
             'status'     => !empty($result['success']) ? 'scored' : 'failed',
         ];
         $DB->update_record('local_ai_course_assistant_sbx_rec', $update);
+    }
+
+    /**
+     * Download a stored deck and extract its per-page text.
+     *
+     * @param string $deckkey
+     * @return string[] Per-page text (empty on failure).
+     */
+    public static function deck_text(string $deckkey): array {
+        global $CFG;
+        require_once($CFG->libdir . '/filelib.php');
+        $storage = new soapbox_storage();
+        $tmp = make_request_directory() . '/deck.pdf';
+        $curl = new \curl();
+        $curl->download_one($storage->presign_get($deckkey, 900), null,
+            ['filepath' => $tmp, 'timeout' => 120, 'followlocation' => true]);
+        if (!is_file($tmp) || filesize($tmp) === 0) {
+            return [];
+        }
+        return soapbox_deck_renderer::extract_text($tmp);
+    }
+
+    /**
+     * Build a compact slide-by-slide context string with per-slide text and the
+     * time the speaker spent on each slide, for the scoring prompt. Pure so it is
+     * unit-testable. Time on a slide = the gap to the next advance (or to the end
+     * of the recording for the last slide).
+     *
+     * @param string[] $texts Per-slide text (index 0 = slide 1).
+     * @param array $timeline Normalized [{t, i}] advances.
+     * @param int $duration Total recording length in seconds.
+     * @return string
+     */
+    public static function build_slide_context(array $texts, array $timeline, int $duration): string {
+        $count = count($texts);
+        if ($count === 0) {
+            return '';
+        }
+        // Seconds spent on each slide index from the advance timeline.
+        $spent = array_fill(0, $count, 0);
+        if (!empty($timeline)) {
+            for ($k = 0; $k < count($timeline); $k++) {
+                $i = max(0, min($count - 1, (int) $timeline[$k]['i']));
+                $start = (int) $timeline[$k]['t'];
+                $end = ($k + 1 < count($timeline)) ? (int) $timeline[$k + 1]['t'] : max($start, $duration);
+                $spent[$i] += max(0, $end - $start);
+            }
+        }
+        $lines = ["The presentation used {$count} slide(s). Slide text and time spent per slide:"];
+        for ($i = 0; $i < $count; $i++) {
+            $txt = trim($texts[$i]);
+            if ($txt === '') {
+                $txt = '(no text on this slide)';
+            }
+            $txt = mb_substr($txt, 0, 600);
+            $lines[] = 'Slide ' . ($i + 1) . ' (~' . $spent[$i] . 's): ' . $txt;
+        }
+        $lines[] = 'Consider slide design and clarity, whether the spoken content matches the slide it is on, '
+            . 'and pacing (roughly even time per slide, not rushing the last slides).';
+        return implode("\n", $lines);
     }
 }

--- a/tests/soapbox_scorer_test.php
+++ b/tests/soapbox_scorer_test.php
@@ -1,0 +1,54 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Slide-aware scoring context builder (v6.8.27).
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_ai_course_assistant\soapbox_scorer::build_slide_context
+ */
+final class soapbox_scorer_test extends \basic_testcase {
+
+    public function test_build_slide_context_computes_time_per_slide(): void {
+        $texts = ['Intro', 'Body', 'Conclusion'];
+        // Advance to slide 1 at 8s, slide 2 at 20s; recording is 30s long.
+        $timeline = [['t' => 0, 'i' => 0], ['t' => 8, 'i' => 1], ['t' => 20, 'i' => 2]];
+        $ctx = soapbox_scorer::build_slide_context($texts, $timeline, 30);
+
+        $this->assertStringContainsString('used 3 slide', $ctx);
+        $this->assertStringContainsString('Slide 1 (~8s): Intro', $ctx);   // 0 -> 8
+        $this->assertStringContainsString('Slide 2 (~12s): Body', $ctx);   // 8 -> 20
+        $this->assertStringContainsString('Slide 3 (~10s): Conclusion', $ctx); // 20 -> 30
+    }
+
+    public function test_build_slide_context_empty_deck_is_empty(): void {
+        $this->assertSame('', soapbox_scorer::build_slide_context([], [], 30));
+    }
+
+    public function test_build_slide_context_handles_no_timeline_and_blank_text(): void {
+        $ctx = soapbox_scorer::build_slide_context(['', 'Only slide'], [], 60);
+        $this->assertStringContainsString('used 2 slide', $ctx);
+        $this->assertStringContainsString('(no text on this slide)', $ctx);
+        // With no advances, no time is attributed, but the slides still list.
+        $this->assertStringContainsString('Slide 2 (~0s): Only slide', $ctx);
+    }
+}

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_ai_course_assistant';
-$plugin->version = 2026071015;
+$plugin->version = 2026071016;
 $plugin->requires = 2024100700; // Moodle 4.5+.
 $plugin->supported = [405, 503]; // Tested on Moodle 4.5 through 5.3dev.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '6.8.26';
+$plugin->release = '6.8.27';


### PR DESCRIPTION
Phase 2 slide-aware scoring. When a presentation had a deck, the AI now sees the slide content and the pacing, not just the transcript.

Built off main (depends only on merged pieces: deck_key, soapbox_deck_renderer, soapbox_scorer, score_speech), so it is independent of the wiring/playback PRs.

## What
- `soapbox_deck_renderer::extract_text`: per-page slide text via Ghostscript's `txtwrite` device (same binary as the raster render; no new dependency).
- `soapbox_scorer`: on a slides recording, downloads the deck, extracts text, and builds a slide-by-slide context with per-slide time derived from the advance timeline (pure `build_slide_context`: time on a slide = gap to the next advance; the last slide runs to the recording end). Passed to `score_speech`.
- `score_speech`: optional `slidecontext` + `slidecount` params; when present a SLIDES block is added to the prompt and the coach is told to weigh slide design, slide-to-speech alignment, and pacing alongside the spoken rubric. Non-slides scoring is unchanged.
- Tests pin `build_slide_context` (per-slide timing, empty deck, blank slide text).

## Validation
End to end under Moodle with the installed Ghostscript: `extract_text` pulls the deck text; `build_slide_context` computes 8s/12s/10s for a 0/8/20 timeline over a 30s recording; `score_speech` now takes 9 params. Lints clean.

Note: WSCUC per-outcome benchmark + criterion-to-outcome mapping remain a separate cross-cutting follow-up (they touch rubric_manager / objective_manager / instructor_analytics), as planned.

v6.8.24 to v6.8.27.

Generated with Claude Code
