### PR TITLE
feat(mastery): partial-credit (continuous) observations (v6.8.29)

### DIFF
--- a/classes/objective_manager.php
+++ b/classes/objective_manager.php
@@ -271,6 +271,7 @@ class objective_manager {
      * @param float      $weight      Quiz attempts 1.0; classifier signals 0.3.
      * @param int|null   $msgid       Optional pointer to the originating message.
      * @param float|null $confidence  Classifier confidence (0..1) when source=conversation.
+     * @param float|null $score       Partial-credit observation (0..1); blends fractionally when set.
      * @return int Attempt row id.
      */
     public static function record_attempt(
@@ -281,9 +282,17 @@ class objective_manager {
         string $source = 'quiz',
         float $weight = 1.0,
         ?int $msgid = null,
-        ?float $confidence = null
+        ?float $confidence = null,
+        ?float $score = null
     ): int {
         global $DB;
+        // A partial-credit score (0-1), when supplied, is stored so mastery can
+        // blend it fractionally; iscorrect is still set (rounded) so any code
+        // reading the binary column stays sensible.
+        if ($score !== null) {
+            $score = max(0.0, min(1.0, $score));
+            $iscorrect = $score >= 0.5;
+        }
         return (int) $DB->insert_record(self::TABLE_ATTS, (object) [
             'userid' => $userid,
             'courseid' => $courseid,
@@ -293,6 +302,7 @@ class objective_manager {
             'iscorrect' => $iscorrect ? 1 : 0,
             'weight' => $weight,
             'confidence' => $confidence,
+            'score' => $score,
             'timecreated' => time(),
         ]);
     }
@@ -361,9 +371,14 @@ class objective_manager {
             $decay = self::DEFAULT_DECAY ** $i;
             $w = (float) $att->weight * $decay;
             $denominator += $w;
-            if ((int) $att->iscorrect === 1) {
-                $numerator += $w;
+            // Partial-credit: when a continuous score (0-1) is present it
+            // contributes fractionally; otherwise the binary iscorrect (0/1).
+            if (isset($att->score) && $att->score !== null) {
+                $correctness = max(0.0, min(1.0, (float) $att->score));
+            } else {
+                $correctness = ((int) $att->iscorrect === 1) ? 1.0 : 0.0;
             }
+            $numerator += $w * $correctness;
             if ($i === 0) {
                 $last = (int) $att->timecreated;
             }

--- a/db/install.xml
+++ b/db/install.xml
@@ -523,6 +523,7 @@
         <FIELD NAME="iscorrect" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="1 mastered/correct, 0 not"/>
         <FIELD NAME="weight" TYPE="number" LENGTH="5" DECIMALS="2" NOTNULL="true" DEFAULT="1.00" SEQUENCE="false" COMMENT="Quizzes weigh 1.0; classifier signals weigh 0.3 by default"/>
         <FIELD NAME="confidence" TYPE="number" LENGTH="5" DECIMALS="2" NOTNULL="false" SEQUENCE="false" COMMENT="Classifier confidence 0-1 when source=conversation"/>
+        <FIELD NAME="score" TYPE="number" LENGTH="4" DECIMALS="3" NOTNULL="false" SEQUENCE="false" COMMENT="v6.8.29: partial-credit observation 0-1 (e.g. a rubric criterion normalized); when set it contributes fractionally to mastery instead of the binary iscorrect"/>
         <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1224,5 +1224,19 @@ function xmldb_local_ai_course_assistant_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2026071010, 'local', 'ai_course_assistant');
     }
 
+    if ($oldversion < 2026071100) {
+        // v6.8.29: partial-credit (continuous) mastery observations. A nullable
+        // score column on obj_att; when set (0-1) it contributes fractionally to
+        // the mastery estimate instead of the binary iscorrect.
+        $table = new xmldb_table('local_ai_course_assistant_obj_att');
+        $field = new xmldb_field('score', XMLDB_TYPE_NUMBER, '4, 3', null,
+            null, null, null, 'confidence');
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        upgrade_plugin_savepoint(true, 2026071100, 'local', 'ai_course_assistant');
+    }
+
     return true;
 }

--- a/tests/objective_partial_credit_test.php
+++ b/tests/objective_partial_credit_test.php
@@ -1,0 +1,97 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Partial-credit (continuous) mastery observations (v6.8.29).
+ *
+ * A stored score in [0,1] contributes fractionally to the Beta posterior instead
+ * of the binary iscorrect; attempts without a score behave exactly as before.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_ai_course_assistant\objective_manager
+ */
+final class objective_partial_credit_test extends \advanced_testcase {
+
+    /** @var int */
+    private $courseid;
+    /** @var int */
+    private $userid;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+        // Isolate the estimator from time-decay for a deterministic assertion.
+        set_config('mastery_decay_enabled', 0, 'local_ai_course_assistant');
+        $course = $this->getDataGenerator()->create_course();
+        $user = $this->getDataGenerator()->create_user();
+        $this->courseid = (int) $course->id;
+        $this->userid = (int) $user->id;
+    }
+
+    private function make_objective(): int {
+        return objective_manager::create($this->courseid, 'Constructs an argument', 'CLO-1');
+    }
+
+    public function test_partial_credit_lands_between_wrong_and_right(): void {
+        // Same objective assessed once with a 0.8 partial-credit attempt.
+        $oid = $this->make_objective();
+        objective_manager::record_attempt($this->userid, $this->courseid, $oid,
+            true, 'rubric', 1.0, null, null, 0.8);
+        $partial = objective_manager::compute_mastery($this->userid, $oid)['score'];
+
+        // Compare against a fully-correct and a fully-wrong single attempt on
+        // separate objectives (same prior, weight, no decay).
+        $oidc = $this->make_objective();
+        objective_manager::record_attempt($this->userid, $this->courseid, $oidc, true, 'quiz', 1.0);
+        $correct = objective_manager::compute_mastery($this->userid, $oidc)['score'];
+
+        $oidw = $this->make_objective();
+        objective_manager::record_attempt($this->userid, $this->courseid, $oidw, false, 'quiz', 1.0);
+        $wrong = objective_manager::compute_mastery($this->userid, $oidw)['score'];
+
+        $this->assertGreaterThan($wrong, $partial);
+        $this->assertLessThan($correct, $partial);
+    }
+
+    public function test_score_of_one_matches_binary_correct(): void {
+        $oids = $this->make_objective();
+        objective_manager::record_attempt($this->userid, $this->courseid, $oids,
+            true, 'rubric', 1.0, null, null, 1.0);
+        $scored = objective_manager::compute_mastery($this->userid, $oids)['score'];
+
+        $oidb = $this->make_objective();
+        objective_manager::record_attempt($this->userid, $this->courseid, $oidb, true, 'quiz', 1.0);
+        $binary = objective_manager::compute_mastery($this->userid, $oidb)['score'];
+
+        $this->assertEqualsWithDelta($binary, $scored, 0.0001);
+    }
+
+    public function test_record_attempt_rounds_iscorrect_from_score(): void {
+        global $DB;
+        $oid = $this->make_objective();
+        $id = objective_manager::record_attempt($this->userid, $this->courseid, $oid,
+            false, 'rubric', 1.0, null, null, 0.7);
+        $row = $DB->get_record(objective_manager::TABLE_ATTS, ['id' => $id]);
+        $this->assertEquals(1, (int) $row->iscorrect); // 0.7 >= 0.5
+        $this->assertEqualsWithDelta(0.7, (float) $row->score, 0.0001);
+    }
+}

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_ai_course_assistant';
-$plugin->version = 2026071017;
+$plugin->version = 2026071100;
 $plugin->requires = 2024100700; // Moodle 4.5+.
 $plugin->supported = [405, 503]; // Tested on Moodle 4.5 through 5.3dev.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '6.8.28';
+$plugin->release = '6.8.29';


### PR DESCRIPTION
Foundation for the WSCUC criterion->outcome mapping. You chose to **blend** a rubric-criterion score as a weighted signal into the mastery estimate rather than a binary met/not-met; today the estimator only handles binary correct/incorrect, so this adds continuous (partial-credit) observations.

## What
- `obj_att` gains a nullable `score` column (install.xml + idempotent upgrade).
- `objective_manager::record_attempt` takes an optional `score`; when set it is clamped to [0,1], stored, and `iscorrect` is rounded from it so any binary reader stays sensible.
- `objective_manager::compute_mastery` blends: an attempt with a `score` contributes `w * score` to the Beta posterior; attempts without a score behave exactly as before — fully backward compatible.
- Tests: a 0.8 attempt lands strictly between a wrong and a right attempt; `score = 1.0` matches a binary-correct attempt; `iscorrect` is rounded from the score.

## Validation
On Moodle 4.5: the upgrade adds the column; a single 0.8 attempt yields mastery 0.56, between wrong 0.4 and correct 0.6 (the Beta(2,2) prior math: (2+0.8)/5 = 0.56). Lints clean; XML valid.

## Next
The follow-up PR wires it up: Soapbox rubric criteria carry an optional `objectiveid`, a rubric-editor outcome picker, and `score_speech` records these partial-credit attempts per mapped criterion — which then flow into the outcomes report (#139).

v6.8.28 to v6.8.29.

Generated with Claude Code
