### PR TITLE
feat(outcomes): map rubric criteria to course outcomes (v6.8.30)

### DIFF
--- a/classes/external/score_speech.php
+++ b/classes/external/score_speech.php
@@ -26,6 +26,7 @@ use core_external\external_multiple_structure;
 use local_ai_course_assistant\provider\base_provider;
 use local_ai_course_assistant\rubric_manager;
 use local_ai_course_assistant\feature_flags;
+use local_ai_course_assistant\objective_manager;
 
 /**
  * Soapbox: score a transcribed speech against the per-course speech rubric and
@@ -236,6 +237,33 @@ class score_speech extends external_api {
         } catch (\Throwable $e) {
             // History persistence is best-effort; still return the feedback.
             $scoreid = 0;
+        }
+
+        // v6.8.30: outcome mapping. A criterion mapped to a course outcome
+        // records a partial-credit mastery attempt (its normalized score), so
+        // the presentation feeds the WSCUC outcomes report. Best-effort.
+        try {
+            $defbyname = [];
+            foreach ($criteriadefs as $d) {
+                $dname = (string) ($d['name'] ?? '');
+                if ($dname !== '') {
+                    $defbyname[$dname] = $d;
+                }
+            }
+            foreach ($criteria as $scored) {
+                $def = $defbyname[$scored['name']] ?? null;
+                $oid = (int) ($def['objectiveid'] ?? 0);
+                if (!$def || $oid <= 0) {
+                    continue;
+                }
+                $max = max(1, (int) ($def['max_score'] ?? 5));
+                $norm = max(0.0, min(1.0, $scored['score'] / $max));
+                objective_manager::record_attempt(
+                    (int) $USER->id, $courseid, $oid, $norm >= 0.5, 'rubric', 1.0, null, null, $norm);
+            }
+        } catch (\Throwable $e) {
+            // Outcome recording is best-effort; feedback is unaffected.
+            null;
         }
 
         return [

--- a/rubric_admin.php
+++ b/rubric_admin.php
@@ -81,11 +81,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             if (empty(trim($c['name'] ?? ''))) {
                 continue;
             }
-            $clean[] = [
+            $entry = [
                 'name' => clean_param(trim($c['name']), PARAM_TEXT),
                 'description' => clean_param(trim($c['description'] ?? ''), PARAM_TEXT),
                 'max_score' => max(1, (int) ($c['max_score'] ?? 5)),
             ];
+            // v6.8.30: optional outcome mapping. Only meaningful for a per-course
+            // rubric (objectives are per-course); kept only if the objective
+            // belongs to this course.
+            $oid = (int) ($c['objectiveid'] ?? 0);
+            if ($oid > 0 && $courseid > 0
+                    && \local_ai_course_assistant\objective_manager::get($oid)
+                    && (int) \local_ai_course_assistant\objective_manager::get($oid)->courseid === $courseid) {
+                $entry['objectiveid'] = $oid;
+            }
+            $clean[] = $entry;
         }
 
         if (empty($clean)) {
@@ -127,6 +137,16 @@ rubric_manager::ensure_default_rubric($type);
 $rubric = rubric_manager::get_rubric($courseid, $type);
 $is_inherited = ($rubric && (int) $rubric->courseid !== $courseid && $courseid > 0);
 $criteria = $rubric ? $rubric->criteria : rubric_manager::get_default_criteria($type);
+
+// v6.8.30: course outcomes offered for per-criterion mapping (per-course rubrics
+// only; objectives are per-course). Empty for the global rubric, which hides the
+// picker in the editor JS.
+$outcomesforjs = [];
+if ($courseid > 0) {
+    foreach (\local_ai_course_assistant\objective_manager::list_for_course($courseid) as $o) {
+        $outcomesforjs[] = ['id' => (int) $o->id, 'title' => (string) $o->title, 'code' => (string) ($o->code ?? '')];
+    }
+}
 
 // v6.7.0: Soapbox sample-rubric loader. ?preset=<level> seeds the editor with a
 // built-in sample (General Speech / ESL beginner / ESL advanced) which the admin
@@ -247,6 +267,8 @@ echo $OUTPUT->header();
 <script>
 (function() {
     var criteria = <?php echo json_encode($criteria); ?>;
+    // Course outcomes available to map criteria to (per-course rubrics only).
+    var sbxObjectives = <?php echo json_encode($outcomesforjs); ?>;
     var container = document.getElementById('aica-criteria-container');
     var addBtn = document.getElementById('aica-add-criterion-btn');
     var resetBtn = document.getElementById('aica-reset-btn');
@@ -382,6 +404,34 @@ echo $OUTPUT->header();
         descInp.addEventListener('input', function() { c.description = descInp.value; });
         descField.appendChild(descInp);
         card.appendChild(descField);
+
+        // Outcome mapping (per-course rubrics only): map this criterion to a
+        // course learning outcome so scoring it feeds the outcomes report.
+        if (sbxObjectives.length) {
+            var outField = document.createElement('div');
+            outField.className = 'aica-rb-field';
+            var outLbl = document.createElement('label');
+            outLbl.textContent = 'Maps to outcome (optional)';
+            outField.appendChild(outLbl);
+            var outSel = document.createElement('select');
+            outSel.setAttribute('aria-label', 'Course outcome this criterion maps to');
+            var none = document.createElement('option');
+            none.value = '0';
+            none.textContent = '- None -';
+            outSel.appendChild(none);
+            sbxObjectives.forEach(function(o) {
+                var opt = document.createElement('option');
+                opt.value = String(o.id);
+                opt.textContent = (o.code ? o.code + ' ' : '') + o.title;
+                if (parseInt(c.objectiveid, 10) === o.id) { opt.selected = true; }
+                outSel.appendChild(opt);
+            });
+            outSel.addEventListener('change', function() {
+                c.objectiveid = parseInt(outSel.value, 10) || 0;
+            });
+            outField.appendChild(outSel);
+            card.appendChild(outField);
+        }
 
         return card;
     }

--- a/tests/outcomes_rubric_source_test.php
+++ b/tests/outcomes_rubric_source_test.php
@@ -1,0 +1,67 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * A rubric-mapped criterion feeds the WSCUC outcomes report (v6.8.30).
+ *
+ * Mirrors what score_speech does after scoring: a criterion carrying an
+ * objectiveid records a normalized partial-credit attempt (source 'rubric'),
+ * which then surfaces per-outcome in outcomes_report::course_report.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_ai_course_assistant\outcomes_report
+ */
+final class outcomes_rubric_source_test extends \advanced_testcase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+        set_config('mastery_decay_enabled', 0, 'local_ai_course_assistant');
+        set_config('outcomes_benchmark_default', 70, 'local_ai_course_assistant');
+    }
+
+    public function test_rubric_criterion_surfaces_in_outcomes_report(): void {
+        $course = $this->getDataGenerator()->create_course();
+        $courseid = (int) $course->id;
+        $oid = objective_manager::create($courseid, 'Constructs and defends an argument', 'CLO-A');
+
+        // Three learners scored on a max_score=5 criterion mapped to the outcome:
+        // 5/5, 4/5, 2/5 -> normalized 1.0, 0.8, 0.4 (what score_speech records).
+        foreach ([[1.0], [0.8], [0.4]] as $i => $pair) {
+            $user = $this->getDataGenerator()->create_user();
+            $norm = $pair[0];
+            objective_manager::record_attempt((int) $user->id, $courseid, $oid,
+                $norm >= 0.5, 'rubric', 1.0, null, null, $norm);
+        }
+
+        $rows = outcomes_report::course_report($courseid);
+        $row = null;
+        foreach ($rows as $r) {
+            if ((int) $r['id'] === $oid) {
+                $row = $r;
+            }
+        }
+        $this->assertNotNull($row, 'Mapped outcome missing from the report');
+        $this->assertEquals(70, (int) $row['benchmark_pct']);
+        $this->assertEquals(3, (int) $row['n'], 'All three rubric attempts should be assessed');
+    }
+}

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_ai_course_assistant';
-$plugin->version = 2026071100;
+$plugin->version = 2026071101;
 $plugin->requires = 2024100700; // Moodle 4.5+.
 $plugin->supported = [405, 503]; // Tested on Moodle 4.5 through 5.3dev.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '6.8.29';
+$plugin->release = '6.8.30';


### PR DESCRIPTION
## Rubric criterion → course outcome mapping (v6.8.30)

Closes the loop between Soapbox rubric scoring and the WSCUC outcomes report (#139). An admin can map any rubric criterion to a course outcome; when a learner's speech is scored, each mapped criterion records a **partial-credit** mastery attempt (its normalized score, source `rubric`), so the presentation feeds the per-outcome achievement report.

Built on the partial-credit continuous observations landed in #140 (`record_attempt(..., ?float $score)`).

### Blend-as-weighted-signal semantics
A criterion scored 4/5 (max_score 5) records a normalized attempt of 0.8 against the mapped outcome — it contributes fractionally to the Beta posterior rather than a hard pass/fail. This is the "blend as weighted signal" mapping decided during design.

### Changes
- **`rubric_admin.php`** — per-criterion "Course outcome" `<select>` picker (populated from `objective_manager::list_for_course`, shown only when the course has outcomes; "- None -" = unmapped). Validated `objectiveid` preserved through the clean-loop. Gated on `moodle/site:config`.
- **`classes/external/score_speech.php`** — after scoring, each criterion carrying an `objectiveid` records a normalized partial-credit attempt via `objective_manager::record_attempt(... source 'rubric', score=norm)`. Best-effort: feedback is unaffected if recording fails.
- **`tests/outcomes_rubric_source_test.php`** — pins the contract at the data level: rubric-source partial-credit attempts surface per-outcome in `outcomes_report::course_report`.
- **`version.php`** — 6.8.29 → 6.8.30.

### Testing
- `outcomes_rubric_source_test` — 1 test, 3 assertions, pass.
- `objective_partial_credit_test` (from #140) — 3 tests, 5 assertions, pass.
- Full end-to-end data flow (rubric attempt → mastery → outcomes report) verified via live CLI integration check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
