### PR TITLE
Fix Soapbox storage delete: blank Authorization header on presigned S3 DELETE

### DIFF
--- a/classes/soapbox_storage.php
+++ b/classes/soapbox_storage.php
@@ -226,7 +226,12 @@ class soapbox_storage {
             'timestamp' => time(),
         ]);
         $curl = new \curl();
-        $curl->delete($url);
+        // Moodle's curl::delete() injects CURLOPT_USERPWD ('anonymous: ...'),
+        // which makes curl add an Authorization: Basic header. On a presigned
+        // S3 URL (SigV4 auth in the query string) that second mechanism triggers
+        // 400 InvalidArgument "Only one auth mechanism allowed". Blank the
+        // Authorization header so only the query-string signature is used.
+        $curl->delete($url, [], ['CURLOPT_HTTPHEADER' => ['Authorization:']]);
         $code = (int) ($curl->get_info()['http_code'] ?? 0);
         return ($code >= 200 && $code < 300) || $code === 404;
     }

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_ai_course_assistant';
-$plugin->version = 2026071103;
+$plugin->version = 2026071104;
 $plugin->requires = 2024100700; // Moodle 4.5+.
 $plugin->supported = [405, 503]; // Tested on Moodle 4.5 through 5.3dev.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '6.8.32';
+$plugin->release = '6.8.33';


### PR DESCRIPTION
## Problem
`soapbox_storage::delete_object()` silently failed against S3 — objects were never removed. This is used by the Soapbox retention-cleanup task and by GDPR erasure, so recordings and slide decks were only being removed by the 30-day bucket lifecycle rule, not on demand.

## Root cause
Moodle's `curl::delete()` injects `CURLOPT_USERPWD` (`'anonymous: noreply@moodle.org'`), which makes curl send an `Authorization: Basic` header. Our storage URLs are **presigned** (AWS SigV4 auth in the query string), so the extra header is a second auth mechanism and S3 rejects the request:

```
400 InvalidArgument: Only one auth mechanism allowed; only the X-Amz-Algorithm
query parameter, Signature query string parameter or the Authorization header...
```

`presign_get`/`object_size` (HEAD/GET) were unaffected because `curl::head()`/`get()` do not set `USERPWD`.

## Fix
Blank the `Authorization` header on the delete so only the query-string signature is used:

```php
$curl->delete($url, [], ['CURLOPT_HTTPHEADER' => ['Authorization:']]);
```

## Verification
Against the live dev S3 bucket: default delete -> **400** (object remained); fixed delete -> **204** (object removed). Confirmed via the plugin's own `soapbox_storage` signing code.

Version bumped to 6.8.33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)