### PR TITLE
Zendesk escalation: include the learner's page URL as context (v6.9.0)

### DIFF
--- a/classes/zendesk_client.php
+++ b/classes/zendesk_client.php
@@ -111,6 +111,7 @@ class zendesk_client {
      * @param int $courseid The course ID.
      * @param string $question The student's original question.
      * @param string $conversationsummary A summary of the chat conversation so far.
+     * @param int $pageid Course-module id of the page the learner was on (0 = none).
      * @return string|null The ticket ID/URL if created, or null on failure.
      */
     public static function create_ticket(

--- a/classes/zendesk_client.php
+++ b/classes/zendesk_client.php
@@ -60,6 +60,51 @@ class zendesk_client {
     }
 
     /**
+     * Build the Zendesk ticket body. Pure (no IO) so the exact format is pinned
+     * by tests. The learner's current page URL is included as context for the
+     * support agent, on its own "Page:" line after the course.
+     *
+     * @param \stdClass $user firstname, lastname, email
+     * @param \stdClass $course fullname
+     * @param string $pageurl absolute page URL ('' to omit the line)
+     * @param string $question the learner's original question
+     * @param string $summary the conversation summary
+     * @return string
+     */
+    public static function format_ticket_body(\stdClass $user, \stdClass $course,
+            string $pageurl, string $question, string $summary): string {
+        $body = "Student: {$user->firstname} {$user->lastname} ({$user->email})\n"
+            . "Course: {$course->fullname}\n";
+        if (trim($pageurl) !== '') {
+            $body .= "Page: {$pageurl}\n";
+        }
+        $body .= "Original Question: {$question}\n\n"
+            . "--- Conversation Summary ---\n{$summary}\n\n"
+            . "--- End of AI Tutor Conversation ---\n"
+            . "The AI tutor was unable to resolve this question. Please follow up with the student.";
+        return $body;
+    }
+
+    /**
+     * Resolve the learner's current page URL for ticket context: the module view
+     * URL when a course-module id is known, else the course page. The cmid is
+     * pinned to the course so a foreign id cannot resolve to another course.
+     *
+     * @param int $courseid
+     * @param int $pageid course-module id (0 = none)
+     * @return string absolute URL
+     */
+    public static function resolve_page_url(int $courseid, int $pageid): string {
+        if ($pageid > 0) {
+            $cm = get_coursemodule_from_id('', $pageid, $courseid, false, IGNORE_MISSING);
+            if ($cm) {
+                return (new \moodle_url('/mod/' . $cm->modname . '/view.php', ['id' => $pageid]))->out(false);
+            }
+        }
+        return (new \moodle_url('/course/view.php', ['id' => $courseid]))->out(false);
+    }
+
+    /**
      * Create a Zendesk support ticket from a chat conversation.
      *
      * @param int $userid The Moodle user ID.
@@ -72,7 +117,8 @@ class zendesk_client {
         int $userid,
         int $courseid,
         string $question,
-        string $conversationsummary
+        string $conversationsummary,
+        int $pageid = 0
     ): ?string {
         global $DB, $CFG;
         require_once($CFG->libdir . '/filelib.php'); // For \curl.
@@ -89,12 +135,8 @@ class zendesk_client {
         $course = $DB->get_record('course', ['id' => $courseid], 'id, fullname', MUST_EXIST);
 
         $subject = "AI Tutor Support: {$course->fullname} - " . shorten_text($question, 80);
-        $body = "Student: {$user->firstname} {$user->lastname} ({$user->email})\n"
-            . "Course: {$course->fullname}\n"
-            . "Original Question: {$question}\n\n"
-            . "--- Conversation Summary ---\n{$conversationsummary}\n\n"
-            . "--- End of AI Tutor Conversation ---\n"
-            . "The AI tutor was unable to resolve this question. Please follow up with the student.";
+        $pageurl = self::resolve_page_url($courseid, $pageid);
+        $body = self::format_ticket_body($user, $course, $pageurl, $question, $conversationsummary);
 
         $url = "https://{$subdomain}.zendesk.com/api/v2/tickets.json";
 

--- a/sse.php
+++ b/sse.php
@@ -868,7 +868,7 @@ try {
     } else if ($needsescalation && zendesk_client::is_enabled()) {
         $messages = conversation_manager::get_messages($conv->id);
         $summary = zendesk_client::build_conversation_summary($messages);
-        $ticketref = zendesk_client::create_ticket($userid, $courseid, $message, $summary);
+        $ticketref = zendesk_client::create_ticket($userid, $courseid, $message, $summary, $pageid);
 
         if ($ticketref) {
             $escalationmsg = get_string('chat:escalated_to_support', 'local_ai_course_assistant', $ticketref);

--- a/tests/zendesk_client_test.php
+++ b/tests/zendesk_client_test.php
@@ -1,0 +1,63 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Tests for zendesk_client ticket body formatting (v6.9.0 page-context line).
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_ai_course_assistant\zendesk_client
+ */
+final class zendesk_client_test extends \basic_testcase {
+
+    /**
+     * The page URL appears on its own line, between Course and Original Question.
+     */
+    public function test_body_includes_page_line_after_course(): void {
+        $user = (object) ['firstname' => 'Ana', 'lastname' => 'Morales', 'email' => 'ana@example.com'];
+        $course = (object) ['fullname' => 'ESL001: Elementary English as a Second Language'];
+        $pageurl = 'https://learn.example.org/mod/quiz/view.php?id=42';
+
+        $body = zendesk_client::format_ticket_body($user, $course, $pageurl, 'Hola?', 'Summary here.');
+
+        $this->assertStringContainsString("Page: {$pageurl}\n", $body);
+        $cpos = strpos($body, 'Course:');
+        $ppos = strpos($body, 'Page:');
+        $qpos = strpos($body, 'Original Question:');
+        $this->assertNotFalse($ppos);
+        $this->assertTrue($cpos < $ppos, 'Page line should come after Course');
+        $this->assertTrue($ppos < $qpos, 'Page line should come before Original Question');
+    }
+
+    /**
+     * An empty page URL omits the Page line entirely (no dangling label).
+     */
+    public function test_body_omits_page_line_when_empty(): void {
+        $user = (object) ['firstname' => 'A', 'lastname' => 'B', 'email' => 'a@example.com'];
+        $course = (object) ['fullname' => 'C'];
+
+        $body = zendesk_client::format_ticket_body($user, $course, '   ', 'q', 's');
+
+        $this->assertStringNotContainsString('Page:', $body);
+        $this->assertStringContainsString('Course: C', $body);
+        $this->assertStringContainsString('Original Question: q', $body);
+    }
+}

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_ai_course_assistant';
-$plugin->version = 2026071103;
+$plugin->version = 2026071600;
 $plugin->requires = 2024100700; // Moodle 4.5+.
 $plugin->supported = [405, 503]; // Tested on Moodle 4.5 through 5.3dev.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '6.8.32';
+$plugin->release = '6.9.0';


### PR DESCRIPTION
## Suggestion
Include page context (the URL) in the message sent to Zendesk, right after the `Course:` line, so a support agent can jump straight to the page the learner was on.

Before:
```
Student: ...
Course: ESL001: Elementary English as a Second Language
Original Question: Hola, me puedes explicar...
```

After:
```
Student: ...
Course: ESL001: Elementary English as a Second Language
Page: https://learn.saylor.org/mod/quiz/view.php?id=42
Original Question: Hola, me puedes explicar...
```

## Implementation
- `zendesk_client::create_ticket()` takes the current `pageid` and resolves a page URL: the module view URL when a course-module id is known, else the course page. The cmid is **pinned to the course** (`get_coursemodule_from_id('', $pageid, $courseid, ...)`) so a foreign id cannot resolve to another course's module (same guard sse.php already uses).
- No client/JS change: `sse.php` already receives `pageid` and now forwards it.
- Body build extracted to a pure `format_ticket_body()` method; the `Page:` line and its position (after Course, before Original Question) are pinned by new unit tests in `tests/zendesk_client_test.php`. An empty URL omits the line.
- Version bumped to **6.9.0** (2026071600).

## Notes
- Labels in the ticket body are hardcoded English (consistent with the existing `Student:` / `Course:` / `Original Question:` labels), so no i18n change.
- Escalation still requires disclosed consent (`zendesk_require_consent`), unchanged.
- Version.php will conflict with #144 (delete fix, 6.8.33) at merge; rebase whichever merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)