### PR TITLE
CI: authenticate claude-code-action via ANTHROPIC_API_KEY

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Allow Dependabot-authored PRs to be auto-reviewed (bot-initiated
           # runs are blocked by default). Use '*' to allow all bots.
           allowed_bots: 'dependabot'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Why
`claude-review` (and the `@claude` workflow) stopped posting. Auth to GitHub succeeds, but the Claude run returns `is_error: true` immediately (`num_turns: 1`, ~2s, `total_cost_usd: 0`) — the Anthropic side rejecting the request. Both workflows authenticate with `CLAUDE_CODE_OAUTH_TOKEN` (a Claude subscription token, set 2026-06-08); it worked as of PR #109 (2026-07-03) and now fails, consistent with the OAuth token being revoked/rotated or its subscription hitting a usage limit.

## Change
Switch both workflows from `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}` to `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}`, so CI uses a stable Anthropic API key rather than the subscription token.

- `.github/workflows/claude-code-review.yml`
- `.github/workflows/claude.yml`

## Required before this works / before merging
Set an **`ANTHROPIC_API_KEY`** repo secret:
```
gh secret set ANTHROPIC_API_KEY --repo saylordotorg/moodle-local_ai_course_assistant
```
Until that secret exists, the `claude-review` check will still fail (same as today). The phpunit matrix is unaffected.

## Alternative
If you'd rather keep the subscription-token path, refresh it instead (`claude setup-token` then `gh secret set CLAUDE_CODE_OAUTH_TOKEN`) and close this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)