### PR TITLE
a11y + docs for the WSCUC outcomes report

### DIFF
--- a/.drafts/v6.8.32-release-notes-and-walkthrough.md
+++ b/.drafts/v6.8.32-release-notes-and-walkthrough.md
@@ -50,4 +50,20 @@ Plugin version `2026071103`, release `6.8.32`.
 ---
 
 ## Part 3: Admin Walkthrough
-(Carried forward from v6.8.20 / v6.8.5; additions this release: enabling slides on a Soapbox assignment and turning on the optional slide-vision setting; reviewing the WSCUC outcomes report and setting a per-outcome benchmark; mapping a rubric criterion to a course outcome; and the `rag_scope` document-scoping setting.)
+
+Core drawer, quiz, voice, analytics, and privacy flows are carried forward from v6.8.20 / v6.8.5. Concrete steps for the new surfaces are below; the Soapbox slides / slide-vision and `rag_scope` walkthroughs are carried forward as one-line pointers pending their own detailed pass.
+
+### Reviewing the WSCUC outcomes report (v6.8.28 - v6.8.30)
+
+Prerequisite: the demo course has learning objectives defined (Objectives Admin, `/local/ai_course_assistant/objectives_admin.php?courseid=<id>`) and mastery tracking on (`mastery_enabled_course_<id>`), so there is outcome evidence to report.
+
+1. **Open the report.** From the course, use the "Outcomes report" course-nav link, or go to `/local/ai_course_assistant/outcomes_report.php?courseid=<id>`. It requires the `viewanalytics` capability (teachers, instructional designers, admins). Talking point: "This is the accreditation-facing readout — for each outcome, the share of students who met the benchmark."
+2. **Read the table.** Each row is one course outcome: code and title, the benchmark %, students assessed (anyone with at least one scored attempt on that outcome), students who met the benchmark, and the percent met. Talking point: "We report the aggregate percentage meeting the standard, not pass/fail per student — that is the WSCUC shape."
+3. **Explain the benchmark.** Two numbers, deliberately separate: the site default `outcomes_benchmark_default` (70%) applies to every outcome unless overridden per outcome (`outcomes_benchmark_obj_<id>`); the separate coaching mastery threshold (0.75) drives in-tutor nudges. The benchmark is the reporting standard, not the pedagogy trigger.
+4. **Show the mixed evidence.** The same report is fed by quizzes and by rubric-scored Soapbox presentations: a rubric criterion mapped to a course outcome (Rubric Editor) records a partial-credit attempt, so a spoken presentation counts toward outcome achievement exactly like a quiz item.
+5. **Export for accreditation.** Click "Export CSV." A per-outcome CSV downloads (outcome code, outcome, benchmark, students assessed, met benchmark, percent met). Talking point: "This is the artifact that goes into an accreditation self-study."
+6. **Name the current limit.** Be candid that the report is course-scoped today; aggregating course outcomes up to program (degree-level) outcomes is the next build.
+
+### Carried-forward pointers (detail in a later pass)
+- Enabling slides on a Soapbox assignment and turning on the optional slide-vision setting.
+- The `rag_scope` document-scoping setting.

--- a/outcomes_report.php
+++ b/outcomes_report.php
@@ -85,13 +85,20 @@ if (empty($rows)) {
         get_string('outcomes:col_pct', 'local_ai_course_assistant'),
     ];
     $table->attributes['class'] = 'generaltable';
+    // Screen-reader caption (visually hidden; the visible <h2> already names the table).
+    $table->caption = get_string('outcomes:title', 'local_ai_course_assistant');
+    $table->captionhide = true;
     foreach ($rows as $r) {
         $label = format_string($r['title']);
         if ($r['code'] !== '') {
             $label = html_writer::span(s($r['code']) . ' ', 'text-muted') . $label;
         }
+        // Outcome name is the row header so screen readers associate each data cell with it.
+        $labelcell = new html_table_cell($label);
+        $labelcell->header = true;
+        $labelcell->scope = 'row';
         $table->data[] = [
-            $label,
+            $labelcell,
             $r['benchmark_pct'] . '%',
             $r['n'],
             $r['met'],

--- a/tests/a11y/axe-run.js
+++ b/tests/a11y/axe-run.js
@@ -34,6 +34,7 @@ const PAGES = [
   'sandbox.php?courseid=2',
   'flashcards.php?courseid=2',
   'objectives_admin.php?courseid=2',
+  'outcomes_report.php?courseid=2',
   'instructor_dashboard.php?courseid=2',
   'rag_admin.php',
   'analytics.php?courseid=2',


### PR DESCRIPTION
## Why
Follow-up hygiene for the WSCUC outcomes report (`outcomes_report.php`, v6.8.28–v6.8.30). An audit found i18n was complete (46/46) but accessibility, user guides, and the demo walkthrough had gaps. This closes the a11y and demo-script gaps that live in this repo.

## Changes
- **a11y harness** (`tests/a11y/axe-run.js`): add `outcomes_report.php?courseid=2` to the audited WCAG2AA page list — the report previously had zero automated a11y coverage.
- **Accessible table** (`outcomes_report.php`): add a screen-reader `<caption>` (visually hidden via `captionhide`; reuses the existing `outcomes:title` key so **no new i18n strings**), and make the outcome-name column a `<th scope="row">` so each data cell is associated with its outcome.
- **Demo script** (`.drafts/v6.8.32-release-notes-and-walkthrough.md`): replace the one-line Part 3 pointer with a real 6-step admin walkthrough for the outcomes report (open → read → benchmark → mixed quiz+Soapbox evidence → CSV export → program-rollup limit).

## Not in this PR
- The **wiki docs** (Features, Admin-Settings, Mastery-Tracking, Release-Checklist) are in the separate `...wiki.git` repo, which has no PR mechanism. Those 4 edits are staged separately and will be pushed to the wiki directly.

## Verification
- `php -l outcomes_report.php` and `node --check tests/a11y/axe-run.js` both clean.
- Full axe audit + visual check of the caption/row-header need the local Moodle stack with objectives on course 2 (otherwise the page renders the empty state); not run here.
- i18n unchanged (kept at 46/46 by reusing an existing key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)