### PR TITLE
ci: skip claude-review on Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,12 @@ on:
 
 jobs:
   claude-review:
+    # Skip Dependabot PRs: GitHub runs Dependabot-triggered pull_request
+    # workflows with a restricted token that reads from Dependabot secrets, not
+    # Actions secrets, so ANTHROPIC_API_KEY is empty and the review fails with
+    # is_error. Guard here so these runs are skipped cleanly, not marked failed.
+    if: github.actor != 'dependabot[bot]'
+
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
@@ -36,9 +42,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # Allow Dependabot-authored PRs to be auto-reviewed (bot-initiated
-          # runs are blocked by default). Use '*' to allow all bots.
-          allowed_bots: 'dependabot'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Why
`claude-review` fails with `is_error:true` on every Dependabot PR. Root cause: GitHub runs Dependabot-triggered `pull_request` workflows with a restricted token whose secrets come from **Dependabot** secrets, not Actions secrets — so `secrets.ANTHROPIC_API_KEY` is empty and the action can't authenticate. The existing `allowed_bots: 'dependabot'` line lets the action *attempt* the review but can't solve the missing-secret problem.

## Change
- Guard the job with `if: github.actor != 'dependabot[bot]'` so Dependabot PRs skip `claude-review` cleanly (a skipped job is not a failure).
- Remove the now-moot `allowed_bots: 'dependabot'` line (other bots remain blocked by default).

## Effect
No more spurious `claude-review` failure emails on dependabot dependency-bump PRs. Human PRs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)