### PR TITLE
feat(rag): parent-document retrieval (window/page expansion)

### DIFF
--- a/classes/content_chunker.php
+++ b/classes/content_chunker.php
@@ -114,4 +114,67 @@ class content_chunker {
 
         return $chunks;
     }
+
+    /**
+     * Reconstruct a module's chunks into one passage: keep the shared
+     * "[Section] Title:" prefix once, and remove the word overlap between
+     * consecutive chunks. Pure (no DB/provider) so it is unit-testable.
+     *
+     * @param string[] $contents Ordered chunk `content` strings for one module.
+     * @return string
+     */
+    public static function reconstruct(array $contents): string {
+        $contents = array_values($contents);
+        $n = count($contents);
+        if ($n === 0) {
+            return '';
+        }
+        if ($n === 1) {
+            return $contents[0];
+        }
+
+        // Longest common prefix across all chunks, cut at the last ": " so we
+        // only strip the "[Section] Title: " header, never shared body text.
+        $prefix = $contents[0];
+        foreach ($contents as $c) {
+            $max = min(strlen($prefix), strlen($c));
+            $i = 0;
+            while ($i < $max && $prefix[$i] === $c[$i]) {
+                $i++;
+            }
+            $prefix = substr($prefix, 0, $i);
+            if ($prefix === '') {
+                break;
+            }
+        }
+        $cut = strrpos($prefix, ': ');
+        $prefix = ($cut !== false) ? substr($prefix, 0, $cut + 2) : '';
+        $plen = strlen($prefix);
+
+        $result    = $contents[0];
+        $prevwords = preg_split('/\s+/', trim(substr($contents[0], $plen)), -1, PREG_SPLIT_NO_EMPTY);
+
+        for ($k = 1; $k < $n; $k++) {
+            $body     = trim(substr($contents[$k], $plen));
+            $curwords = preg_split('/\s+/', $body, -1, PREG_SPLIT_NO_EMPTY);
+            if (empty($curwords)) {
+                continue;
+            }
+            // Largest o such that the last o words of prev equal the first o of cur.
+            $cap = min(count($prevwords), count($curwords), 100);
+            $ov  = 0;
+            for ($o = $cap; $o >= 1; $o--) {
+                if (array_slice($prevwords, -$o) === array_slice($curwords, 0, $o)) {
+                    $ov = $o;
+                    break;
+                }
+            }
+            $newwords = array_slice($curwords, $ov);
+            if (!empty($newwords)) {
+                $result .= ' ' . implode(' ', $newwords);
+            }
+            $prevwords = $curwords;
+        }
+        return $result;
+    }
 }

--- a/classes/rag_retriever.php
+++ b/classes/rag_retriever.php
@@ -351,10 +351,10 @@ class rag_retriever {
             $merged = content_chunker::reconstruct(array_map(fn($s) => (string) $s['content'], $selected));
 
             // Size cap: page -> window -> single matched chunk.
-            if (strlen($merged) > $maxchars) {
+            if (mb_strlen($merged) > $maxchars) {
                 $selected = $pick(max(1, $windowsize));
                 $merged = content_chunker::reconstruct(array_map(fn($s) => (string) $s['content'], $selected));
-                if (strlen($merged) > $maxchars) {
+                if (mb_strlen($merged) > $maxchars) {
                     $selected = [['content' => (string) $row['content'], 'chunkindex' => $center]];
                     $merged = (string) $row['content'];
                 }

--- a/classes/rag_retriever.php
+++ b/classes/rag_retriever.php
@@ -59,6 +59,8 @@ class rag_retriever {
     public static function retrieve(int $courseid, string $query, int $topk = 5, int $currentcmid = 0): array {
         global $DB;
 
+        $final = null;
+
         // Static cache of decoded embeddings — avoids re-decoding JSON on
         // subsequent RAG queries within the same PHP request.
         static $embedding_cache = [];
@@ -196,7 +198,7 @@ class rag_retriever {
                             }
                         }
                         if (!empty($out)) {
-                            return $out;
+                            $final = $out;
                         }
                     }
                 }
@@ -206,7 +208,40 @@ class rag_retriever {
             }
         }
 
-        return array_slice($scored, 0, $topk);
+        $final = $final ?? array_slice($scored, 0, $topk);
+
+        // Parent-document expansion (opt-in). Selection above is unchanged;
+        // here we optionally widen each hit to a neighbour window or full page.
+        $rawreturn = get_config('local_ai_course_assistant', 'rag_return_scope');
+        $returnscope = ($rawreturn === false || $rawreturn === '') ? 'chunk' : (string) $rawreturn;
+        if ($returnscope === 'chunk') {
+            return $final;
+        }
+        $rawwin = get_config('local_ai_course_assistant', 'rag_window_size');
+        $windowsize = ($rawwin === false || $rawwin === '') ? 1 : max(0, (int) $rawwin);
+        $rawcap = get_config('local_ai_course_assistant', 'rag_parent_max_chars');
+        $maxchars = ($rawcap === false || $rawcap === '') ? 6000 : max(500, (int) $rawcap);
+
+        $cmids = array_values(array_unique(array_filter(
+            array_map(fn($r) => (int) ($r['cmid'] ?? 0), $final))));
+        $siblingsbycmid = [];
+        if (!empty($cmids)) {
+            list($insql, $inparams) = $DB->get_in_or_equal($cmids, SQL_PARAMS_NAMED);
+            $rows = $DB->get_records_select(
+                'local_ai_course_assistant_chunks',
+                "courseid = :cid AND cmid {$insql}",
+                array_merge(['cid' => $courseid], $inparams),
+                'cmid, chunkindex',
+                'id, cmid, chunkindex, content'
+            );
+            foreach ($rows as $r) {
+                $siblingsbycmid[(int) $r->cmid][] = [
+                    'content'    => (string) $r->content,
+                    'chunkindex' => (int) $r->chunkindex,
+                ];
+            }
+        }
+        return self::merge_parents($final, $siblingsbycmid, $returnscope, $windowsize, $maxchars);
     }
 
     /**

--- a/classes/rag_retriever.php
+++ b/classes/rag_retriever.php
@@ -278,6 +278,63 @@ class rag_retriever {
     }
 
     /**
+     * Expand selected chunks into parent units (neighbor window or whole page),
+     * deduplicated by cmid, size-capped with fallback. Pure (no DB/provider).
+     *
+     * @param array  $topkrows       Final selected rows (post-rerank), rank-sorted.
+     * @param array  $siblingsbycmid [cmid => [ ['content'=>string,'chunkindex'=>int], ... ]]
+     * @param string $mode           'window' | 'page'.
+     * @param int    $windowsize     Neighbors each side for 'window' mode.
+     * @param int    $maxchars       Per-passage cap; over-cap pages fall back.
+     * @return array Expanded rows (same shape + 'expand_mode', 'expanded_from').
+     */
+    public static function merge_parents(array $topkrows, array $siblingsbycmid,
+            string $mode, int $windowsize, int $maxchars): array {
+        $out = [];
+        $seen = [];
+        foreach ($topkrows as $row) {
+            $cmid = (int) ($row['cmid'] ?? 0);
+            if ($cmid <= 0 || empty($siblingsbycmid[$cmid])) {
+                $out[] = $row;
+                continue;
+            }
+            if (isset($seen[$cmid])) {
+                continue; // page already emitted from a higher-ranked hit
+            }
+            $seen[$cmid] = true;
+
+            $siblings = $siblingsbycmid[$cmid];
+            usort($siblings, fn($a, $b) => ((int) $a['chunkindex']) <=> ((int) $b['chunkindex']));
+            $center = (int) ($row['chunkindex'] ?? 0);
+
+            $pick = function (int $win) use ($siblings, $center) {
+                return array_values(array_filter($siblings,
+                    fn($s) => abs(((int) $s['chunkindex']) - $center) <= $win));
+            };
+
+            $selected = ($mode === 'window') ? $pick($windowsize) : $siblings;
+            $merged = content_chunker::reconstruct(array_map(fn($s) => (string) $s['content'], $selected));
+
+            // Size cap: page -> window -> single matched chunk.
+            if (strlen($merged) > $maxchars) {
+                $selected = $pick(max(1, $windowsize));
+                $merged = content_chunker::reconstruct(array_map(fn($s) => (string) $s['content'], $selected));
+                if (strlen($merged) > $maxchars) {
+                    $selected = [['content' => (string) $row['content'], 'chunkindex' => $center]];
+                    $merged = (string) $row['content'];
+                }
+            }
+
+            $newrow = $row;
+            $newrow['content']       = $merged;
+            $newrow['expand_mode']   = $mode;
+            $newrow['expanded_from'] = count($selected);
+            $out[] = $newrow;
+        }
+        return $out;
+    }
+
+    /**
      * Compute cosine similarity between two equal-length float vectors.
      *
      * @param float[] $a

--- a/docs/superpowers/plans/2026-07-17-parent-document-retrieval.md
+++ b/docs/superpowers/plans/2026-07-17-parent-document-retrieval.md
@@ -1,0 +1,477 @@
+# Parent-document retrieval — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Retrieve on small chunks for precision, then expand the selected chunks into a larger parent unit (a neighbor window or the whole module page) before injecting them into the prompt, so cross-page answers arrive as coherent passages.
+
+**Architecture:** A config-gated, post-selection expansion step in `rag_retriever::retrieve()`. Selection/floor/scope/rerank are unchanged and still operate on small chunks; expansion runs on the final top-k rows, deduplicates by `cmid`, reconstructs page text from the stored chunks (de-overlapping the 50-word joins and the repeated `[Section] Title:` prefix), and caps size with a fallback. No DB schema change — uses existing `cmid`/`chunkindex`.
+
+**Tech Stack:** PHP 8.3, Moodle plugin, PHPUnit (Moodle test harness).
+
+## Global Constraints
+
+- Namespace `local_ai_course_assistant`. Match existing code style in `classes/rag_retriever.php` and `classes/content_chunker.php`.
+- The two pure helpers must be side-effect-free (no DB, no provider) and unit-tested with `\basic_testcase`, matching `filter_and_rank`/`scope_to_document`.
+- Default behavior unchanged: `rag_return_scope` defaults to `chunk`, which must be byte-identical to today's output.
+- New admin strings go in `lang/en/local_ai_course_assistant.php`; a full 46-language i18n sync is required before release (the completeness test fails otherwise).
+- PHP lint every changed file: `/opt/homebrew/opt/php@8.3/bin/php -l <file>`.
+- Run tests from the Moodle root (`~/Sites/moodle`): `/opt/homebrew/opt/php@8.3/bin/php vendor/bin/phpunit local/ai_course_assistant/tests/<file>`.
+
+---
+
+## File Structure
+
+- `classes/content_chunker.php` (modify) — add pure `reconstruct(array $contents): string`.
+- `classes/rag_retriever.php` (modify) — add pure `merge_parents(...)`; wire expansion into `retrieve()`.
+- `settings.php` (modify) — add `rag_return_scope`, `rag_window_size`, `rag_parent_max_chars` in the Content & RAG section.
+- `lang/en/local_ai_course_assistant.php` (modify) — strings for the three settings.
+- `tests/content_chunker_test.php` (create) — `reconstruct` unit tests.
+- `tests/rag_retriever_test.php` (modify) — `merge_parents` unit tests.
+
+---
+
+### Task 1: `content_chunker::reconstruct()` — de-overlap + prefix strip
+
+**Files:**
+- Modify: `classes/content_chunker.php`
+- Test: `tests/content_chunker_test.php` (create)
+
+**Interfaces:**
+- Produces: `content_chunker::reconstruct(array $contents): string` — given the ordered chunk `content` strings of ONE module, returns one passage with the shared `[Section] Title:` prefix kept once and the 50-word overlaps between consecutive chunks removed.
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+// tests/content_chunker_test.php
+namespace local_ai_course_assistant;
+defined('MOODLE_INTERNAL') || die();
+
+class content_chunker_test extends \basic_testcase {
+    public function test_reconstruct_single_chunk_unchanged() {
+        $c = "[2.1: Legal Forms] Corporations: a corporation is a legal entity";
+        $this->assertSame($c, content_chunker::reconstruct([$c]));
+    }
+
+    public function test_reconstruct_dedupes_overlap_and_prefix() {
+        $prefix = "[2.1: Legal Forms] Corporations: ";
+        $c0 = $prefix . "a corporation is a legal entity separate from its owners";
+        // c1 = prefix + 4-word overlap tail of c0 + new body
+        $c1 = $prefix . "separate from its owners and can raise capital by issuing stock";
+        $out = content_chunker::reconstruct([$c0, $c1]);
+        $this->assertSame(
+            $prefix . "a corporation is a legal entity separate from its owners "
+                . "and can raise capital by issuing stock",
+            $out
+        );
+        // Prefix header appears exactly once.
+        $this->assertSame(1, substr_count($out, "Corporations:"));
+    }
+
+    public function test_reconstruct_empty() {
+        $this->assertSame('', content_chunker::reconstruct([]));
+    }
+}
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `/opt/homebrew/opt/php@8.3/bin/php vendor/bin/phpunit local/ai_course_assistant/tests/content_chunker_test.php`
+Expected: FAIL — `Error: Call to undefined method ...content_chunker::reconstruct()`.
+
+- [ ] **Step 3: Implement `reconstruct` in `classes/content_chunker.php`**
+
+Add this method inside the `content_chunker` class (after `chunk`):
+```php
+    /**
+     * Reconstruct a module's chunks into one passage: keep the shared
+     * "[Section] Title:" prefix once, and remove the word overlap between
+     * consecutive chunks. Pure (no DB/provider) so it is unit-testable.
+     *
+     * @param string[] $contents Ordered chunk `content` strings for one module.
+     * @return string
+     */
+    public static function reconstruct(array $contents): string {
+        $contents = array_values($contents);
+        $n = count($contents);
+        if ($n === 0) {
+            return '';
+        }
+        if ($n === 1) {
+            return $contents[0];
+        }
+
+        // Longest common prefix across all chunks, cut at the last ": " so we
+        // only strip the "[Section] Title: " header, never shared body text.
+        $prefix = $contents[0];
+        foreach ($contents as $c) {
+            $max = min(strlen($prefix), strlen($c));
+            $i = 0;
+            while ($i < $max && $prefix[$i] === $c[$i]) {
+                $i++;
+            }
+            $prefix = substr($prefix, 0, $i);
+            if ($prefix === '') {
+                break;
+            }
+        }
+        $cut = strrpos($prefix, ': ');
+        $prefix = ($cut !== false) ? substr($prefix, 0, $cut + 2) : '';
+        $plen = strlen($prefix);
+
+        $result    = $contents[0];
+        $prevwords = preg_split('/\s+/', trim(substr($contents[0], $plen)), -1, PREG_SPLIT_NO_EMPTY);
+
+        for ($k = 1; $k < $n; $k++) {
+            $body     = trim(substr($contents[$k], $plen));
+            $curwords = preg_split('/\s+/', $body, -1, PREG_SPLIT_NO_EMPTY);
+            if (empty($curwords)) {
+                continue;
+            }
+            // Largest o such that the last o words of prev equal the first o of cur.
+            $cap = min(count($prevwords), count($curwords), 100);
+            $ov  = 0;
+            for ($o = $cap; $o >= 1; $o--) {
+                if (array_slice($prevwords, -$o) === array_slice($curwords, 0, $o)) {
+                    $ov = $o;
+                    break;
+                }
+            }
+            $newwords = array_slice($curwords, $ov);
+            if (!empty($newwords)) {
+                $result .= ' ' . implode(' ', $newwords);
+            }
+            $prevwords = $curwords;
+        }
+        return $result;
+    }
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `/opt/homebrew/opt/php@8.3/bin/php vendor/bin/phpunit local/ai_course_assistant/tests/content_chunker_test.php`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+/opt/homebrew/opt/php@8.3/bin/php -l classes/content_chunker.php
+git add classes/content_chunker.php tests/content_chunker_test.php
+git commit -m "feat(rag): content_chunker::reconstruct (de-overlap + prefix strip)"
+```
+
+---
+
+### Task 2: `rag_retriever::merge_parents()` — expand + dedup + cap
+
+**Files:**
+- Modify: `classes/rag_retriever.php`
+- Test: `tests/rag_retriever_test.php`
+
+**Interfaces:**
+- Consumes: `content_chunker::reconstruct` (Task 1).
+- Produces: `rag_retriever::merge_parents(array $topkrows, array $siblingsbycmid, string $mode, int $windowsize, int $maxchars): array`.
+  - `$topkrows`: final selected rows `{content, score, cmid, modtype, chunkindex, ...}`.
+  - `$siblingsbycmid`: `[cmid => [ ['content'=>string,'chunkindex'=>int], ... ]]` (all chunks for the cmids present).
+  - `$mode`: `'window'` | `'page'`. Returns rows with expanded `content`, deduped by `cmid` (first/highest-ranked hit wins), plus `expand_mode` and `expanded_from`. Rows with no `cmid` or no siblings pass through unchanged. Over-`$maxchars` pages fall back to a window, then to the single matched chunk.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/rag_retriever_test.php`:
+```php
+    public function test_merge_parents_page_dedupes_and_reconstructs() {
+        $prefix = "[U1] Intro: ";
+        $siblings = [510 => [
+            ['content' => $prefix . "alpha beta gamma", 'chunkindex' => 0],
+            ['content' => $prefix . "beta gamma delta epsilon", 'chunkindex' => 1],
+        ]];
+        // Two top-k hits from the same cmid -> collapse to one expanded page.
+        $topk = [
+            ['content' => $prefix . "beta gamma delta epsilon", 'score' => 0.9, 'cmid' => 510, 'chunkindex' => 1],
+            ['content' => $prefix . "alpha beta gamma", 'score' => 0.8, 'cmid' => 510, 'chunkindex' => 0],
+        ];
+        $out = \local_ai_course_assistant\rag_retriever::merge_parents($topk, $siblings, 'page', 1, 6000);
+        $this->assertCount(1, $out);
+        $this->assertSame($prefix . "alpha beta gamma delta epsilon", $out[0]['content']);
+        $this->assertSame('page', $out[0]['expand_mode']);
+        $this->assertSame(2, $out[0]['expanded_from']);
+        $this->assertSame(0.9, $out[0]['score']); // best score preserved
+    }
+
+    public function test_merge_parents_passthrough_without_cmid() {
+        $topk = [['content' => 'x', 'score' => 0.7, 'cmid' => null, 'chunkindex' => 0]];
+        $out = \local_ai_course_assistant\rag_retriever::merge_parents($topk, [], 'page', 1, 6000);
+        $this->assertSame($topk, $out);
+    }
+
+    public function test_merge_parents_cap_falls_back_to_chunk() {
+        $big = str_repeat('word ', 50);
+        $siblings = [7 => [
+            ['content' => $big . 'a', 'chunkindex' => 0],
+            ['content' => $big . 'b', 'chunkindex' => 1],
+            ['content' => $big . 'c', 'chunkindex' => 2],
+        ]];
+        $matched = $big . 'b';
+        $topk = [['content' => $matched, 'score' => 0.9, 'cmid' => 7, 'chunkindex' => 1]];
+        // maxchars smaller than any multi-chunk merge -> fall back to matched chunk.
+        $out = \local_ai_course_assistant\rag_retriever::merge_parents($topk, $siblings, 'page', 1, strlen($matched) + 5);
+        $this->assertSame($matched, $out[0]['content']);
+    }
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `/opt/homebrew/opt/php@8.3/bin/php vendor/bin/phpunit local/ai_course_assistant/tests/rag_retriever_test.php`
+Expected: FAIL — undefined method `merge_parents`.
+
+- [ ] **Step 3: Implement `merge_parents` in `classes/rag_retriever.php`**
+
+Add after `scope_to_document`:
+```php
+    /**
+     * Expand selected chunks into parent units (neighbor window or whole page),
+     * deduplicated by cmid, size-capped with fallback. Pure (no DB/provider).
+     *
+     * @param array  $topkrows       Final selected rows (post-rerank), rank-sorted.
+     * @param array  $siblingsbycmid [cmid => [ ['content'=>string,'chunkindex'=>int], ... ]]
+     * @param string $mode           'window' | 'page'.
+     * @param int    $windowsize     Neighbors each side for 'window' mode.
+     * @param int    $maxchars       Per-passage cap; over-cap pages fall back.
+     * @return array Expanded rows (same shape + 'expand_mode', 'expanded_from').
+     */
+    public static function merge_parents(array $topkrows, array $siblingsbycmid,
+            string $mode, int $windowsize, int $maxchars): array {
+        $out = [];
+        $seen = [];
+        foreach ($topkrows as $row) {
+            $cmid = (int) ($row['cmid'] ?? 0);
+            if ($cmid <= 0 || empty($siblingsbycmid[$cmid])) {
+                $out[] = $row;
+                continue;
+            }
+            if (isset($seen[$cmid])) {
+                continue; // page already emitted from a higher-ranked hit
+            }
+            $seen[$cmid] = true;
+
+            $siblings = $siblingsbycmid[$cmid];
+            usort($siblings, fn($a, $b) => ((int) $a['chunkindex']) <=> ((int) $b['chunkindex']));
+            $center = (int) ($row['chunkindex'] ?? 0);
+
+            $pick = function (int $win) use ($siblings, $center) {
+                return array_values(array_filter($siblings,
+                    fn($s) => abs(((int) $s['chunkindex']) - $center) <= $win));
+            };
+
+            $selected = ($mode === 'window') ? $pick($windowsize) : $siblings;
+            $merged = content_chunker::reconstruct(array_map(fn($s) => (string) $s['content'], $selected));
+
+            // Size cap: page -> window -> single matched chunk.
+            if (strlen($merged) > $maxchars) {
+                $selected = $pick(max(1, $windowsize));
+                $merged = content_chunker::reconstruct(array_map(fn($s) => (string) $s['content'], $selected));
+                if (strlen($merged) > $maxchars) {
+                    $selected = [['content' => (string) $row['content'], 'chunkindex' => $center]];
+                    $merged = (string) $row['content'];
+                }
+            }
+
+            $newrow = $row;
+            $newrow['content']       = $merged;
+            $newrow['expand_mode']   = $mode;
+            $newrow['expanded_from'] = count($selected);
+            $out[] = $newrow;
+        }
+        return $out;
+    }
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `/opt/homebrew/opt/php@8.3/bin/php vendor/bin/phpunit local/ai_course_assistant/tests/rag_retriever_test.php`
+Expected: PASS (existing tests + 3 new).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+/opt/homebrew/opt/php@8.3/bin/php -l classes/rag_retriever.php
+git add classes/rag_retriever.php tests/rag_retriever_test.php
+git commit -m "feat(rag): merge_parents — expand chunks to window/page, dedup, cap"
+```
+
+---
+
+### Task 3: Config settings
+
+**Files:**
+- Modify: `settings.php` (Content & RAG section)
+- Modify: `lang/en/local_ai_course_assistant.php`
+
+**Interfaces:**
+- Produces: config keys `rag_return_scope` (`chunk`|`window`|`page`, default `chunk`), `rag_window_size` (int, default 1), `rag_parent_max_chars` (int, default 6000).
+
+- [ ] **Step 1: Add English strings**
+
+In `lang/en/local_ai_course_assistant.php` add:
+```php
+$string['rag_return_scope'] = 'Retrieval return scope';
+$string['rag_return_scope_desc'] = 'What to inject for each retrieved hit. "chunk" (default) injects the matched ~400-word chunk. "window" injects the matched chunk plus neighbouring chunks from the same page. "page" injects the whole module page the match belongs to. window/page help when an answer spans a page, at the cost of a larger prompt.';
+$string['rag_window_size'] = 'Retrieval window size';
+$string['rag_window_size_desc'] = 'For "window" return scope: number of neighbouring chunks to include on each side of a matched chunk. Default 1.';
+$string['rag_parent_max_chars'] = 'Parent passage cap (characters)';
+$string['rag_parent_max_chars_desc'] = 'Maximum characters for an expanded window/page passage. Over-cap pages fall back to a window, then to the single chunk. Default 6000.';
+```
+
+- [ ] **Step 2: Register the settings in `settings.php`**
+
+In the Content & RAG settings page, after the existing `rag_chunksize` setting, add:
+```php
+    $settings->add(new admin_setting_configselect(
+        'local_ai_course_assistant/rag_return_scope',
+        get_string('rag_return_scope', 'local_ai_course_assistant'),
+        get_string('rag_return_scope_desc', 'local_ai_course_assistant'),
+        'chunk',
+        ['chunk' => 'chunk', 'window' => 'window', 'page' => 'page']
+    ));
+    $settings->add(new admin_setting_configtext(
+        'local_ai_course_assistant/rag_window_size',
+        get_string('rag_window_size', 'local_ai_course_assistant'),
+        get_string('rag_window_size_desc', 'local_ai_course_assistant'),
+        '1', PARAM_INT
+    ));
+    $settings->add(new admin_setting_configtext(
+        'local_ai_course_assistant/rag_parent_max_chars',
+        get_string('rag_parent_max_chars', 'local_ai_course_assistant'),
+        get_string('rag_parent_max_chars_desc', 'local_ai_course_assistant'),
+        '6000', PARAM_INT
+    ));
+```
+(Use the exact `$settings` variable name in scope at that point in `settings.php` — match the adjacent `rag_*` settings; if RAG settings are added to a differently-named settingpage object there, use that object.)
+
+- [ ] **Step 3: Lint + verify strings load**
+
+```bash
+/opt/homebrew/opt/php@8.3/bin/php -l settings.php
+/opt/homebrew/opt/php@8.3/bin/php -l lang/en/local_ai_course_assistant.php
+```
+Expected: no syntax errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add settings.php lang/en/local_ai_course_assistant.php
+git commit -m "feat(rag): rag_return_scope/window_size/parent_max_chars settings"
+```
+
+Note: before release, run the repo's i18n sync so the three keys land in all 45 non-English lang files (the completeness test fails otherwise).
+
+---
+
+### Task 4: Wire parent expansion into `retrieve()`
+
+**Files:**
+- Modify: `classes/rag_retriever.php` (`retrieve()` tail)
+
+**Interfaces:**
+- Consumes: `merge_parents` (Task 2), the new config (Task 3), `$DB`.
+
+- [ ] **Step 1: Read the current `retrieve()` tail**
+
+The method currently returns in two places: inside the rerank block (`return $out;`) and at the end (`return array_slice($scored, 0, $topk);`). Refactor so both feed one variable `$final`, then apply expansion once.
+
+- [ ] **Step 2: Replace the rerank block's early return**
+
+In the rerank block, change:
+```php
+                        if (!empty($out)) {
+                            return $out;
+                        }
+```
+to:
+```php
+                        if (!empty($out)) {
+                            $final = $out;
+                        }
+```
+and add, just before the `catch` closes the rerank attempt, nothing else (the fallthrough handles the rest).
+
+- [ ] **Step 3: Replace the final return with selection + expansion**
+
+Change the method's final line:
+```php
+        return array_slice($scored, 0, $topk);
+```
+to:
+```php
+        $final = $final ?? array_slice($scored, 0, $topk);
+
+        // Parent-document expansion (opt-in). Selection above is unchanged;
+        // here we optionally widen each hit to a neighbour window or full page.
+        $rawreturn = get_config('local_ai_course_assistant', 'rag_return_scope');
+        $returnscope = ($rawreturn === false || $rawreturn === '') ? 'chunk' : (string) $rawreturn;
+        if ($returnscope === 'chunk') {
+            return $final;
+        }
+        $rawwin = get_config('local_ai_course_assistant', 'rag_window_size');
+        $windowsize = ($rawwin === false || $rawwin === '') ? 1 : max(0, (int) $rawwin);
+        $rawcap = get_config('local_ai_course_assistant', 'rag_parent_max_chars');
+        $maxchars = ($rawcap === false || $rawcap === '') ? 6000 : max(500, (int) $rawcap);
+
+        $cmids = array_values(array_unique(array_filter(
+            array_map(fn($r) => (int) ($r['cmid'] ?? 0), $final))));
+        $siblingsbycmid = [];
+        if (!empty($cmids)) {
+            list($insql, $inparams) = $DB->get_in_or_equal($cmids, SQL_PARAMS_NAMED);
+            $rows = $DB->get_records_select(
+                'local_ai_course_assistant_chunks',
+                "courseid = :cid AND cmid {$insql}",
+                array_merge(['cid' => $courseid], $inparams),
+                'cmid, chunkindex',
+                'id, cmid, chunkindex, content'
+            );
+            foreach ($rows as $r) {
+                $siblingsbycmid[(int) $r->cmid][] = [
+                    'content'    => (string) $r->content,
+                    'chunkindex' => (int) $r->chunkindex,
+                ];
+            }
+        }
+        return self::merge_parents($final, $siblingsbycmid, $returnscope, $windowsize, $maxchars);
+```
+Also declare `$final = null;` near the top of `retrieve()` (just after `global $DB;`) so the `?? ` is defined even when rerank is off.
+
+- [ ] **Step 4: Lint**
+
+```bash
+/opt/homebrew/opt/php@8.3/bin/php -l classes/rag_retriever.php
+```
+Expected: no syntax errors.
+
+- [ ] **Step 5: Regression + live verification on dev**
+
+Deploy to dev and verify both regimes:
+```bash
+python3 deploy_dev.py --target dev
+```
+Then via SSM (as done for the earlier eyeball), for BUS101 (courseid 11), question "What is the difference between a sole proprietorship and a corporation, and how does liability differ?":
+- With `rag_return_scope=chunk`: output identical to today (fragments across cmids 510/509/508/504).
+- With `rag_return_scope=page`: fewer rows, each the full reconstructed page (no mid-sentence starts, `[2.1: Legal Forms of Business]` header once per page).
+Confirm the same via **Prompt Playground** (`/local/ai_course_assistant/prompt_playground.php`) live-retrieval box — it calls `retrieve()`, so expanded passages show automatically.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add classes/rag_retriever.php
+git commit -m "feat(rag): wire parent-document expansion into retrieve()"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** modes chunk/window/page (Tasks 3+4), dedup by cmid (Task 2), de-overlap + prefix strip (Task 1), char cap with fallback (Task 2), no schema change (uses existing `cmid`/`chunkindex`), selection path untouched (Task 4 only adds a tail step), playground/debug show expanded passages automatically because they call `retrieve()` (Task 4 Step 5). All covered.
+
+**Placeholder scan:** no TBD/TODO; every code step has complete code. The one soft spot is the `$settings` object name in Task 3 Step 2 — flagged explicitly to match the adjacent `rag_*` registration in `settings.php` rather than guessed.
+
+**Type consistency:** `reconstruct(array): string` used by `merge_parents` (Task 2) and `retrieve()` matches Task 1. `merge_parents(array,array,string,int,int): array` signature matches between Task 2 definition, its tests, and the Task 4 call. Config keys `rag_return_scope`/`rag_window_size`/`rag_parent_max_chars` are identical across Tasks 3 and 4. Row shape `{content,score,cmid,chunkindex,...}` matches what `retrieve()` already produces.
+
+**Evaluation note:** recall@k is unchanged (selection is unchanged), so the embedding/rerank benchmark does not measure this; the win is answer coherence on cross-page questions, evaluated via the real-student-question set (separate spec) and the live dev verification in Task 4 Step 5.

--- a/docs/superpowers/specs/2026-07-17-parent-document-retrieval-design.md
+++ b/docs/superpowers/specs/2026-07-17-parent-document-retrieval-design.md
@@ -1,0 +1,128 @@
+# Spec: Parent-document retrieval
+
+**Date:** 2026-07-17
+**Status:** Approved (brainstorming)
+**Component:** `local_ai_course_assistant` RAG retrieval
+
+## Goal
+
+Select on small chunks for precision, but return a larger *parent* unit (a
+neighbor window or the whole module page) to the LLM, so answers that span a
+page arrive as coherent passages instead of mid-sentence fragments. Uses the
+metadata chunks already carry (`cmid`, `chunkindex`); no new embedding model or
+vendor.
+
+## Motivation (measured)
+
+Live retrieval on dev, BUS101 (courseid 11), query "What is the difference
+between a sole proprietorship and a corporation, and how does liability
+differ?" returned 5 chunks spanning 4 pages of one book (cmids 510, 509, 508,
+504), several beginning mid-sentence ("difficult to setup...", "wanted the
+company to be owned by..."). The right content is present but arrives as
+disjoint ~400-word fragments. Handing the model the full page(s) those hits
+belong to gives a coherent, cross-page answer.
+
+## Current state (do not change the selection path)
+
+- Chunker (`classes/content_chunker.php`): paragraph-aware merge to ~400 words,
+  50-word overlap, each chunk prefixed `[Section] Title:`. Chunks store
+  `courseid, cmid, modtype, chunkindex, content, contenthash, embedding`.
+- Retriever (`classes/rag_retriever.php::retrieve`): embed query -> cosine over
+  course chunks -> relevance floor (`rag_min_similarity`, 0.25) -> current-page
+  boost -> scope (`rag_scope`, `document_first`) -> optional Voyage rerank
+  (`rerank_candidates` 50 -> top-k) -> returns top-k rows
+  `{content, score, cmid, modtype, chunkindex}`.
+
+Selection/ranking stays exactly as-is. Parent expansion is a **post-selection**
+step, so it composes cleanly with the floor, scope, and reranker (which keep
+operating on small chunks).
+
+## Design
+
+Add one config-gated step at the end of `retrieve()`: after the final top-k
+(post-rerank) rows are chosen, expand them into parents and de-duplicate.
+
+Modes (`rag_return_scope`):
+- `chunk` (default) - current behavior, return the matched chunk unchanged.
+- `window` - return the matched chunk plus +/- N neighbors by `chunkindex`
+  within the same `cmid` (`rag_window_size`, default 1).
+- `page` - return the whole module: all chunks for that `cmid`, ordered by
+  `chunkindex`, reconstructed into one passage.
+
+Mechanics:
+- **Dedup:** multiple top-k hits from the same `cmid` collapse to a single
+  expanded parent; it inherits the best (highest) score of its member hits for
+  ordering. So `page` mode never injects the same page twice.
+- **De-overlap + prefix strip:** because chunks overlap by 50 words and each
+  repeats the `[Section] Title:` prefix, reconstruction must (a) keep the prefix
+  only on the first segment, and (b) drop the duplicated overlap tail at each
+  join. This is the main correctness risk and gets a pure, unit-tested helper.
+- **Budget cap:** expanded parents are larger. A `rag_parent_max_chars` cap
+  (default 6000) bounds each returned passage; if a page exceeds it, fall back
+  to `window` (then `chunk`) for that hit. Expansion also participates in the
+  existing `prompt_budget_chars` / section-weight budgeting in
+  `context_builder` so page mode cannot blow the prompt.
+- **Return shape unchanged** except `content` is now the expanded text; add
+  `expand_mode` and `expanded_from` (member chunk count) for telemetry.
+  `context_builder` needs no change beyond receiving fuller passages.
+
+No DB schema change (uses existing columns).
+
+## Config (settings.php, RAG section)
+
+| Setting | Default | Meaning |
+|---|---|---|
+| `rag_return_scope` | `chunk` | `chunk` \| `window` \| `page`. Opt-in to expansion; default preserves current behavior. |
+| `rag_window_size` | `1` | Neighbors each side for `window` mode. |
+| `rag_parent_max_chars` | `6000` | Per-passage cap; over-cap pages fall back window -> chunk. |
+
+Per-course override via the existing per-course settings pattern
+(`rag_return_scope_course_<id>`), optional.
+
+## Implementation units
+
+1. `rag_retriever::expand_parents(array $rows, string $mode, int $courseid): array`
+   - For `window`/`page`, fetch the needed sibling chunks per `cmid` (one
+     `get_records_select` by `cmid`, ordered by `chunkindex`), reconstruct,
+     dedup by `cmid`, apply the char cap with fallback.
+2. `content_chunker::reconstruct(array $orderedchunks): string` - pure helper
+   that strips the repeated `[Section] Title:` prefix from all but the first
+   segment and removes the 50-word overlap at each join. Unit-tested.
+3. Wire `expand_parents()` into `retrieve()` after the top-k/rerank selection,
+   gated on `rag_return_scope !== 'chunk'`.
+4. `prompt_playground.php` and `prompt_debug_view.php` show the expanded
+   passage (so admins can inspect what actually gets injected).
+
+## Testing
+
+- Unit (`content_chunker::reconstruct`): overlap removed at joins; prefix kept
+  once; ordering by `chunkindex`; a single-chunk page returns unchanged.
+- Unit (`expand_parents`): `window` selects correct neighbors; `page` returns
+  full module; same-`cmid` hits dedup to one parent with the best score;
+  over-cap page falls back to window then chunk.
+- Integration (`retrieve`): `rag_return_scope=page` on the BUS101 liability
+  query returns whole "Legal Forms of Business" pages, not fragments;
+  `rag_return_scope=chunk` is byte-identical to today (regression guard).
+
+## Evaluation note
+
+Recall@k is a property of the small-chunk selection, which is unchanged, so the
+existing embedding/rerank benchmark does not measure this feature. The win is
+answer coherence/completeness on cross-page questions, which is a generation-
+quality signal - evaluate with the real-student-question set (separate spec)
+via answer grading, not recall@k.
+
+## Risks / trade-offs
+
+- Higher token cost per turn (bigger passages) - mitigated by the char cap,
+  budget integration, and default-off.
+- De-overlap correctness is the main implementation risk - isolated in the
+  tested pure helper.
+- Interaction with `document_first` scoping and rerank is safe: expansion runs
+  after both, on already-selected chunks.
+
+## Out of scope
+
+- Cross-document / graph retrieval (GraphRAG) - separate, program-level idea.
+- Changing chunk size/overlap or the embedding model.
+- Contextual/late chunking (separate embedding-side experiment).

--- a/lang/en/local_ai_course_assistant.php
+++ b/lang/en/local_ai_course_assistant.php
@@ -330,6 +330,12 @@ $string['settings:rag_scope_document_only'] = 'Document-only (restrict to the cu
 $string['settings:rag_scope_course'] = 'Course-wide (search all course content)';
 $string['settings:rag_chunksize'] = 'Chunk Size (words)';
 $string['settings:rag_chunksize_desc'] = 'Target number of words per content chunk when indexing course material. Smaller chunks are more precise; larger chunks provide more context.';
+$string['settings:rag_return_scope'] = 'Retrieval return scope';
+$string['settings:rag_return_scope_desc'] = 'What to inject for each retrieved hit. "chunk" (default) injects the matched ~400-word chunk. "window" injects the matched chunk plus neighbouring chunks from the same page. "page" injects the whole module page the match belongs to. window/page help when an answer spans a page, at the cost of a larger prompt.';
+$string['settings:rag_window_size'] = 'Retrieval window size';
+$string['settings:rag_window_size_desc'] = 'For "window" return scope: number of neighbouring chunks to include on each side of a matched chunk. Default 1.';
+$string['settings:rag_parent_max_chars'] = 'Parent passage cap (characters)';
+$string['settings:rag_parent_max_chars_desc'] = 'Maximum characters for an expanded window/page passage. Over-cap pages fall back to a window, then to the single chunk. Default 6000.';
 
 // v5.11.0: two-stage retrieval with Voyage rerank-2.5.
 // v6.1.0: heading strings (the block was orphaned without a group boundary).

--- a/settings.php
+++ b/settings.php
@@ -675,6 +675,28 @@ if ($hassiteconfig) {
         PARAM_INT
     ));
 
+    // Parent-document retrieval: what to inject for a retrieved hit (single
+    // chunk, a window of neighbouring chunks, or the whole page).
+    $settings->add(new admin_setting_configselect(
+        'local_ai_course_assistant/rag_return_scope',
+        get_string('settings:rag_return_scope', 'local_ai_course_assistant'),
+        get_string('settings:rag_return_scope_desc', 'local_ai_course_assistant'),
+        'chunk',
+        ['chunk' => 'chunk', 'window' => 'window', 'page' => 'page']
+    ));
+    $settings->add(new admin_setting_configtext(
+        'local_ai_course_assistant/rag_window_size',
+        get_string('settings:rag_window_size', 'local_ai_course_assistant'),
+        get_string('settings:rag_window_size_desc', 'local_ai_course_assistant'),
+        '1', PARAM_INT
+    ));
+    $settings->add(new admin_setting_configtext(
+        'local_ai_course_assistant/rag_parent_max_chars',
+        get_string('settings:rag_parent_max_chars', 'local_ai_course_assistant'),
+        get_string('settings:rag_parent_max_chars_desc', 'local_ai_course_assistant'),
+        '6000', PARAM_INT
+    ));
+
     // v5.11.0: two-stage retrieval with Voyage rerank-2.5.
     // v6.1.0: own heading — these five settings were orphaned after
     // rag_chunksize with no visual group boundary.

--- a/tests/content_chunker_test.php
+++ b/tests/content_chunker_test.php
@@ -48,4 +48,29 @@ class content_chunker_test extends \basic_testcase {
     public function test_reconstruct_empty() {
         $this->assertSame('', content_chunker::reconstruct([]));
     }
+
+    public function test_reconstruct_no_common_prefix() {
+        // No shared prefix and no ": " boundary -> prefix resolves to empty;
+        // chunks are simply de-overlapped and joined.
+        $out = content_chunker::reconstruct(["alpha beta", "gamma delta"]);
+        $this->assertSame("alpha beta gamma delta", $out);
+    }
+
+    public function test_reconstruct_three_chunks_ordering_and_deoverlap() {
+        $prefix = "[S] T: ";
+        // Each chunk overlaps the previous by exactly 2 words.
+        $c0 = $prefix . "one two three four";
+        $c1 = $prefix . "three four five six";
+        $c2 = $prefix . "five six seven eight";
+        $out = content_chunker::reconstruct([$c0, $c1, $c2]);
+        $this->assertSame(
+            $prefix . "one two three four five six seven eight",
+            $out
+        );
+        // Prefix header appears exactly once.
+        $this->assertSame(1, substr_count($out, "[S] T:"));
+        // Overlap words are not duplicated.
+        $this->assertSame(1, substr_count($out, "three four"));
+        $this->assertSame(1, substr_count($out, "five six"));
+    }
 }

--- a/tests/content_chunker_test.php
+++ b/tests/content_chunker_test.php
@@ -1,0 +1,51 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Unit tests for content_chunker::reconstruct().
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 AI Course Assistant
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class content_chunker_test extends \basic_testcase {
+    public function test_reconstruct_single_chunk_unchanged() {
+        $c = "[2.1: Legal Forms] Corporations: a corporation is a legal entity";
+        $this->assertSame($c, content_chunker::reconstruct([$c]));
+    }
+
+    public function test_reconstruct_dedupes_overlap_and_prefix() {
+        $prefix = "[2.1: Legal Forms] Corporations: ";
+        $c0 = $prefix . "a corporation is a legal entity separate from its owners";
+        // c1 = prefix + 4-word overlap tail of c0 + new body
+        $c1 = $prefix . "separate from its owners and can raise capital by issuing stock";
+        $out = content_chunker::reconstruct([$c0, $c1]);
+        $this->assertSame(
+            $prefix . "a corporation is a legal entity separate from its owners "
+                . "and can raise capital by issuing stock",
+            $out
+        );
+        // Prefix header appears exactly once.
+        $this->assertSame(1, substr_count($out, "Corporations:"));
+    }
+
+    public function test_reconstruct_empty() {
+        $this->assertSame('', content_chunker::reconstruct([]));
+    }
+}

--- a/tests/rag_retriever_test.php
+++ b/tests/rag_retriever_test.php
@@ -130,4 +130,43 @@ final class rag_retriever_test extends \advanced_testcase {
         $this->assertCount(3, rag_retriever::scope_to_document($ranked, 10, 'course'));
         $this->assertCount(3, rag_retriever::scope_to_document($ranked, 0, 'document_first'));
     }
+
+    public function test_merge_parents_page_dedupes_and_reconstructs() {
+        $prefix = "[U1] Intro: ";
+        $siblings = [510 => [
+            ['content' => $prefix . "alpha beta gamma", 'chunkindex' => 0],
+            ['content' => $prefix . "beta gamma delta epsilon", 'chunkindex' => 1],
+        ]];
+        // Two top-k hits from the same cmid -> collapse to one expanded page.
+        $topk = [
+            ['content' => $prefix . "beta gamma delta epsilon", 'score' => 0.9, 'cmid' => 510, 'chunkindex' => 1],
+            ['content' => $prefix . "alpha beta gamma", 'score' => 0.8, 'cmid' => 510, 'chunkindex' => 0],
+        ];
+        $out = \local_ai_course_assistant\rag_retriever::merge_parents($topk, $siblings, 'page', 1, 6000);
+        $this->assertCount(1, $out);
+        $this->assertSame($prefix . "alpha beta gamma delta epsilon", $out[0]['content']);
+        $this->assertSame('page', $out[0]['expand_mode']);
+        $this->assertSame(2, $out[0]['expanded_from']);
+        $this->assertSame(0.9, $out[0]['score']); // best score preserved
+    }
+
+    public function test_merge_parents_passthrough_without_cmid() {
+        $topk = [['content' => 'x', 'score' => 0.7, 'cmid' => null, 'chunkindex' => 0]];
+        $out = \local_ai_course_assistant\rag_retriever::merge_parents($topk, [], 'page', 1, 6000);
+        $this->assertSame($topk, $out);
+    }
+
+    public function test_merge_parents_cap_falls_back_to_chunk() {
+        $big = str_repeat('word ', 50);
+        $siblings = [7 => [
+            ['content' => $big . 'a', 'chunkindex' => 0],
+            ['content' => $big . 'b', 'chunkindex' => 1],
+            ['content' => $big . 'c', 'chunkindex' => 2],
+        ]];
+        $matched = $big . 'b';
+        $topk = [['content' => $matched, 'score' => 0.9, 'cmid' => 7, 'chunkindex' => 1]];
+        // maxchars smaller than any multi-chunk merge -> fall back to matched chunk.
+        $out = \local_ai_course_assistant\rag_retriever::merge_parents($topk, $siblings, 'page', 1, strlen($matched) + 5);
+        $this->assertSame($matched, $out[0]['content']);
+    }
 }

--- a/tests/rag_retriever_test.php
+++ b/tests/rag_retriever_test.php
@@ -169,4 +169,53 @@ final class rag_retriever_test extends \advanced_testcase {
         $out = \local_ai_course_assistant\rag_retriever::merge_parents($topk, $siblings, 'page', 1, strlen($matched) + 5);
         $this->assertSame($matched, $out[0]['content']);
     }
+
+    public function test_merge_parents_window_mode_selects_correct_neighbors() {
+        $prefix = "[U] T: ";
+        $siblings = [42 => [
+            ['content' => $prefix . "one", 'chunkindex' => 0],
+            ['content' => $prefix . "two", 'chunkindex' => 1],
+            ['content' => $prefix . "three", 'chunkindex' => 2],
+            ['content' => $prefix . "four", 'chunkindex' => 3],
+            ['content' => $prefix . "five", 'chunkindex' => 4],
+        ]];
+        $topk = [['content' => $prefix . "three", 'score' => 0.9, 'cmid' => 42, 'chunkindex' => 2]];
+        $out = \local_ai_course_assistant\rag_retriever::merge_parents($topk, $siblings, 'window', 1, 6000);
+        $this->assertCount(1, $out);
+        // Window is chunkindex 1,2,3 only ("two three four") -- 0 and 4 excluded.
+        $this->assertSame($prefix . "two three four", $out[0]['content']);
+        $this->assertSame('window', $out[0]['expand_mode']);
+        $this->assertSame(3, $out[0]['expanded_from']);
+    }
+
+    public function test_merge_parents_page_over_cap_falls_back_to_window() {
+        $prefix = "[P] X: ";
+        // Distinct 100-char bodies per chunk (no shared words -> no de-overlap
+        // collapsing), so reconstructed lengths are exactly predictable:
+        //   full page (5 chunks): 7 + 5*100 + 4 spaces = 511 chars
+        //   ±1 window (3 chunks): 7 + 3*100 + 2 spaces = 309 chars
+        $words = [];
+        for ($i = 0; $i < 5; $i++) {
+            $words[$i] = str_repeat(chr(97 + $i), 100); // 'a'*100 .. 'e'*100
+        }
+        $siblings = [99 => [
+            ['content' => $prefix . $words[0], 'chunkindex' => 0],
+            ['content' => $prefix . $words[1], 'chunkindex' => 1],
+            ['content' => $prefix . $words[2], 'chunkindex' => 2],
+            ['content' => $prefix . $words[3], 'chunkindex' => 3],
+            ['content' => $prefix . $words[4], 'chunkindex' => 4],
+        ]];
+        $topk = [['content' => $prefix . $words[2], 'score' => 0.9, 'cmid' => 99, 'chunkindex' => 2]];
+        // maxchars=400: page (511) > cap >= window (309) -> falls back to window,
+        // not all the way to the single matched chunk.
+        $out = \local_ai_course_assistant\rag_retriever::merge_parents($topk, $siblings, 'page', 1, 400);
+        $this->assertCount(1, $out);
+        $content = $out[0]['content'];
+        $this->assertStringContainsString($words[1], $content);
+        $this->assertStringContainsString($words[2], $content);
+        $this->assertStringContainsString($words[3], $content);
+        $this->assertStringNotContainsString($words[0], $content);
+        $this->assertStringNotContainsString($words[4], $content);
+        $this->assertSame(3, $out[0]['expanded_from']);
+    }
 }


### PR DESCRIPTION
## Why
RAG currently injects ~400-word chunks. On cross-page questions the answer arrives as disjoint fragments (measured on dev BUS101 "sole proprietorship vs corporation, liability": 5 chunks across 4 pages of one book, several starting mid-sentence). This adds an opt-in step to return coherent parent context.

## What
A **config-gated, post-selection** expansion in `rag_retriever::retrieve()`. Selection/floor/scope/rerank are unchanged and still operate on small chunks; expansion runs on the final top-k, dedups by `cmid`, de-overlaps the 50-word joins and repeated `[Section] Title:` prefix, and caps size with a page→window→chunk fallback. No DB schema change (uses existing `cmid`/`chunkindex`).

- `content_chunker::reconstruct()` — pure de-overlap + prefix-strip helper
- `rag_retriever::merge_parents()` — expand to window/page, dedup, cap (pure)
- `retrieve()` wiring — reads new settings, loads siblings, expands
- New settings: `rag_return_scope` (chunk|window|page, **default chunk = today's behavior**), `rag_window_size` (1), `rag_parent_max_chars` (6000)
- Spec + plan under `docs/superpowers/`

## Tests & verification
- Pure-function unit tests: `content_chunker_test` 5/5, `rag_retriever_test` 15/15 (window mode, page mode, dedup, cap→window→chunk fallback, reconstruct edge cases).
- **Chunk-mode (default) byte-identity**: proven via control-flow review (every non-empty return path rewired through `$final`; `rag_return_scope` defaults to `chunk` → early return of the unchanged selection).
- **Live check on dev**: ran `reconstruct()` against real BUS101 chunks — pages rebuild coherently (prefix once, no mid-sentence fragments); confirmed a 15-chunk/41KB page correctly trips the cap→window fallback.
- Final whole-branch review (opus): **APPROVE WITH MINORS**, no Critical/blocking.

## Deferred (from the final review; tracked, not blockers)
- A full `retrieve()` integration/regression test (needs embedding-provider mocking; default byte-identity already proven statically + verified live).
- Window-mode union-of-windows for far same-page hits; `windowsize=0` cosmetic; per-course override (spec-optional); reconstruct whitespace-flatten on appended chunks (intended).
- **i18n:** the 3 new settings strings are `lang/en` only — needs the 45-language sync before a tagged release.

## Rollout
Ships **off** (`rag_return_scope=chunk`). Enable per-site (or later per-course) after the real-question eval set exists to measure it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)