### PR TITLE
feat(rag): label-free judge-mode benchmark (--judge)

### DIFF
--- a/admin/cli/run_rag_fixture_benchmark.php
+++ b/admin/cli/run_rag_fixture_benchmark.php
@@ -258,6 +258,111 @@ if ($judgemode) {
     }
     echo "\n";
 
+    // Family B: embedding-provider arms via in-memory re-embed (bare cosine,
+    // no rerank/scope/parent-doc). Comparable to the embedding A/B, judged.
+    $famB = [
+        ['label' => 'openai:3-small', 'prov' => 'openai', 'model' => 'text-embedding-3-small', 'dim' => 1536, 'key' => ($openaiapikey ?: $judgekey)],
+        ['label' => 'voyage:3.5',     'prov' => 'voyage', 'model' => 'voyage-3.5',            'dim' => 1024, 'key' => $voyageapikey],
+    ];
+    $origB = [
+        'embed_provider'   => get_config('local_ai_course_assistant', 'embed_provider'),
+        'embed_model'      => get_config('local_ai_course_assistant', 'embed_model'),
+        'embed_apikey'     => get_config('local_ai_course_assistant', 'embed_apikey'),
+        'embed_dimensions' => get_config('local_ai_course_assistant', 'embed_dimensions'),
+    ];
+    $restoreB = function () use ($origB) {
+        foreach ($origB as $k => $v) {
+            set_config($k, ($v === false) ? null : $v, 'local_ai_course_assistant');
+        }
+    };
+    register_shutdown_function($restoreB);
+
+    // Preload chunk contents for the courses referenced by the sampled questions.
+    $courseids = array_values(array_unique(array_map(fn($q) => $q['courseid'], $qitems)));
+    $bcontents = [];
+    foreach ($courseids as $cid) {
+        $rows = $DB->get_records_select('local_ai_course_assistant_chunks',
+            'courseid = :cid', ['cid' => $cid], '', 'id, content');
+        foreach ($rows as $row) {
+            if (trim((string) $row->content) !== '') {
+                $bcontents[$cid][(int) $row->id] = (string) $row->content;
+            }
+        }
+    }
+
+    $resultsB = [];
+    foreach ($famB as $arm) {
+        if (empty($arm['key'])) {
+            echo "  (skip {$arm['label']}: no API key)\n";
+            continue;
+        }
+        $restoreB();
+        set_config('embed_provider', $arm['prov'], 'local_ai_course_assistant');
+        set_config('embed_model', $arm['model'], 'local_ai_course_assistant');
+        set_config('embed_dimensions', $arm['dim'], 'local_ai_course_assistant');
+        set_config('embed_apikey', $arm['key'], 'local_ai_course_assistant');
+        try {
+            $prov = base_embedding_provider::create_from_config();
+        } catch (\Throwable $e) {
+            echo "  (skip {$arm['label']}: provider error: " . mb_substr($e->getMessage(), 0, 100) . ")\n";
+            $restoreB();
+            continue;
+        }
+        $isvoyage = $prov instanceof \local_ai_course_assistant\embedding_provider\voyage_embedding_provider;
+
+        // Re-embed each course's chunk contents (document vectors), sliced.
+        $vecs = [];
+        foreach ($bcontents as $cid => $contents) {
+            $ids = array_keys($contents);
+            $texts = array_values($contents);
+            for ($off = 0; $off < count($texts); $off += $abbatch) {
+                $embs = $prov->embed_batch(array_slice($texts, $off, $abbatch));
+                foreach (array_slice($ids, $off, $abbatch) as $j => $chunkid) {
+                    $vecs[$cid][$chunkid] = $embs[$j];
+                }
+            }
+        }
+
+        $ndcg = $prec = $hit = $mean = 0.0; $scored = 0; $errors = 0;
+        foreach ($qitems as $q) {
+            $cid = $q['courseid'];
+            $qvec = $isvoyage ? $prov->embed_query($q['question']) : $prov->embed($q['question']);
+            if (empty($qvec) || empty($vecs[$cid])) { $scored++; continue; }
+            $scoredchunks = [];
+            foreach ($vecs[$cid] as $chunkid => $vec) {
+                $scoredchunks[] = ['id' => $chunkid, 's' => cosine_sim($qvec, $vec)];
+            }
+            usort($scoredchunks, fn($a, $b) => $b['s'] <=> $a['s']);
+            $passages = [];
+            foreach (array_slice($scoredchunks, 0, $topk) as $sc) {
+                $passages[] = $bcontents[$cid][$sc['id']];
+            }
+            $grades = judge_passages($q['question'], $passages, $judgemodel, $judgekey);
+            if ($grades === null) { $errors++; continue; }
+            $ndcg += \local_ai_course_assistant\rag_judge::ndcg_at_k($grades, $topk);
+            $prec += \local_ai_course_assistant\rag_judge::precision_at_k($grades, $topk);
+            $hit  += \local_ai_course_assistant\rag_judge::hit_at_k($grades, $topk);
+            $mean += \local_ai_course_assistant\rag_judge::mean_relevance($grades, $topk);
+            $scored++;
+        }
+        $n = max(1, $scored);
+        $resultsB[] = ['arm' => $arm['label'], 'ndcg' => $ndcg / $n, 'precision' => $prec / $n,
+                       'hit' => $hit / $n, 'mean_rel' => $mean / $n, 'scored' => $scored, 'errors' => $errors];
+        printf("  %-15s nDCG@%d=%.3f  P@%d=%.3f  hit@%d=%.3f  mean=%.2f  (scored %d, judge-err %d)\n",
+            $arm['label'], $topk, $ndcg / $n, $topk, $prec / $n, $topk, $hit / $n, $mean / $n, $scored, $errors);
+        $restoreB();
+    }
+    $restoreB();
+
+    echo "\n" . str_repeat('=', 64) . "\n";
+    echo "FAMILY B (embedding provider, in-memory re-embed, bare cosine)\n";
+    echo str_repeat('=', 64) . "\n";
+    foreach ($resultsB as $r) {
+        printf("  %-15s nDCG=%.3f  P@k=%.3f  hit@k=%.3f  mean=%.2f\n",
+            $r['arm'], $r['ndcg'], $r['precision'], $r['hit'], $r['mean_rel']);
+    }
+    echo "\n";
+
     $out = [
         'run_at'     => date('c'),
         'mode'       => 'judge',
@@ -265,6 +370,7 @@ if ($judgemode) {
         'topk'       => $topk,
         'n'          => count($qitems),
         'family_a'   => $resultsA,
+        'family_b'   => $resultsB,
     ];
     file_put_contents($outfile, json_encode($out, JSON_PRETTY_PRINT));
     echo "Results written to: {$outfile}\n";

--- a/admin/cli/run_rag_fixture_benchmark.php
+++ b/admin/cli/run_rag_fixture_benchmark.php
@@ -74,6 +74,11 @@ $openaiapikey = '';
 $voyageapikey = '';
 $abbatch = 96; // Chunk re-embed slice size; bounds per-call token usage for both providers.
 
+$judgemode     = false;
+$questionspath = '';
+$samplesize    = 100;
+$judgemodel    = 'gpt-4o-mini';
+
 foreach ($argv as $arg) {
     if (preg_match('/^--fixtures=(.+)$/', $arg, $m)) {
         $fixturespath = trim($m[1]);
@@ -93,6 +98,14 @@ foreach ($argv as $arg) {
         $openaiapikey = trim($m[1]);
     } else if (preg_match('/^--voyage-apikey=(.+)$/', $arg, $m)) {
         $voyageapikey = trim($m[1]);
+    } else if ($arg === '--judge') {
+        $judgemode = true;
+    } else if (preg_match('/^--questions=(.+)$/', $arg, $m)) {
+        $questionspath = trim($m[1]);
+    } else if (preg_match('/^--sample=(\d+)$/', $arg, $m)) {
+        $samplesize = max(1, (int) $m[1]);
+    } else if (preg_match('/^--judge-model=(.+)$/', $arg, $m)) {
+        $judgemodel = trim($m[1]);
     } else if ($arg === '--help' || $arg === '-h') {
         echo <<<TXT
 Usage: php run_rag_fixture_benchmark.php [options]
@@ -159,6 +172,104 @@ if (!is_array($fixturedoc) || empty($fixturedoc['fixtures'])) {
 }
 $fixtures = $fixturedoc['fixtures'];
 echo "Loaded " . count($fixtures) . " fixtures from " . basename($fixturespath) . "\n";
+
+// ---------- Judge mode (2026-07-18): label-free LLM relevance grading ----------
+if ($judgemode) {
+    // ---------- Judge mode: label-free relevance grading ----------
+    $qpath = $questionspath !== ''
+        ? (($questionspath[0] === '/') ? $questionspath : __DIR__ . '/../../' . $questionspath)
+        : __DIR__ . '/../../tests/golden/rag_fixtures_synthetic_1000.json';
+    $qdoc = json_decode((string) file_get_contents($qpath), true);
+    $qsrc = $qdoc['questions'] ?? $qdoc['fixtures'] ?? [];
+    $qitems = [];
+    foreach ($qsrc as $i => $row) {
+        if (!empty($row['question']) && !empty($row['courseid'])) {
+            $qitems[] = [
+                'id'       => (string) ($row['id'] ?? $i),
+                'courseid' => (int) $row['courseid'],
+                'question' => (string) $row['question'],
+            ];
+        }
+    }
+    usort($qitems, fn($a, $b) => strcmp($a['id'], $b['id']));
+    $qitems = array_slice($qitems, 0, $samplesize);
+
+    $judgekey = get_config('local_ai_course_assistant', 'embed_apikey');
+    if ($judgekey === false || $judgekey === '') {
+        $judgekey = (string) get_config('local_ai_course_assistant', 'apikey');
+    }
+    if ($openaiapikey !== '') {
+        $judgekey = $openaiapikey;
+    }
+    if ($judgekey === '') {
+        fwrite(STDERR, "ERROR: no OpenAI key for the judge (set embed_apikey/apikey or --openai-apikey)\n");
+        exit(1);
+    }
+
+    echo "JUDGE MODE: " . count($qitems) . " questions, judge={$judgemodel}, top-k={$topk}\n";
+    echo str_repeat('=', 64) . "\n\n";
+
+    // Family A: pipeline-config arms via the real retriever.
+    $famA = [
+        ['label' => 'return=chunk', 'cfg' => ['rag_return_scope' => 'chunk']],
+        ['label' => 'return=page',  'cfg' => ['rag_return_scope' => 'page']],
+        ['label' => 'rerank=off',   'cfg' => ['rerank_enabled' => '0']],
+        ['label' => 'rerank=on',    'cfg' => ['rerank_enabled' => '1']],
+    ];
+    $touched = ['rag_return_scope', 'rerank_enabled'];
+    $origA = [];
+    foreach ($touched as $key) {
+        $origA[$key] = get_config('local_ai_course_assistant', $key);
+    }
+    $restoreA = function () use ($origA) {
+        foreach ($origA as $k => $v) {
+            set_config($k, ($v === false) ? null : $v, 'local_ai_course_assistant');
+        }
+    };
+    register_shutdown_function($restoreA);
+
+    $resultsA = [];
+    foreach ($famA as $arm) {
+        $restoreA();
+        foreach ($arm['cfg'] as $k => $v) {
+            set_config($k, $v, 'local_ai_course_assistant');
+        }
+        $per = judge_arm($qitems, $topk, $judgemodel, $judgekey);
+        $resultsA[] = ['arm' => $arm['label']] + $per;
+        printf("  %-13s nDCG@%d=%.3f  P@%d=%.3f  hit@%d=%.3f  mean=%.2f  (scored %d, judge-err %d)\n",
+            $arm['label'], $topk, $per['ndcg'], $topk, $per['precision'], $topk, $per['hit'],
+            $per['mean_rel'], $per['scored'], $per['errors']);
+    }
+    $restoreA();
+
+    echo "\n" . str_repeat('=', 64) . "\n";
+    echo "FAMILY A (pipeline config, via live retriever)\n";
+    echo str_repeat('=', 64) . "\n";
+    $hdr = ['Arm', 'nDCG', 'P@k', 'hit@k', 'mean'];
+    echo implode(' | ', array_map(fn($h) => str_pad($h, 13), $hdr)) . "\n";
+    foreach ($resultsA as $r) {
+        echo implode(' | ', [
+            str_pad($r['arm'], 13),
+            str_pad(sprintf('%.3f', $r['ndcg']), 13),
+            str_pad(sprintf('%.3f', $r['precision']), 13),
+            str_pad(sprintf('%.3f', $r['hit']), 13),
+            str_pad(sprintf('%.2f', $r['mean_rel']), 13),
+        ]) . "\n";
+    }
+    echo "\n";
+
+    $out = [
+        'run_at'     => date('c'),
+        'mode'       => 'judge',
+        'judge'      => $judgemodel,
+        'topk'       => $topk,
+        'n'          => count($qitems),
+        'family_a'   => $resultsA,
+    ];
+    file_put_contents($outfile, json_encode($out, JSON_PRETTY_PRINT));
+    echo "Results written to: {$outfile}\n";
+    exit(0);
+}
 
 // ---------- Embedding provider A/B mode (2026-07-08) ----------
 // When one or more --embed-provider arms are supplied, run a head-to-head
@@ -499,6 +610,94 @@ function cosine_sim(array $a, array $b): float {
         return 0.0;
     }
     return $dot / (sqrt($norma) * sqrt($normb));
+}
+
+// ---------- Judge-mode helpers (2026-07-18) ----------
+
+/**
+ * LLM-grade each passage 0-3 for relevance to the question (one batched call).
+ * Returns exactly count($passages) grades, or null on judge/parse failure.
+ *
+ * @return int[]|null
+ */
+function judge_passages(string $question, array $passages, string $model, string $apikey): ?array {
+    $k = count($passages);
+    if ($k === 0) {
+        return [];
+    }
+    $lines = [];
+    foreach ($passages as $i => $p) {
+        $lines[] = 'PASSAGE ' . ($i + 1) . ":\n" . mb_substr((string) $p, 0, 1500);
+    }
+    $sys = "You grade how well each passage answers a student's question, for a retrieval-quality eval. "
+        . "Grade each passage 0-3: 0 = irrelevant, 1 = tangentially related, 2 = relevant / partially answers, "
+        . "3 = directly answers. Return ONLY a JSON array of {$k} integers, one grade per passage in order, "
+        . "e.g. [3,1,0,2,0].";
+    $user = 'QUESTION: ' . $question . "\n\n" . implode("\n\n", $lines);
+    $payload = json_encode([
+        'model' => $model,
+        'messages' => [
+            ['role' => 'system', 'content' => $sys],
+            ['role' => 'user', 'content' => $user],
+        ],
+        'temperature' => 0,
+    ]);
+    for ($attempt = 0; $attempt < 4; $attempt++) {
+        $c = curl_init('https://api.openai.com/v1/chat/completions');
+        curl_setopt_array($c, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_POST => true,
+            CURLOPT_HTTPHEADER => ['Content-Type: application/json', 'Authorization: Bearer ' . $apikey],
+            CURLOPT_POSTFIELDS => $payload,
+            CURLOPT_TIMEOUT => 60,
+        ]);
+        $resp = curl_exec($c);
+        $code = curl_getinfo($c, CURLINFO_HTTP_CODE);
+        curl_close($c);
+        if ($code === 429 || $code >= 500) {
+            sleep(3);
+            continue;
+        }
+        if ($code !== 200 || !$resp) {
+            return null;
+        }
+        $body = json_decode($resp, true);
+        $content = $body['choices'][0]['message']['content'] ?? '';
+        return \local_ai_course_assistant\rag_judge::parse_grades($content, $k);
+    }
+    return null;
+}
+
+/**
+ * Run the live retriever over the questions under the current config and judge
+ * the returned passages. Returns aggregate metrics for one arm.
+ */
+function judge_arm(array $qitems, int $topk, string $model, string $key): array {
+    $ndcg = $prec = $hit = $mean = 0.0;
+    $scored = 0;
+    $errors = 0;
+    foreach ($qitems as $q) {
+        $res = \local_ai_course_assistant\rag_retriever::retrieve($q['courseid'], $q['question'], $topk, 0);
+        $passages = array_map(fn($r) => (string) $r['content'], $res);
+        if (empty($passages)) {
+            // Retrieval returned nothing -> zero relevance for this question.
+            $scored++;
+            continue;
+        }
+        $grades = judge_passages($q['question'], $passages, $model, $key);
+        if ($grades === null) {
+            $errors++;
+            continue;
+        }
+        $ndcg += \local_ai_course_assistant\rag_judge::ndcg_at_k($grades, $topk);
+        $prec += \local_ai_course_assistant\rag_judge::precision_at_k($grades, $topk);
+        $hit  += \local_ai_course_assistant\rag_judge::hit_at_k($grades, $topk);
+        $mean += \local_ai_course_assistant\rag_judge::mean_relevance($grades, $topk);
+        $scored++;
+    }
+    $n = max(1, $scored);
+    return ['ndcg' => $ndcg / $n, 'precision' => $prec / $n, 'hit' => $hit / $n,
+            'mean_rel' => $mean / $n, 'scored' => $scored, 'errors' => $errors];
 }
 
 // ---------- Run each fixture ----------

--- a/admin/cli/run_rag_fixture_benchmark.php
+++ b/admin/cli/run_rag_fixture_benchmark.php
@@ -724,6 +724,10 @@ function cosine_sim(array $a, array $b): float {
  * LLM-grade each passage 0-3 for relevance to the question (one batched call).
  * Returns exactly count($passages) grades, or null on judge/parse failure.
  *
+ * @param string $question The learner question.
+ * @param string[] $passages Retrieved passage texts in rank order.
+ * @param string $model Judge model id.
+ * @param string $apikey OpenAI API key.
  * @return int[]|null
  */
 function judge_passages(string $question, array $passages, string $model, string $apikey): ?array {
@@ -777,6 +781,12 @@ function judge_passages(string $question, array $passages, string $model, string
 /**
  * Run the live retriever over the questions under the current config and judge
  * the returned passages. Returns aggregate metrics for one arm.
+ *
+ * @param array $qitems Question rows, each ['courseid' => int, 'question' => string].
+ * @param int $topk Passages to retrieve and judge per question.
+ * @param string $model Judge model id.
+ * @param string $key OpenAI API key for the judge.
+ * @return array
  */
 function judge_arm(array $qitems, int $topk, string $model, string $key): array {
     $ndcg = $prec = $hit = $mean = 0.0;

--- a/classes/rag_judge.php
+++ b/classes/rag_judge.php
@@ -41,14 +41,20 @@ class rag_judge {
         return $idcg > 0 ? $dcg / $idcg : 0.0;
     }
 
-    /** Fraction of the top-k passages graded >= threshold. */
+    /**
+     * Fraction of the top-k passages graded >= threshold.
+     *
+     * Divides by $k (not count($grades)) so arms that return fewer than k
+     * passages (e.g. page-mode dedups) are comparable: missing slots count
+     * as not-relevant / grade 0, per standard precision@k semantics.
+     */
     public static function precision_at_k(array $grades, int $k, int $threshold = 2): float {
-        $g = array_slice(array_map('intval', $grades), 0, $k);
-        if (empty($g)) {
+        if ($k <= 0) {
             return 0.0;
         }
+        $g = array_slice(array_map('intval', $grades), 0, $k);
         $rel = count(array_filter($g, fn($x) => $x >= $threshold));
-        return $rel / count($g);
+        return $rel / $k;
     }
 
     /** 1 if any top-k passage is graded >= threshold, else 0. */
@@ -61,13 +67,18 @@ class rag_judge {
         return 0;
     }
 
-    /** Mean grade over the top-k passages. */
+    /**
+     * Mean grade over the top-k passages.
+     *
+     * Divides by $k (not count($grades)) so arms that return fewer than k
+     * passages are comparable: missing slots count as grade 0.
+     */
     public static function mean_relevance(array $grades, int $k): float {
-        $g = array_slice(array_map('intval', $grades), 0, $k);
-        if (empty($g)) {
+        if ($k <= 0) {
             return 0.0;
         }
-        return array_sum($g) / count($g);
+        $g = array_slice(array_map('intval', $grades), 0, $k);
+        return array_sum($g) / $k;
     }
 
     /**

--- a/classes/rag_judge.php
+++ b/classes/rag_judge.php
@@ -1,0 +1,97 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+
+/**
+ * Pure scoring + parse helpers for the RAG judge-mode benchmark.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class rag_judge {
+
+    /** nDCG@k using graded relevance (gain = 2^grade - 1). 0.0 when nothing is relevant. */
+    public static function ndcg_at_k(array $grades, int $k): float {
+        $g = array_slice(array_map('intval', $grades), 0, $k);
+        $dcg = 0.0;
+        foreach ($g as $i => $gi) {
+            $dcg += (pow(2, $gi) - 1) / log($i + 2, 2);
+        }
+        $ideal = $g;
+        rsort($ideal);
+        $idcg = 0.0;
+        foreach ($ideal as $i => $gi) {
+            $idcg += (pow(2, $gi) - 1) / log($i + 2, 2);
+        }
+        return $idcg > 0 ? $dcg / $idcg : 0.0;
+    }
+
+    /** Fraction of the top-k passages graded >= threshold. */
+    public static function precision_at_k(array $grades, int $k, int $threshold = 2): float {
+        $g = array_slice(array_map('intval', $grades), 0, $k);
+        if (empty($g)) {
+            return 0.0;
+        }
+        $rel = count(array_filter($g, fn($x) => $x >= $threshold));
+        return $rel / count($g);
+    }
+
+    /** 1 if any top-k passage is graded >= threshold, else 0. */
+    public static function hit_at_k(array $grades, int $k, int $threshold = 2): int {
+        foreach (array_slice(array_map('intval', $grades), 0, $k) as $x) {
+            if ($x >= $threshold) {
+                return 1;
+            }
+        }
+        return 0;
+    }
+
+    /** Mean grade over the top-k passages. */
+    public static function mean_relevance(array $grades, int $k): float {
+        $g = array_slice(array_map('intval', $grades), 0, $k);
+        if (empty($g)) {
+            return 0.0;
+        }
+        return array_sum($g) / count($g);
+    }
+
+    /**
+     * Parse a judge reply into exactly $expected integer grades clamped to 0-3.
+     * Extracts the first JSON array in the reply. Returns null on parse failure
+     * or length mismatch (so the caller can count a judge error, never zero-fill).
+     *
+     * @return int[]|null
+     */
+    public static function parse_grades(string $reply, int $expected): ?array {
+        if (!preg_match('/\[[\s\S]*?\]/', $reply, $m)) {
+            return null;
+        }
+        $arr = json_decode($m[0], true);
+        if (!is_array($arr) || count($arr) !== $expected) {
+            return null;
+        }
+        $out = [];
+        foreach ($arr as $v) {
+            if (!is_numeric($v)) {
+                return null;
+            }
+            $out[] = max(0, min(3, (int) $v));
+        }
+        return $out;
+    }
+}

--- a/classes/rag_judge.php
+++ b/classes/rag_judge.php
@@ -25,7 +25,13 @@ namespace local_ai_course_assistant;
  */
 class rag_judge {
 
-    /** nDCG@k using graded relevance (gain = 2^grade - 1). 0.0 when nothing is relevant. */
+    /**
+     * nDCG@k using graded relevance (gain = 2^grade - 1). 0.0 when nothing is relevant.
+     *
+     * @param int[] $grades Per-passage relevance grades in rank order.
+     * @param int $k Cutoff.
+     * @return float
+     */
     public static function ndcg_at_k(array $grades, int $k): float {
         $g = array_slice(array_map('intval', $grades), 0, $k);
         $dcg = 0.0;
@@ -47,6 +53,11 @@ class rag_judge {
      * Divides by $k (not count($grades)) so arms that return fewer than k
      * passages (e.g. page-mode dedups) are comparable: missing slots count
      * as not-relevant / grade 0, per standard precision@k semantics.
+     *
+     * @param int[] $grades Per-passage relevance grades in rank order.
+     * @param int $k Cutoff.
+     * @param int $threshold Minimum grade counted as relevant.
+     * @return float
      */
     public static function precision_at_k(array $grades, int $k, int $threshold = 2): float {
         if ($k <= 0) {
@@ -57,7 +68,14 @@ class rag_judge {
         return $rel / $k;
     }
 
-    /** 1 if any top-k passage is graded >= threshold, else 0. */
+    /**
+     * 1 if any top-k passage is graded >= threshold, else 0.
+     *
+     * @param int[] $grades Per-passage relevance grades in rank order.
+     * @param int $k Cutoff.
+     * @param int $threshold Minimum grade counted as relevant.
+     * @return int
+     */
     public static function hit_at_k(array $grades, int $k, int $threshold = 2): int {
         foreach (array_slice(array_map('intval', $grades), 0, $k) as $x) {
             if ($x >= $threshold) {
@@ -72,6 +90,10 @@ class rag_judge {
      *
      * Divides by $k (not count($grades)) so arms that return fewer than k
      * passages are comparable: missing slots count as grade 0.
+     *
+     * @param int[] $grades Per-passage relevance grades in rank order.
+     * @param int $k Cutoff.
+     * @return float
      */
     public static function mean_relevance(array $grades, int $k): float {
         if ($k <= 0) {
@@ -86,6 +108,8 @@ class rag_judge {
      * Extracts the first JSON array in the reply. Returns null on parse failure
      * or length mismatch (so the caller can count a judge error, never zero-fill).
      *
+     * @param string $reply Raw judge reply text.
+     * @param int $expected Required number of grades.
      * @return int[]|null
      */
     public static function parse_grades(string $reply, int $expected): ?array {

--- a/docs/superpowers/plans/2026-07-18-rag-judge-mode-harness.md
+++ b/docs/superpowers/plans/2026-07-18-rag-judge-mode-harness.md
@@ -1,0 +1,580 @@
+# RAG judge-mode harness — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `--judge` mode to `admin/cli/run_rag_fixture_benchmark.php` that grades retrieved-passage relevance with an LLM (label-free) and compares configs — Family A (chunk/page, rerank) via the real retriever, Family B (OpenAI/Voyage) via in-memory re-embed.
+
+**Architecture:** Pure metric + parse logic in a new testable class `classes/rag_judge.php` (unit-tested). The `--judge` block in the CLI orchestrates: load unlabeled questions → per arm, retrieve (or re-embed) → LLM-grade each passage 0-3 → aggregate metrics. Config is flipped per Family-A arm and restored on exit (existing `register_shutdown_function` pattern). Runs on dev via SSM.
+
+**Tech Stack:** PHP 8.3, Moodle plugin, PHPUnit, `curl` to OpenAI chat completions.
+
+## Global Constraints
+
+- Namespace `local_ai_course_assistant`. Match the style of `classes/rag_retriever.php` and the existing CLI.
+- Pure functions in `rag_judge` are side-effect-free; unit-tested with `\basic_testcase`.
+- Default k (top-k) is the CLI's existing `$topk` (default 10); judge mode passes it through.
+- API keys never printed; read from plugin config (`embed_apikey`, fallback `apikey`) or `--openai-apikey`.
+- Config touched by Family A (`rag_return_scope`, `rerank_enabled`) is captured before and restored on exit — the run must not mutate stored config.
+- Lint every changed file: `/opt/homebrew/opt/php@8.3/bin/php -l <file>`.
+- Unit tests run from `~/Sites/moodle`: `/opt/homebrew/opt/php@8.3/bin/php vendor/bin/phpunit local/ai_course_assistant/tests/<file>`.
+- Commit after each task.
+
+---
+
+## File Structure
+
+- `classes/rag_judge.php` (new) — `ndcg_at_k`, `precision_at_k`, `hit_at_k`, `mean_relevance`, `parse_grades` (all pure static).
+- `admin/cli/run_rag_fixture_benchmark.php` (modify) — new `--judge` args, the judge HTTP call, Family A block, Family B block.
+- `tests/rag_judge_test.php` (new) — unit tests for the class.
+
+---
+
+### Task 1: `rag_judge` metrics + parser (pure, tested)
+
+**Files:**
+- Create: `classes/rag_judge.php`
+- Test: `tests/rag_judge_test.php`
+
+**Interfaces:**
+- Produces: `rag_judge::ndcg_at_k(array $grades, int $k): float`, `precision_at_k(array $grades, int $k, int $threshold=2): float`, `hit_at_k(array $grades, int $k, int $threshold=2): int`, `mean_relevance(array $grades, int $k): float`, `parse_grades(string $reply, int $expected): ?array` (returns exactly `$expected` ints clamped 0-3, or null on parse/length failure).
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+// tests/rag_judge_test.php
+namespace local_ai_course_assistant;
+defined('MOODLE_INTERNAL') || die();
+
+class rag_judge_test extends \basic_testcase {
+    public function test_ndcg_perfect_and_zero_and_mixed() {
+        $this->assertEqualsWithDelta(1.0, rag_judge::ndcg_at_k([3, 2, 1], 3), 1e-9);
+        $this->assertEqualsWithDelta(0.0, rag_judge::ndcg_at_k([0, 0, 0], 3), 1e-9);
+        // grades [0,3,0]: DCG = 7/log2(3); IDCG = 7/log2(2)=7 -> 0.6309
+        $this->assertEqualsWithDelta(0.63093, rag_judge::ndcg_at_k([0, 3, 0], 3), 1e-4);
+    }
+    public function test_precision_hit_mean() {
+        $this->assertEqualsWithDelta(0.5, rag_judge::precision_at_k([3, 1, 2, 0], 4), 1e-9);
+        $this->assertSame(0, rag_judge::hit_at_k([1, 0, 1], 3));
+        $this->assertSame(1, rag_judge::hit_at_k([1, 2, 0], 3));
+        $this->assertEqualsWithDelta(2.0, rag_judge::mean_relevance([3, 0, 3], 3), 1e-9);
+    }
+    public function test_parse_grades() {
+        $this->assertSame([3, 2, 0, 1, 0], rag_judge::parse_grades('[3, 2, 0, 1, 0]', 5));
+        // extra prose around the array is tolerated
+        $this->assertSame([3, 2, 1, 0, 0], rag_judge::parse_grades("grades: [3,2,1,0,0] done", 5));
+        // out-of-range clamped
+        $this->assertSame([3, 0], rag_judge::parse_grades('[5, -1]', 2));
+        // wrong length -> null
+        $this->assertNull(rag_judge::parse_grades('[3, 2]', 5));
+        // garbage -> null
+        $this->assertNull(rag_judge::parse_grades('no json here', 3));
+    }
+}
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `/opt/homebrew/opt/php@8.3/bin/php vendor/bin/phpunit local/ai_course_assistant/tests/rag_judge_test.php`
+Expected: FAIL — class `rag_judge` not found.
+
+- [ ] **Step 3: Implement `classes/rag_judge.php`**
+
+```php
+<?php
+// This file is part of Moodle - http://moodle.org/
+// [GPL v3 boilerplate matching other classes in this plugin]
+
+namespace local_ai_course_assistant;
+
+/**
+ * Pure scoring + parse helpers for the RAG judge-mode benchmark.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class rag_judge {
+
+    /** nDCG@k using graded relevance (gain = 2^grade - 1). 0.0 when nothing is relevant. */
+    public static function ndcg_at_k(array $grades, int $k): float {
+        $g = array_slice(array_map('intval', $grades), 0, $k);
+        $dcg = 0.0;
+        foreach ($g as $i => $gi) {
+            $dcg += (pow(2, $gi) - 1) / log($i + 2, 2);
+        }
+        $ideal = $g;
+        rsort($ideal);
+        $idcg = 0.0;
+        foreach ($ideal as $i => $gi) {
+            $idcg += (pow(2, $gi) - 1) / log($i + 2, 2);
+        }
+        return $idcg > 0 ? $dcg / $idcg : 0.0;
+    }
+
+    /** Fraction of the top-k passages graded >= threshold. */
+    public static function precision_at_k(array $grades, int $k, int $threshold = 2): float {
+        $g = array_slice(array_map('intval', $grades), 0, $k);
+        if (empty($g)) {
+            return 0.0;
+        }
+        $rel = count(array_filter($g, fn($x) => $x >= $threshold));
+        return $rel / count($g);
+    }
+
+    /** 1 if any top-k passage is graded >= threshold, else 0. */
+    public static function hit_at_k(array $grades, int $k, int $threshold = 2): int {
+        foreach (array_slice(array_map('intval', $grades), 0, $k) as $x) {
+            if ($x >= $threshold) {
+                return 1;
+            }
+        }
+        return 0;
+    }
+
+    /** Mean grade over the top-k passages. */
+    public static function mean_relevance(array $grades, int $k): float {
+        $g = array_slice(array_map('intval', $grades), 0, $k);
+        if (empty($g)) {
+            return 0.0;
+        }
+        return array_sum($g) / count($g);
+    }
+
+    /**
+     * Parse a judge reply into exactly $expected integer grades clamped to 0-3.
+     * Extracts the first JSON array in the reply. Returns null on parse failure
+     * or length mismatch (so the caller can count a judge error, never zero-fill).
+     *
+     * @return int[]|null
+     */
+    public static function parse_grades(string $reply, int $expected): ?array {
+        if (!preg_match('/\[[\s\S]*?\]/', $reply, $m)) {
+            return null;
+        }
+        $arr = json_decode($m[0], true);
+        if (!is_array($arr) || count($arr) !== $expected) {
+            return null;
+        }
+        $out = [];
+        foreach ($arr as $v) {
+            if (!is_numeric($v)) {
+                return null;
+            }
+            $out[] = max(0, min(3, (int) $v));
+        }
+        return $out;
+    }
+}
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `/opt/homebrew/opt/php@8.3/bin/php vendor/bin/phpunit local/ai_course_assistant/tests/rag_judge_test.php`
+Expected: PASS.
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+/opt/homebrew/opt/php@8.3/bin/php -l classes/rag_judge.php
+git add classes/rag_judge.php tests/rag_judge_test.php
+git commit -m "feat(rag): rag_judge metrics + grade parser (pure, tested)"
+```
+
+---
+
+### Task 2: `--judge` mode core + Family A (config arms via retrieve())
+
+**Files:**
+- Modify: `admin/cli/run_rag_fixture_benchmark.php`
+
+**Interfaces:**
+- Consumes: `rag_judge` (Task 1), `rag_retriever::retrieve()`.
+- Produces: `--judge`, `--questions=PATH`, `--sample=N`, `--judge-model=` flags; the `--judge` block that prints a Family A arms table and writes a run JSON. Global helpers `judge_passages()` and `judge_arm()`.
+
+- [ ] **Step 1: Add the new CLI args**
+
+In the arg-parse `foreach ($argv ...)` loop, alongside the existing `--embed-provider` etc. cases, add:
+```php
+    } else if ($arg === '--judge') {
+        $judgemode = true;
+    } else if (preg_match('/^--questions=(.+)$/', $arg, $m)) {
+        $questionspath = trim($m[1]);
+    } else if (preg_match('/^--sample=(\d+)$/', $arg, $m)) {
+        $samplesize = max(1, (int) $m[1]);
+    } else if (preg_match('/^--judge-model=(.+)$/', $arg, $m)) {
+        $judgemodel = trim($m[1]);
+```
+And initialise the defaults near the other `$` defaults at the top (after `$abbatch = 96;`):
+```php
+$judgemode     = false;
+$questionspath = '';
+$samplesize    = 100;
+$judgemodel    = 'gpt-4o-mini';
+```
+
+- [ ] **Step 2: Add the judge helper functions**
+
+Add these two global functions near `cosine_sim()` (anywhere at file top-level function scope):
+```php
+/**
+ * LLM-grade each passage 0-3 for relevance to the question (one batched call).
+ * Returns exactly count($passages) grades, or null on judge/parse failure.
+ *
+ * @return int[]|null
+ */
+function judge_passages(string $question, array $passages, string $model, string $apikey): ?array {
+    $k = count($passages);
+    if ($k === 0) {
+        return [];
+    }
+    $lines = [];
+    foreach ($passages as $i => $p) {
+        $lines[] = 'PASSAGE ' . ($i + 1) . ":\n" . mb_substr((string) $p, 0, 1500);
+    }
+    $sys = "You grade how well each passage answers a student's question, for a retrieval-quality eval. "
+        . "Grade each passage 0-3: 0 = irrelevant, 1 = tangentially related, 2 = relevant / partially answers, "
+        . "3 = directly answers. Return ONLY a JSON array of {$k} integers, one grade per passage in order, "
+        . "e.g. [3,1,0,2,0].";
+    $user = 'QUESTION: ' . $question . "\n\n" . implode("\n\n", $lines);
+    $payload = json_encode([
+        'model' => $model,
+        'messages' => [
+            ['role' => 'system', 'content' => $sys],
+            ['role' => 'user', 'content' => $user],
+        ],
+        'temperature' => 0,
+    ]);
+    for ($attempt = 0; $attempt < 4; $attempt++) {
+        $c = curl_init('https://api.openai.com/v1/chat/completions');
+        curl_setopt_array($c, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_POST => true,
+            CURLOPT_HTTPHEADER => ['Content-Type: application/json', 'Authorization: Bearer ' . $apikey],
+            CURLOPT_POSTFIELDS => $payload,
+            CURLOPT_TIMEOUT => 60,
+        ]);
+        $resp = curl_exec($c);
+        $code = curl_getinfo($c, CURLINFO_HTTP_CODE);
+        curl_close($c);
+        if ($code === 429 || $code >= 500) {
+            sleep(3);
+            continue;
+        }
+        if ($code !== 200 || !$resp) {
+            return null;
+        }
+        $body = json_decode($resp, true);
+        $content = $body['choices'][0]['message']['content'] ?? '';
+        return \local_ai_course_assistant\rag_judge::parse_grades($content, $k);
+    }
+    return null;
+}
+
+/**
+ * Run the live retriever over the questions under the current config and judge
+ * the returned passages. Returns aggregate metrics for one arm.
+ */
+function judge_arm(array $qitems, int $topk, string $model, string $key): array {
+    $ndcg = $prec = $hit = $mean = 0.0;
+    $scored = 0;
+    $errors = 0;
+    foreach ($qitems as $q) {
+        $res = \local_ai_course_assistant\rag_retriever::retrieve($q['courseid'], $q['question'], $topk, 0);
+        $passages = array_map(fn($r) => (string) $r['content'], $res);
+        if (empty($passages)) {
+            // Retrieval returned nothing -> zero relevance for this question.
+            $scored++;
+            continue;
+        }
+        $grades = judge_passages($q['question'], $passages, $model, $key);
+        if ($grades === null) {
+            $errors++;
+            continue;
+        }
+        $ndcg += \local_ai_course_assistant\rag_judge::ndcg_at_k($grades, $topk);
+        $prec += \local_ai_course_assistant\rag_judge::precision_at_k($grades, $topk);
+        $hit  += \local_ai_course_assistant\rag_judge::hit_at_k($grades, $topk);
+        $mean += \local_ai_course_assistant\rag_judge::mean_relevance($grades, $topk);
+        $scored++;
+    }
+    $n = max(1, $scored);
+    return ['ndcg' => $ndcg / $n, 'precision' => $prec / $n, 'hit' => $hit / $n,
+            'mean_rel' => $mean / $n, 'scored' => $scored, 'errors' => $errors];
+}
+```
+
+- [ ] **Step 3: Add the `--judge` block (Family A)**
+
+Immediately AFTER the fixtures are loaded (`$fixtures = $fixturedoc['fixtures'];` / the `echo "Loaded ..."` line) and BEFORE the `if (!empty($abproviders))` A/B block, insert:
+```php
+if ($judgemode) {
+    // ---------- Judge mode: label-free relevance grading ----------
+    $qpath = $questionspath !== ''
+        ? (($questionspath[0] === '/') ? $questionspath : __DIR__ . '/../../' . $questionspath)
+        : __DIR__ . '/../../tests/golden/rag_fixtures_synthetic_1000.json';
+    $qdoc = json_decode((string) file_get_contents($qpath), true);
+    $qsrc = $qdoc['questions'] ?? $qdoc['fixtures'] ?? [];
+    $qitems = [];
+    foreach ($qsrc as $i => $row) {
+        if (!empty($row['question']) && !empty($row['courseid'])) {
+            $qitems[] = [
+                'id'       => (string) ($row['id'] ?? $i),
+                'courseid' => (int) $row['courseid'],
+                'question' => (string) $row['question'],
+            ];
+        }
+    }
+    usort($qitems, fn($a, $b) => strcmp($a['id'], $b['id']));
+    $qitems = array_slice($qitems, 0, $samplesize);
+
+    $judgekey = get_config('local_ai_course_assistant', 'embed_apikey');
+    if ($judgekey === false || $judgekey === '') {
+        $judgekey = (string) get_config('local_ai_course_assistant', 'apikey');
+    }
+    if ($openaiapikey !== '') {
+        $judgekey = $openaiapikey;
+    }
+    if ($judgekey === '') {
+        fwrite(STDERR, "ERROR: no OpenAI key for the judge (set embed_apikey/apikey or --openai-apikey)\n");
+        exit(1);
+    }
+
+    echo "JUDGE MODE: " . count($qitems) . " questions, judge={$judgemodel}, top-k={$topk}\n";
+    echo str_repeat('=', 64) . "\n\n";
+
+    // Family A: pipeline-config arms via the real retriever.
+    $famA = [
+        ['label' => 'return=chunk', 'cfg' => ['rag_return_scope' => 'chunk']],
+        ['label' => 'return=page',  'cfg' => ['rag_return_scope' => 'page']],
+        ['label' => 'rerank=off',   'cfg' => ['rerank_enabled' => '0']],
+        ['label' => 'rerank=on',    'cfg' => ['rerank_enabled' => '1']],
+    ];
+    $touched = ['rag_return_scope', 'rerank_enabled'];
+    $origA = [];
+    foreach ($touched as $key) {
+        $origA[$key] = get_config('local_ai_course_assistant', $key);
+    }
+    $restoreA = function () use ($origA) {
+        foreach ($origA as $k => $v) {
+            set_config($k, ($v === false) ? null : $v, 'local_ai_course_assistant');
+        }
+    };
+    register_shutdown_function($restoreA);
+
+    $resultsA = [];
+    foreach ($famA as $arm) {
+        $restoreA();
+        foreach ($arm['cfg'] as $k => $v) {
+            set_config($k, $v, 'local_ai_course_assistant');
+        }
+        $per = judge_arm($qitems, $topk, $judgemodel, $judgekey);
+        $resultsA[] = ['arm' => $arm['label']] + $per;
+        printf("  %-13s nDCG@%d=%.3f  P@%d=%.3f  hit@%d=%.3f  mean=%.2f  (scored %d, judge-err %d)\n",
+            $arm['label'], $topk, $per['ndcg'], $topk, $per['precision'], $topk, $per['hit'],
+            $per['mean_rel'], $per['scored'], $per['errors']);
+    }
+    $restoreA();
+
+    echo "\n" . str_repeat('=', 64) . "\n";
+    echo "FAMILY A (pipeline config, via live retriever)\n";
+    echo str_repeat('=', 64) . "\n";
+    $hdr = ['Arm', 'nDCG', 'P@k', 'hit@k', 'mean'];
+    echo implode(' | ', array_map(fn($h) => str_pad($h, 13), $hdr)) . "\n";
+    foreach ($resultsA as $r) {
+        echo implode(' | ', [
+            str_pad($r['arm'], 13),
+            str_pad(sprintf('%.3f', $r['ndcg']), 13),
+            str_pad(sprintf('%.3f', $r['precision']), 13),
+            str_pad(sprintf('%.3f', $r['hit']), 13),
+            str_pad(sprintf('%.2f', $r['mean_rel']), 13),
+        ]) . "\n";
+    }
+    echo "\n";
+
+    $out = [
+        'run_at'     => date('c'),
+        'mode'       => 'judge',
+        'judge'      => $judgemodel,
+        'topk'       => $topk,
+        'n'          => count($qitems),
+        'family_a'   => $resultsA,
+    ];
+    file_put_contents($outfile, json_encode($out, JSON_PRETTY_PRINT));
+    echo "Results written to: {$outfile}\n";
+    exit(0);
+}
+```
+
+- [ ] **Step 4: Lint**
+
+Run: `/opt/homebrew/opt/php@8.3/bin/php -l admin/cli/run_rag_fixture_benchmark.php`
+Expected: no syntax errors.
+
+- [ ] **Step 5: Dev smoke (controller runs this — implementer just confirms lint)**
+
+The end-to-end run happens on dev via SSM (has chunks, keys, retriever), sampled small:
+`sudo -u www-data php admin/cli/run_rag_fixture_benchmark.php --judge --sample=8`
+Expected: prints a Family A table with 4 arms; `return=page` and `rerank=on` show nDCG/hit >= their off/chunk counterparts within noise; judge-err small; config restored afterward. (Implementer: confirm `php -l` only; note that the dev smoke is the controller's step.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add admin/cli/run_rag_fixture_benchmark.php
+git commit -m "feat(rag): --judge mode + Family A (config arms via retriever)"
+```
+
+---
+
+### Task 3: Family B (embedding-provider arms via re-embed)
+
+**Files:**
+- Modify: `admin/cli/run_rag_fixture_benchmark.php` (inside the `--judge` block, before the JSON write)
+
+**Interfaces:**
+- Consumes: `base_embedding_provider::create_from_config`, `embed_batch`/`embed_query`/`embed`, `cosine_sim`, `judge_passages`, `rag_judge`.
+- Produces: a Family B arms table + `family_b` in the run JSON.
+
+- [ ] **Step 1: Add the Family B block**
+
+Inside the `if ($judgemode)` block, AFTER the Family A table print and BEFORE building `$out`, insert:
+```php
+    // Family B: embedding-provider arms via in-memory re-embed (bare cosine,
+    // no rerank/scope/parent-doc). Comparable to the embedding A/B, judged.
+    $famB = [
+        ['label' => 'openai:3-small', 'prov' => 'openai', 'model' => 'text-embedding-3-small', 'dim' => 1536, 'key' => ($openaiapikey ?: $judgekey)],
+        ['label' => 'voyage:3.5',     'prov' => 'voyage', 'model' => 'voyage-3.5',            'dim' => 1024, 'key' => $voyageapikey],
+    ];
+    $origB = [
+        'embed_provider'   => get_config('local_ai_course_assistant', 'embed_provider'),
+        'embed_model'      => get_config('local_ai_course_assistant', 'embed_model'),
+        'embed_apikey'     => get_config('local_ai_course_assistant', 'embed_apikey'),
+        'embed_dimensions' => get_config('local_ai_course_assistant', 'embed_dimensions'),
+    ];
+    $restoreB = function () use ($origB) {
+        foreach ($origB as $k => $v) {
+            set_config($k, ($v === false) ? null : $v, 'local_ai_course_assistant');
+        }
+    };
+    register_shutdown_function($restoreB);
+
+    // Preload chunk contents for the courses referenced by the sampled questions.
+    $courseids = array_values(array_unique(array_map(fn($q) => $q['courseid'], $qitems)));
+    $bcontents = [];
+    foreach ($courseids as $cid) {
+        $rows = $DB->get_records_select('local_ai_course_assistant_chunks',
+            'courseid = :cid', ['cid' => $cid], '', 'id, content');
+        foreach ($rows as $row) {
+            if (trim((string) $row->content) !== '') {
+                $bcontents[$cid][(int) $row->id] = (string) $row->content;
+            }
+        }
+    }
+
+    $resultsB = [];
+    foreach ($famB as $arm) {
+        if (empty($arm['key'])) {
+            echo "  (skip {$arm['label']}: no API key)\n";
+            continue;
+        }
+        $restoreB();
+        set_config('embed_provider', $arm['prov'], 'local_ai_course_assistant');
+        set_config('embed_model', $arm['model'], 'local_ai_course_assistant');
+        set_config('embed_dimensions', $arm['dim'], 'local_ai_course_assistant');
+        set_config('embed_apikey', $arm['key'], 'local_ai_course_assistant');
+        try {
+            $prov = base_embedding_provider::create_from_config();
+        } catch (\Throwable $e) {
+            echo "  (skip {$arm['label']}: provider error: " . mb_substr($e->getMessage(), 0, 100) . ")\n";
+            $restoreB();
+            continue;
+        }
+        $isvoyage = $prov instanceof \local_ai_course_assistant\embedding_provider\voyage_embedding_provider;
+
+        // Re-embed each course's chunk contents (document vectors), sliced.
+        $vecs = [];
+        foreach ($bcontents as $cid => $contents) {
+            $ids = array_keys($contents);
+            $texts = array_values($contents);
+            for ($off = 0; $off < count($texts); $off += $abbatch) {
+                $embs = $prov->embed_batch(array_slice($texts, $off, $abbatch));
+                foreach (array_slice($ids, $off, $abbatch) as $j => $chunkid) {
+                    $vecs[$cid][$chunkid] = $embs[$j];
+                }
+            }
+        }
+
+        $ndcg = $prec = $hit = $mean = 0.0; $scored = 0; $errors = 0;
+        foreach ($qitems as $q) {
+            $cid = $q['courseid'];
+            $qvec = $isvoyage ? $prov->embed_query($q['question']) : $prov->embed($q['question']);
+            if (empty($qvec) || empty($vecs[$cid])) { $scored++; continue; }
+            $scoredchunks = [];
+            foreach ($vecs[$cid] as $chunkid => $vec) {
+                $scoredchunks[] = ['id' => $chunkid, 's' => cosine_sim($qvec, $vec)];
+            }
+            usort($scoredchunks, fn($a, $b) => $b['s'] <=> $a['s']);
+            $passages = [];
+            foreach (array_slice($scoredchunks, 0, $topk) as $sc) {
+                $passages[] = $bcontents[$cid][$sc['id']];
+            }
+            $grades = judge_passages($q['question'], $passages, $judgemodel, $judgekey);
+            if ($grades === null) { $errors++; continue; }
+            $ndcg += \local_ai_course_assistant\rag_judge::ndcg_at_k($grades, $topk);
+            $prec += \local_ai_course_assistant\rag_judge::precision_at_k($grades, $topk);
+            $hit  += \local_ai_course_assistant\rag_judge::hit_at_k($grades, $topk);
+            $mean += \local_ai_course_assistant\rag_judge::mean_relevance($grades, $topk);
+            $scored++;
+        }
+        $n = max(1, $scored);
+        $resultsB[] = ['arm' => $arm['label'], 'ndcg' => $ndcg / $n, 'precision' => $prec / $n,
+                       'hit' => $hit / $n, 'mean_rel' => $mean / $n, 'scored' => $scored, 'errors' => $errors];
+        printf("  %-15s nDCG@%d=%.3f  P@%d=%.3f  hit@%d=%.3f  mean=%.2f  (scored %d, judge-err %d)\n",
+            $arm['label'], $topk, $ndcg / $n, $topk, $prec / $n, $topk, $hit / $n, $mean / $n, $scored, $errors);
+        $restoreB();
+    }
+    $restoreB();
+
+    echo "\n" . str_repeat('=', 64) . "\n";
+    echo "FAMILY B (embedding provider, in-memory re-embed, bare cosine)\n";
+    echo str_repeat('=', 64) . "\n";
+    foreach ($resultsB as $r) {
+        printf("  %-15s nDCG=%.3f  P@k=%.3f  hit@k=%.3f  mean=%.2f\n",
+            $r['arm'], $r['ndcg'], $r['precision'], $r['hit'], $r['mean_rel']);
+    }
+    echo "\n";
+```
+Then change the `$out` array (Task 2 Step 3) to also carry Family B — replace `'family_a' => $resultsA,` with:
+```php
+        'family_a'   => $resultsA,
+        'family_b'   => $resultsB,
+```
+
+- [ ] **Step 2: Lint**
+
+Run: `/opt/homebrew/opt/php@8.3/bin/php -l admin/cli/run_rag_fixture_benchmark.php`
+Expected: no syntax errors.
+
+- [ ] **Step 3: Dev smoke (controller step)**
+
+On dev via SSM, with both keys available server-side:
+`sudo -u www-data php admin/cli/run_rag_fixture_benchmark.php --judge --sample=8 --openai-apikey=<embed_apikey> --voyage-apikey=<rerank_apikey>`
+Expected: Family A table (4 arms) + Family B table (openai vs voyage); Voyage arm skips cleanly if no key; config (embed_* and rag_*) restored afterward (verify `embed_provider`=openai, `rag_return_scope` unchanged).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add admin/cli/run_rag_fixture_benchmark.php
+git commit -m "feat(rag): --judge Family B (embedding-provider re-embed arms)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** `--judge` mode (Task 2); Family A chunk/page + rerank via `retrieve()` (Task 2); Family B openai/voyage via re-embed (Task 3); nDCG/precision/hit/mean (Task 1); judge = gpt-4o-mini batched 0-3 with length-checked parse and error counting (Tasks 1-2); `--sample` deterministic (Task 2); synthetic questions default input (Task 2); config restore on exit for both families (Tasks 2-3); JSON + tables output (Tasks 2-3); dev run (smoke steps). Covered.
+
+**Placeholder scan:** the GPL header in Task 1 Step 3 says "[GPL v3 boilerplate matching other classes]" — the implementer copies the exact header block from an existing `classes/*.php`; every logic line is complete.
+
+**Type consistency:** `rag_judge` method names/signatures match between Task 1 (definition + tests) and their calls in Tasks 2-3. `judge_passages(string,array,string,string): ?array` and `judge_arm(array,int,string,string): array` are consistent between definition (Task 2) and use. Config keys `rag_return_scope`/`rerank_enabled` (Family A) and `embed_*` (Family B) match `rag_retriever`/`base_embedding_provider` reads. `$abbatch`, `$topk`, `$outfile`, `$openaiapikey`, `$voyageapikey`, `$DB`, `cosine_sim`, `register_shutdown_function` are all pre-existing in the CLI.
+
+**Note:** Family A and Family B are separate comparisons (different retrieval paths) and print as two tables — do not read a Family-A arm against a Family-B arm.

--- a/docs/superpowers/specs/2026-07-18-rag-judge-mode-harness-design.md
+++ b/docs/superpowers/specs/2026-07-18-rag-judge-mode-harness-design.md
@@ -1,0 +1,106 @@
+# Spec: RAG judge-mode eval harness
+
+**Date:** 2026-07-18
+**Status:** Approved (brainstorming)
+**Component:** `admin/cli/run_rag_fixture_benchmark.php` (new `--judge` mode)
+
+## Goal
+
+Label-free retrieval evaluation. Add a `--judge` mode to the existing RAG
+benchmark CLI that, for each (unlabeled) question, retrieves top-k passages and
+has an LLM grade each passage's relevance 0-3, then computes graded metrics
+(nDCG@k, precision@k, hit@k, mean relevance) and compares configurations. This
+sidesteps the blocker that we have no labeled "expected chunk" per question and
+effectively no real question corpus.
+
+## Why (context)
+
+- Recall@k needs a pre-labeled gold chunk per query; we can't build that (dev
+  has ~6 real user messages; real questions live on prod, access-gated + private).
+- Judged relevance needs no labels: retrieve, then grade the retrieved passages.
+  Works at small N (dozens) with confidence intervals.
+- Reusing the 984 synthetic questions under judged grading also removes the
+  "ground truth = source chunk" optimism of the earlier recall run, because the
+  judge grades the retrieved passages independently of where a question came from.
+
+## Two comparison families (design constraint)
+
+Dev's stored chunk embeddings are OpenAI vectors, and `rag_retriever::retrieve()`
+ranks the query against those stored vectors. So:
+
+- **Family A — pipeline configs, via the real `retrieve()`.** Arms are plugin
+  config flips: `rag_return_scope` = `chunk` vs `page`; `rerank_enabled` = 0 vs 1.
+  Exercises the full live pipeline (floor, current-page boost, scope, rerank,
+  parent-document expansion). Config is set per arm and restored at exit (the
+  same `register_shutdown_function` pattern the embedding A/B mode already uses).
+- **Family B — embedding provider, via in-memory re-embed.** Arms `openai` vs
+  `voyage`. Reuses the existing A/B re-embed path: re-embed the fixture courses'
+  chunk contents and each query with the arm's provider, cosine top-k (no rerank,
+  scope, or parent-doc). Judged the same way. Reported as a **separate table** —
+  not directly comparable to Family A (different pipeline), directly comparable
+  to the earlier embedding A/B (same method, judged instead of recall).
+
+v1 runs both; each family prints its own arms table.
+
+## Input
+
+- Unlabeled questions JSON: `{"questions": [{"courseid": int, "question": str}, ...]}`.
+- v1 source: the existing `tests/golden/rag_fixtures_synthetic_1000.json` with
+  `expected_chunk_id` ignored (judge mode never reads it). A `--questions=PATH`
+  flag; default to the synthetic file.
+- `--sample=N` (default 100): deterministic subsample (stable order, e.g. first N
+  after a fixed sort by id) so a ~100-question run is cheap and reproducible.
+
+## Judge
+
+- Model: `gpt-4o-mini` (off the chat tier, so it never biases a provider arm).
+  `--judge-model=` override.
+- One batched call per (arm, question): send the question + the k retrieved
+  passages (numbered), ask for a JSON array of integer grades 0-3, one per
+  passage. Grade rubric in the prompt: 0 irrelevant, 1 tangential, 2 relevant,
+  3 directly answers.
+- Key injected server-side (dev `embed_apikey`/`apikey`), never printed.
+- Robust parse: JSON array length must equal k; on mismatch/parse failure, mark
+  that question's grades null and count it as a judge error (reported, excluded
+  from metrics), never silently zero.
+- Cache grades per (arm, question-hash, passage-hash) in the output JSON so a
+  re-run does not re-pay for unchanged (arm, question, passage) tuples.
+
+## Metrics (per arm, top-k, default k=5)
+
+Given judge grades g_1..g_k for the ranked passages:
+- **nDCG@k**: DCG = Σ (2^g_i - 1)/log2(i+1); IDCG from the same grades sorted
+  desc; nDCG = DCG/IDCG (1.0 if IDCG=0).
+- **precision@k**: fraction of the k passages with g_i >= 2.
+- **hit@k**: 1 if any g_i >= 2, else 0.
+- **mean_relevance**: mean of g_i over the k passages.
+Aggregate = mean across questions; report per arm + deltas vs the first arm, plus
+the judge-error count and questions scored.
+
+## Output & run
+
+- Writes `runs/YYYY-MM-DD-His-rag-judge.json` (arms, per-question grades, config)
+  and prints two arms tables (Family A, Family B) with deltas.
+- Executed on dev via SSM (has chunks, keys, the live retriever). Family A sets/
+  restores config per arm; Family B re-embeds in memory. Non-invasive: no reindex,
+  config restored on exit.
+
+## Testing
+
+- Pure metric functions (`ndcg_at_k`, `precision_at_k`, `hit_at_k`,
+  `mean_relevance`) — unit-tested with hand-computed cases (incl. all-zero grades,
+  perfect ranking, IDCG=0).
+- Judge-response parser — unit-tested with canned good/short/garbage JSON
+  (asserts length check + error path).
+- End-to-end is a dev run (like the embedding A/B), not a unit test (retrieval +
+  live LLM).
+
+## v1 scope / out of scope
+
+- **In:** `--judge` mode; Family A arms (chunk/page, rerank off/on) via
+  `retrieve()`; Family B arms (openai/voyage) via re-embed; the four metrics;
+  `--sample`; synthetic questions input; dev run; unit tests for metrics + parse.
+- **Out (later):** curated real-question bank (separate deliverable);
+  production A/B on helpfulness signals; per-passage rationale from the judge;
+  multi-judge agreement / strong-judge spot-check (add if the mini judge looks
+  noisy).

--- a/tests/rag_judge_test.php
+++ b/tests/rag_judge_test.php
@@ -15,6 +15,14 @@ class rag_judge_test extends \basic_testcase {
         $this->assertSame(1, rag_judge::hit_at_k([1, 2, 0], 3));
         $this->assertEqualsWithDelta(2.0, rag_judge::mean_relevance([3, 0, 3], 3), 1e-9);
     }
+    public function test_precision_mean_divide_by_k_when_fewer_grades_returned() {
+        // Count < k: missing slots count as not-relevant / grade 0, so divide by k not count(grades).
+        $this->assertEqualsWithDelta(0.4, rag_judge::precision_at_k([3, 3], 5), 1e-9);
+        $this->assertEqualsWithDelta(1.2, rag_judge::mean_relevance([3, 3], 5), 1e-9);
+        // Empty grades.
+        $this->assertEqualsWithDelta(0.0, rag_judge::precision_at_k([], 5), 1e-9);
+        $this->assertEqualsWithDelta(0.0, rag_judge::mean_relevance([], 5), 1e-9);
+    }
     public function test_parse_grades() {
         $this->assertSame([3, 2, 0, 1, 0], rag_judge::parse_grades('[3, 2, 0, 1, 0]', 5));
         // extra prose around the array is tolerated

--- a/tests/rag_judge_test.php
+++ b/tests/rag_judge_test.php
@@ -1,0 +1,29 @@
+<?php
+namespace local_ai_course_assistant;
+defined('MOODLE_INTERNAL') || die();
+
+class rag_judge_test extends \basic_testcase {
+    public function test_ndcg_perfect_and_zero_and_mixed() {
+        $this->assertEqualsWithDelta(1.0, rag_judge::ndcg_at_k([3, 2, 1], 3), 1e-9);
+        $this->assertEqualsWithDelta(0.0, rag_judge::ndcg_at_k([0, 0, 0], 3), 1e-9);
+        // grades [0,3,0]: DCG = 7/log2(3); IDCG = 7/log2(2)=7 -> 0.6309
+        $this->assertEqualsWithDelta(0.63093, rag_judge::ndcg_at_k([0, 3, 0], 3), 1e-4);
+    }
+    public function test_precision_hit_mean() {
+        $this->assertEqualsWithDelta(0.5, rag_judge::precision_at_k([3, 1, 2, 0], 4), 1e-9);
+        $this->assertSame(0, rag_judge::hit_at_k([1, 0, 1], 3));
+        $this->assertSame(1, rag_judge::hit_at_k([1, 2, 0], 3));
+        $this->assertEqualsWithDelta(2.0, rag_judge::mean_relevance([3, 0, 3], 3), 1e-9);
+    }
+    public function test_parse_grades() {
+        $this->assertSame([3, 2, 0, 1, 0], rag_judge::parse_grades('[3, 2, 0, 1, 0]', 5));
+        // extra prose around the array is tolerated
+        $this->assertSame([3, 2, 1, 0, 0], rag_judge::parse_grades("grades: [3,2,1,0,0] done", 5));
+        // out-of-range clamped
+        $this->assertSame([3, 0], rag_judge::parse_grades('[5, -1]', 2));
+        // wrong length -> null
+        $this->assertNull(rag_judge::parse_grades('[3, 2]', 5));
+        // garbage -> null
+        $this->assertNull(rag_judge::parse_grades('no json here', 3));
+    }
+}


### PR DESCRIPTION
## Why
We can't build a labeled recall set (no real question corpus; dev has ~6 user messages, prod is access-gated + private). This adds **label-free** retrieval eval: retrieve, then have an LLM grade each retrieved passage 0-3, and compare configs. Needs no gold labels and works at small N.

## What
New `--judge` mode in `admin/cli/run_rag_fixture_benchmark.php`, plus a pure, unit-tested `classes/rag_judge.php`.
- **Family A** (via the live `rag_retriever::retrieve()`): `rag_return_scope` chunk vs page, `rerank_enabled` off vs on. Flips config per arm, restored on exit.
- **Family B** (in-memory re-embed, bare cosine): OpenAI vs Voyage. Separate table (different pipeline) — comparable to the earlier embedding A/B but judged.
- **Judge:** gpt-4o-mini, one batched 0-3 grading call per (arm, question); length-checked parse; judge errors excluded from metrics (never zero-filled).
- **Metrics:** nDCG@k, precision@k, hit@k, mean relevance — per arm + deltas. precision@k / mean divide by `k` (comparable across arms with different result counts).
- **Input:** unlabeled questions (`--questions`, defaults to the synthetic set with `expected_chunk_id` ignored); `--sample=N` deterministic.

## Tests & review
- `rag_judge` unit tests: 4 tests / 16 assertions (nDCG incl. idcg=0, precision/hit/mean incl. count<k, parse incl. length-mismatch/garbage).
- Final whole-branch review (opus): **APPROVE WITH MINORS**, no Critical. Config restore for both families verified; judge-error exclusion verified; existing embedding-A/B and rerank CLI paths undisturbed (judge block is fully `--judge`-gated and `exit(0)`s).
- CLI orchestration is verified by a dev run (retrieval + live LLM), not unit tests — consistent with the existing harness.

## Deferred (from review; documented, not blockers)
- Per-question grade persistence + judge-result caching (v1 stores aggregate rows; nDCG/hit are the count-robust signals meanwhile).
- Dev-only nits: `curl_init` vs Moodle `\curl`; judge default-k is the shared `--topk` (10) unless `--topk=5` passed; run artifact uses the shared `-rag-bench.json` name; a Family B partial-batch guard.

## Note
Dev-only benchmark CLI — not learner-facing, excluded from the published zip. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)