### PR TITLE
feat(policy-bundle): allowlist parent-document retrieval keys (v6.9.2)

### DIFF
--- a/classes/policy_bundle.php
+++ b/classes/policy_bundle.php
@@ -113,10 +113,13 @@ class policy_bundle {
         'premium_escalation_course_tags',
         // Widget behavior (v6.5 avatar animation probe).
         'avatar_animation_enabled',
-        // RAG tuning (v6.2 floor/boost, v5.11 rerank).
+        // RAG tuning (v6.2 floor/boost, v5.11 rerank, parent-document expansion).
         'rag_enabled',
         'rag_min_similarity',
         'rag_currentpage_boost',
+        'rag_return_scope',
+        'rag_window_size',
+        'rag_parent_max_chars',
         'rerank_enabled',
         'rerank_model',
         'rerank_candidates',

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_ai_course_assistant';
-$plugin->version = 2026071800;
+$plugin->version = 2026072100;
 $plugin->requires = 2024100700; // Moodle 4.5+.
 $plugin->supported = [405, 503]; // Tested on Moodle 4.5 through 5.3dev.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '6.9.1';
+$plugin->release = '6.9.2';


### PR DESCRIPTION
Adds `rag_return_scope`, `rag_window_size`, `rag_parent_max_chars` to `policy_bundle::ALLOWED_KEYS` so parent-document retrieval (PR #150) can be enabled fleet-wide via a signed bundle instead of only per-site config.

No behavior change: the settings still default to `chunk` (off) until a bundle or admin sets them. Rerank stays per-site (needs a Voyage key). Validators 36/36.

Context: 2026-07-21 benchmark had rerank + `rag_return_scope=window` as the top retrieval arm on conversational queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)