### PR TITLE
i18n: translate settings:provider_auto (46/46)

### DIFF
--- a/lang/am/local_ai_course_assistant.php
+++ b/lang/am/local_ai_course_assistant.php
@@ -453,6 +453,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'ራስ-ሰር (ከተዋቀረ Moodle AI ይጠቀሙ፣ አለበለዚያ ቀጥተኛ አቅራቢ)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'ይህን ገጽ አብራራ';
 $string['chat:starter_ask_anything'] = 'ማንኛውንም ጠይቅ';

--- a/lang/ar/local_ai_course_assistant.php
+++ b/lang/ar/local_ai_course_assistant.php
@@ -424,6 +424,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'تلقائي (استخدام Moodle AI إن كان مُهيّأً، وإلا مزوّد مباشر)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'اشرح هذه الصفحة';
 $string['chat:starter_ask_anything'] = 'اسأل أي شيء';

--- a/lang/bg/local_ai_course_assistant.php
+++ b/lang/bg/local_ai_course_assistant.php
@@ -424,6 +424,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Автоматично (използвай Moodle AI, ако е конфигуриран, иначе директен доставчик)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Обясни тази страница';
 $string['chat:starter_ask_anything'] = 'Задай въпрос';

--- a/lang/bm/local_ai_course_assistant.php
+++ b/lang/bm/local_ai_course_assistant.php
@@ -454,6 +454,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'A yɛrɛ (Moodle AI baara ni a labɛnnen don, n’o tɛ dilannikɛla tilennen)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Nin ɲɛ ɲɛfɔ';
 $string['chat:starter_ask_anything'] = 'Fɛn o fɛn ɲininka';

--- a/lang/bn/local_ai_course_assistant.php
+++ b/lang/bn/local_ai_course_assistant.php
@@ -424,6 +424,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'স্বয়ংক্রিয় (কনফিগার করা থাকলে Moodle AI ব্যবহার করুন, অন্যথায় সরাসরি প্রদানকারী)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'এই পৃষ্ঠা ব্যাখ্যা করুন';
 $string['chat:starter_ask_anything'] = 'যেকোনো কিছু জিজ্ঞাসা করুন';

--- a/lang/cs/local_ai_course_assistant.php
+++ b/lang/cs/local_ai_course_assistant.php
@@ -424,6 +424,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Automaticky (použít Moodle AI, pokud je nastavené, jinak přímého poskytovatele)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Vysvětli tuto stránku';
 $string['chat:starter_ask_anything'] = 'Zeptejte se na cokoliv';

--- a/lang/da/local_ai_course_assistant.php
+++ b/lang/da/local_ai_course_assistant.php
@@ -424,6 +424,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Auto (brug Moodle AI hvis konfigureret, ellers en direkte udbyder)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Forklar denne side';
 $string['chat:starter_ask_anything'] = 'Spørg om hvad som helst';

--- a/lang/de/local_ai_course_assistant.php
+++ b/lang/de/local_ai_course_assistant.php
@@ -424,6 +424,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Automatisch (Moodle AI verwenden, falls konfiguriert, sonst einen direkten Anbieter)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Diese Seite erklären';
 $string['chat:starter_ask_anything'] = 'Frag was du willst';

--- a/lang/el/local_ai_course_assistant.php
+++ b/lang/el/local_ai_course_assistant.php
@@ -370,6 +370,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Αυτόματο (χρήση Moodle AI αν έχει ρυθμιστεί, αλλιώς άμεσος πάροχος)';
 // Strings added by update_langs.py.
 $string['chat:history_saved_subtitle'] = 'Οι αποθηκευμένες απαντήσεις παραμένουν σε αυτή τη συσκευή για αυτό το μάθημα.';
 $string['chat:history_saved_empty'] = 'Αποθηκεύστε μια απάντηση AI για να τη δείτε εδώ.';

--- a/lang/es/local_ai_course_assistant.php
+++ b/lang/es/local_ai_course_assistant.php
@@ -451,6 +451,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Automático (usar Moodle AI si está configurado; si no, un proveedor directo)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Explicar esta página';
 $string['chat:starter_ask_anything'] = 'Pregunta lo que quieras';

--- a/lang/fi/local_ai_course_assistant.php
+++ b/lang/fi/local_ai_course_assistant.php
@@ -424,6 +424,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Automaattinen (käytä Moodle AI:ta jos määritetty, muuten suora palveluntarjoaja)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Selitä tämä sivu';
 $string['chat:starter_ask_anything'] = 'Kysy mitä vain';

--- a/lang/fr/local_ai_course_assistant.php
+++ b/lang/fr/local_ai_course_assistant.php
@@ -424,6 +424,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Auto (utiliser Moodle AI si configuré, sinon un fournisseur direct)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Expliquer cette page';
 $string['chat:starter_ask_anything'] = 'Posez une question';

--- a/lang/ha/local_ai_course_assistant.php
+++ b/lang/ha/local_ai_course_assistant.php
@@ -455,6 +455,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Kai tsaye (yi amfani da Moodle AI idan an saita, in ba haka ba mai bayarwa kai tsaye)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Bayyana wannan shafi';
 $string['chat:starter_ask_anything'] = 'Tambayi komai';

--- a/lang/he/local_ai_course_assistant.php
+++ b/lang/he/local_ai_course_assistant.php
@@ -370,6 +370,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'אוטומטי (השתמש ב-Moodle AI אם מוגדר, אחרת ספק ישיר)';
 // Strings added by update_langs.py.
 $string['chat:history_saved_subtitle'] = 'תגובות שמורות נשארות במכשיר זה עבור קורס זה.';
 $string['chat:history_saved_empty'] = 'שמור תגובת AI כדי לראותה כאן.';

--- a/lang/hi/local_ai_course_assistant.php
+++ b/lang/hi/local_ai_course_assistant.php
@@ -455,6 +455,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'स्वचालित (यदि कॉन्फ़िगर हो तो Moodle AI का उपयोग करें, अन्यथा सीधा प्रदाता)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'यह पेज समझाएं';
 $string['chat:starter_ask_anything'] = 'कुछ भी पूछें';

--- a/lang/hu/local_ai_course_assistant.php
+++ b/lang/hu/local_ai_course_assistant.php
@@ -370,6 +370,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Automatikus (Moodle AI használata, ha be van állítva, egyébként közvetlen szolgáltató)';
 // Strings added by update_langs.py.
 $string['chat:history_saved_subtitle'] = 'A mentett válaszok ezen az eszközön maradnak ehhez a kurzushoz.';
 $string['chat:history_saved_empty'] = 'Ments el egy AI-választ, hogy itt láthasd.';

--- a/lang/id/local_ai_course_assistant.php
+++ b/lang/id/local_ai_course_assistant.php
@@ -455,6 +455,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Otomatis (gunakan Moodle AI jika dikonfigurasi, jika tidak penyedia langsung)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Jelaskan halaman ini';
 $string['chat:starter_ask_anything'] = 'Tanya apa saja';

--- a/lang/ig/local_ai_course_assistant.php
+++ b/lang/ig/local_ai_course_assistant.php
@@ -441,6 +441,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Akpaghị aka (jiri Moodle AI ma ọ bụrụ na ahaziri ya, ma ọ bụghị onye na-eweta ozugbo)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Kọwaa peeji a';
 $string['chat:starter_ask_anything'] = 'Jụọ ihe ọ bụla';

--- a/lang/it/local_ai_course_assistant.php
+++ b/lang/it/local_ai_course_assistant.php
@@ -370,6 +370,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Automatico (usa Moodle AI se configurato, altrimenti un provider diretto)';
 // Strings added by update_langs.py.
 $string['chat:history_saved_subtitle'] = 'Le risposte salvate rimangono su questo dispositivo per questo corso.';
 $string['chat:history_saved_empty'] = 'Salva una risposta dell\'IA per vederla qui.';

--- a/lang/ja/local_ai_course_assistant.php
+++ b/lang/ja/local_ai_course_assistant.php
@@ -424,6 +424,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = '自動（設定されていれば Moodle AI を使用、なければ直接プロバイダー）';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'このページを説明';
 $string['chat:starter_ask_anything'] = '何でも質問';

--- a/lang/ko/local_ai_course_assistant.php
+++ b/lang/ko/local_ai_course_assistant.php
@@ -424,6 +424,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = '자동 (구성된 경우 Moodle AI 사용, 그렇지 않으면 직접 제공자)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = '이 페이지 설명';
 $string['chat:starter_ask_anything'] = '무엇이든 질문하세요';

--- a/lang/ms/local_ai_course_assistant.php
+++ b/lang/ms/local_ai_course_assistant.php
@@ -447,6 +447,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Auto (guna Moodle AI jika dikonfigurasikan, jika tidak pembekal langsung)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Terangkan halaman ini';
 $string['chat:starter_ask_anything'] = 'Tanya apa sahaja';

--- a/lang/nb/local_ai_course_assistant.php
+++ b/lang/nb/local_ai_course_assistant.php
@@ -424,6 +424,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Auto (bruk Moodle AI hvis konfigurert, ellers en direkte leverandør)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Forklar denne siden';
 $string['chat:starter_ask_anything'] = 'Spør om hva som helst';

--- a/lang/ne/local_ai_course_assistant.php
+++ b/lang/ne/local_ai_course_assistant.php
@@ -447,6 +447,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'स्वचालित (कन्फिगर गरिएको भए Moodle AI प्रयोग गर्नुहोस्, अन्यथा प्रत्यक्ष प्रदायक)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'यो पृष्ठ व्याख्या गर्नुहोस्';
 $string['chat:starter_ask_anything'] = 'जे पनि सोध्नुहोस्';

--- a/lang/nl/local_ai_course_assistant.php
+++ b/lang/nl/local_ai_course_assistant.php
@@ -424,6 +424,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Automatisch (gebruik Moodle AI indien geconfigureerd, anders een directe provider)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Leg deze pagina uit';
 $string['chat:starter_ask_anything'] = 'Vraag wat je wilt';

--- a/lang/om/local_ai_course_assistant.php
+++ b/lang/om/local_ai_course_assistant.php
@@ -428,6 +428,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Ofumaan (yoo qindaaʼe Moodle AI fayyadami, kanaan ala dhiyeessaa kallattii)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Fuula kana ibsi';
 $string['chat:starter_ask_anything'] = 'Waan tokko gaafadhu';

--- a/lang/pa/local_ai_course_assistant.php
+++ b/lang/pa/local_ai_course_assistant.php
@@ -447,6 +447,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'ਆਟੋ (ਜੇ ਕੌਂਫਿਗਰ ਹੋਵੇ ਤਾਂ Moodle AI ਵਰਤੋ, ਨਹੀਂ ਤਾਂ ਸਿੱਧਾ ਪ੍ਰਦਾਤਾ)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'ਇਹ ਪੰਨਾ ਸਮਝਾਓ';
 $string['chat:starter_ask_anything'] = 'ਕੁਝ ਵੀ ਪੁੱਛੋ';

--- a/lang/pl/local_ai_course_assistant.php
+++ b/lang/pl/local_ai_course_assistant.php
@@ -424,6 +424,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Automatycznie (użyj Moodle AI, jeśli skonfigurowano, w przeciwnym razie dostawca bezpośredni)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Wyjaśnij tę stronę';
 $string['chat:starter_ask_anything'] = 'Zapytaj o cokolwiek';

--- a/lang/pt_br/local_ai_course_assistant.php
+++ b/lang/pt_br/local_ai_course_assistant.php
@@ -447,6 +447,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Automático (usar Moodle AI se configurado, caso contrário um provedor direto)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Explicar esta página';
 $string['chat:starter_ask_anything'] = 'Pergunte qualquer coisa';

--- a/lang/ro/local_ai_course_assistant.php
+++ b/lang/ro/local_ai_course_assistant.php
@@ -424,6 +424,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Automat (folosește Moodle AI dacă este configurat, altfel un furnizor direct)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Explică această pagină';
 $string['chat:starter_ask_anything'] = 'Întreabă orice';

--- a/lang/ru/local_ai_course_assistant.php
+++ b/lang/ru/local_ai_course_assistant.php
@@ -447,6 +447,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Авто (использовать Moodle AI, если настроен, иначе прямой провайдер)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Объясни эту страницу';
 $string['chat:starter_ask_anything'] = 'Спросите что угодно';

--- a/lang/sk/local_ai_course_assistant.php
+++ b/lang/sk/local_ai_course_assistant.php
@@ -424,6 +424,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Automaticky (použiť Moodle AI, ak je nastavené, inak priameho poskytovateľa)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Vysvetli túto stránku';
 $string['chat:starter_ask_anything'] = 'Opýtajte sa čokoľvek';

--- a/lang/so/local_ai_course_assistant.php
+++ b/lang/so/local_ai_course_assistant.php
@@ -442,6 +442,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Otomaatig (isticmaal Moodle AI haddii la habeeyay, haddii kale bixiye toos ah)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Sharax boggan';
 $string['chat:starter_ask_anything'] = 'Weydii wax kasta';

--- a/lang/sv/local_ai_course_assistant.php
+++ b/lang/sv/local_ai_course_assistant.php
@@ -424,6 +424,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Auto (använd Moodle AI om konfigurerad, annars en direkt leverantör)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Förklara denna sida';
 $string['chat:starter_ask_anything'] = 'Fråga vad du vill';

--- a/lang/sw/local_ai_course_assistant.php
+++ b/lang/sw/local_ai_course_assistant.php
@@ -447,6 +447,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Otomatiki (tumia Moodle AI ikiwa imesanidiwa, vinginevyo mtoa huduma wa moja kwa moja)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Eleza ukurasa huu';
 $string['chat:starter_ask_anything'] = 'Uliza chochote';

--- a/lang/ta/local_ai_course_assistant.php
+++ b/lang/ta/local_ai_course_assistant.php
@@ -447,6 +447,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'தானியங்கி (கட்டமைக்கப்பட்டிருந்தால் Moodle AI ஐப் பயன்படுத்தவும், இல்லையெனில் நேரடி வழங்குநர்)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'இந்தப் பக்கத்தை விளக்கு';
 $string['chat:starter_ask_anything'] = 'எதையும் கேளுங்கள்';

--- a/lang/th/local_ai_course_assistant.php
+++ b/lang/th/local_ai_course_assistant.php
@@ -424,6 +424,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'อัตโนมัติ (ใช้ Moodle AI หากตั้งค่าไว้ มิฉะนั้นใช้ผู้ให้บริการโดยตรง)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'อธิบายหน้านี้';
 $string['chat:starter_ask_anything'] = 'ถามอะไรก็ได้';

--- a/lang/tl/local_ai_course_assistant.php
+++ b/lang/tl/local_ai_course_assistant.php
@@ -447,6 +447,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Awto (gamitin ang Moodle AI kung naka-configure, kung hindi ay isang direktang provider)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Ipaliwanag ang pahinang ito';
 $string['chat:starter_ask_anything'] = 'Magtanong ng kahit ano';

--- a/lang/tr/local_ai_course_assistant.php
+++ b/lang/tr/local_ai_course_assistant.php
@@ -424,6 +424,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Otomatik (yapılandırılmışsa Moodle AI kullan, aksi halde doğrudan bir sağlayıcı)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Bu sayfayı açıkla';
 $string['chat:starter_ask_anything'] = 'Herhangi bir şey sor';

--- a/lang/uk/local_ai_course_assistant.php
+++ b/lang/uk/local_ai_course_assistant.php
@@ -370,6 +370,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Авто (використовувати Moodle AI, якщо налаштовано, інакше прямий постачальник)';
 // Strings added by update_langs.py.
 $string['chat:history_saved_subtitle'] = 'Збережені відповіді залишаються на цьому пристрої для цього курсу.';
 $string['chat:history_saved_empty'] = 'Збережіть відповідь ШІ, щоб побачити її тут.';

--- a/lang/vi/local_ai_course_assistant.php
+++ b/lang/vi/local_ai_course_assistant.php
@@ -447,6 +447,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Tự động (dùng Moodle AI nếu đã cấu hình, nếu không thì nhà cung cấp trực tiếp)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Giải thích trang này';
 $string['chat:starter_ask_anything'] = 'Hỏi bất cứ điều gì';

--- a/lang/wo/local_ai_course_assistant.php
+++ b/lang/wo/local_ai_course_assistant.php
@@ -447,6 +447,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Otomatik (jëfandikoo Moodle AI su ñu ko defaroon, lu ko moy ab joxekat bu jubluwaay)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Xamal bii xët';
 $string['chat:starter_ask_anything'] = 'Laaj lu la neexe';

--- a/lang/yo/local_ai_course_assistant.php
+++ b/lang/yo/local_ai_course_assistant.php
@@ -447,6 +447,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Aládàáṣiṣẹ́ (lo Moodle AI tí a bá ti ṣètò rẹ̀, bí bẹ́ẹ̀ kọ́ olùpèsè tààrà)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Ṣàlàyé ojú-ìwé yìí';
 $string['chat:starter_ask_anything'] = 'Béèrè ohunkóhun';

--- a/lang/zh_cn/local_ai_course_assistant.php
+++ b/lang/zh_cn/local_ai_course_assistant.php
@@ -447,6 +447,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = '自动（若已配置则使用 Moodle AI，否则使用直连提供商）';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = '解释此页面';
 $string['chat:starter_ask_anything'] = '问任何问题';

--- a/lang/zu/local_ai_course_assistant.php
+++ b/lang/zu/local_ai_course_assistant.php
@@ -447,6 +447,7 @@ $string['settings:provider_together'] = 'Together AI (Llama 3.1 8B/70B/405B Turb
 $string['settings:provider_xai'] = 'xAI (Grok)';
 
 $string['settings:provider_coreai'] = 'Moodle AI (core_ai subsystem)';
+$string['settings:provider_auto'] = 'Ngokuzenzakalela (sebenzisa i-Moodle AI uma ilungiselelwe, uma kungenjalo umhlinzeki oqondile)';
 // Strings added by update_langs.py.
 $string['chat:starter_help_page'] = 'Chaza leli khasi';
 $string['chat:starter_ask_anything'] = 'Buza noma yini';


### PR DESCRIPTION
Adds the translated `settings:provider_auto` string to all 45 non-English language files, restoring 46/46 completeness for the new 'auto' chat provider default (v6.9.3). One line per file; all 46 lang files lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)