### PR TITLE
fix(privacy): correct Saylor privacy policy URL

### DIFF
--- a/classes/branding.php
+++ b/classes/branding.php
@@ -104,7 +104,7 @@ class branding {
      */
     public static function privacy_external_url(): string {
         $v = get_config('local_ai_course_assistant', 'privacy_external_url');
-        return $v !== false && $v !== '' ? $v : 'https://www.saylor.org/privacy-policy/';
+        return $v !== false && $v !== '' ? $v : 'https://www.saylor.org/privacypolicy/';
     }
 
     /**


### PR DESCRIPTION
The learner-facing privacy notice linked `https://www.saylor.org/privacy-policy/` (hyphenated), which 404s. Corrected `branding::privacy_external_url()` default to `https://www.saylor.org/privacypolicy/` (the live page). Contact email is already `contact@saylor.org`. Part of the v6.9.3 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)