### PR TITLE
Deny temperature on the Claude 5 family (Opus 5, Sonnet 5, Fable 5, Mythos 5)

### DIFF
--- a/classes/provider/claude_provider.php
+++ b/classes/provider/claude_provider.php
@@ -50,16 +50,24 @@ class claude_provider extends base_provider {
 
     /**
      * Whether the given Anthropic model accepts a `temperature` parameter.
-     * Opus 4.7 and 4.8 (reasoning-class models) reject temperature with HTTP
-     * 400; their successors will likely behave the same way. Maintain this
-     * as a per-prefix denylist so the model-specific 400 doesn't bubble up
-     * as the generic "something went wrong" error.
+     * Reasoning-class models reject sampling parameters (temperature, top_p,
+     * top_k) with HTTP 400: Opus 4.7 and 4.8, and the entire Claude 5 family
+     * (Opus 5, Sonnet 5, Fable 5, Mythos 5). Maintain this as a per-prefix
+     * denylist so the model-specific 400 doesn't bubble up as the generic
+     * "something went wrong" error.
+     *
+     * Note the prefixes are deliberately specific: `claude-sonnet-4-6` and
+     * earlier Sonnets DO accept temperature, so a bare `claude-sonnet` prefix
+     * would wrongly strip it from models that support it.
      *
      * @param string $model
      * @return bool
      */
     private static function model_supports_temperature(string $model): bool {
-        $denyprefixes = ['claude-opus-4-7', 'claude-opus-4-8', 'claude-opus-4-9'];
+        $denyprefixes = [
+            'claude-opus-4-7', 'claude-opus-4-8', 'claude-opus-4-9',
+            'claude-opus-5', 'claude-sonnet-5', 'claude-fable-5', 'claude-mythos-5',
+        ];
         foreach ($denyprefixes as $prefix) {
             if (str_starts_with($model, $prefix)) {
                 return false;

--- a/tests/claude_provider_temperature_denylist_test.php
+++ b/tests/claude_provider_temperature_denylist_test.php
@@ -91,6 +91,31 @@ final class claude_provider_temperature_denylist_test extends \advanced_testcase
         $this->assertTrue($this->supports('claude-sonnet-4-5'));
     }
 
+    /**
+     * The Claude 5 family removed sampling parameters entirely — temperature,
+     * top_p and top_k all return HTTP 400.
+     *
+     * @covers ::model_supports_temperature
+     */
+    public function test_claude_5_family_rejects_temperature(): void {
+        $this->assertFalse($this->supports('claude-opus-5'));
+        $this->assertFalse($this->supports('claude-sonnet-5'));
+        $this->assertFalse($this->supports('claude-fable-5'));
+        $this->assertFalse($this->supports('claude-mythos-5'));
+    }
+
+    /**
+     * Sonnet 5 is denied but Sonnet 4.6 and 4.5 are not — the denylist must
+     * not be widened to a bare `claude-sonnet` prefix.
+     *
+     * @covers ::model_supports_temperature
+     */
+    public function test_sonnet_5_denied_without_catching_earlier_sonnets(): void {
+        $this->assertFalse($this->supports('claude-sonnet-5'));
+        $this->assertTrue($this->supports('claude-sonnet-4-6'));
+        $this->assertTrue($this->supports('claude-sonnet-4-5'));
+    }
+
     public function test_haiku_models_accept_temperature(): void {
         $this->assertTrue($this->supports('claude-haiku-4-5'));
         $this->assertTrue($this->supports('claude-haiku-3-5'));


### PR DESCRIPTION
## Problem
`claude_provider::model_supports_temperature()` strips `temperature` for reasoning-class Anthropic models that reject sampling parameters with a 400. The denylist covered **only** `claude-opus-4-7/4-8/4-9`.

The **entire Claude 5 family also removed `temperature`, `top_p` and `top_k`** — they return HTTP 400. So selecting `claude-opus-5` or `claude-sonnet-5` today fails on *every* call, and (exactly as the original denylist was written to prevent) surfaces as the generic "something went wrong" error instead of anything actionable.

This is latent today — nothing selects those models yet — but it blocks benchmarking or adopting them, which is how it was found.

## Fix
Add `claude-opus-5`, `claude-sonnet-5`, `claude-fable-5`, `claude-mythos-5` to the denylist.

The prefixes are deliberately narrow. `claude-sonnet-4-6` and earlier Sonnets **do** accept `temperature`, so a bare `claude-sonnet` prefix would wrongly strip it from models that support it — a new regression test pins that boundary explicitly.

## Tests
Extended `tests/claude_provider_temperature_denylist_test.php`:
- `test_claude_5_family_rejects_temperature` — all four Claude 5 models denied
- `test_sonnet_5_denied_without_catching_earlier_sonnets` — Sonnet 5 denied, 4.6/4.5 still allowed

**12 tests / 21 assertions pass** locally (PHP 8.3). PHP lint clean.

## Note
Pricing for reference when these get adopted: Opus 5 is **$5/$25 per MTok** (same tier as Opus 4.8, so a drop-in upgrade), Sonnet 5 **$3/$15** with a **$2/$10 introductory rate through 2026-08-31**.