### PR TITLE
Claude temperature: flip to a config-backed allow-list (stacked on #163)

### DIFF
--- a/classes/policy_bundle.php
+++ b/classes/policy_bundle.php
@@ -83,6 +83,7 @@ class policy_bundle {
         // Chat routing and prompt shape.
         'provider',
         'model',
+        'claude_temperature_allow_prefixes',
         'temperature',
         'maxhistory',
         'prompt_verbosity',

--- a/classes/provider/claude_provider.php
+++ b/classes/provider/claude_provider.php
@@ -49,31 +49,86 @@ class claude_provider extends base_provider {
     }
 
     /**
-     * Whether the given Anthropic model accepts a `temperature` parameter.
-     * Reasoning-class models reject sampling parameters (temperature, top_p,
-     * top_k) with HTTP 400: Opus 4.7 and 4.8, and the entire Claude 5 family
-     * (Opus 5, Sonnet 5, Fable 5, Mythos 5). Maintain this as a per-prefix
-     * denylist so the model-specific 400 doesn't bubble up as the generic
-     * "something went wrong" error.
+     * Prefixes of Anthropic models known to ACCEPT sampling parameters.
      *
-     * Note the prefixes are deliberately specific: `claude-sonnet-4-6` and
-     * earlier Sonnets DO accept temperature, so a bare `claude-sonnet` prefix
-     * would wrongly strip it from models that support it.
+     * Used as the default when the `claude_temperature_allow_prefixes` setting
+     * is empty. Deliberately an allow-list, not a deny-list: see
+     * {@see model_supports_temperature()} for why.
+     *
+     * @var string[]
+     */
+    public const DEFAULT_TEMPERATURE_ALLOW_PREFIXES = [
+        // Aliases.
+        'claude-opus-4-6', 'claude-opus-4-5', 'claude-opus-4-1', 'claude-opus-4-0',
+        'claude-sonnet-4-6', 'claude-sonnet-4-5', 'claude-sonnet-4-0',
+        'claude-haiku-4-5', 'claude-haiku-3-5', 'claude-haiku-3',
+        // Dated full IDs for the 4.0 generation, whose alias form does not
+        // prefix-match them: e.g. claude-sonnet-4-20250514 (this provider's
+        // own get_default_model()) and claude-opus-4-20250514. We cannot use a
+        // bare 'claude-opus-4' prefix here because it would also match the
+        // denied claude-opus-4-7 / 4-8.
+        'claude-opus-4-2025', 'claude-sonnet-4-2025',
+        // Claude 3.x and 2.x, all of which accept sampling parameters.
+        'claude-3', 'claude-2',
+    ];
+
+    /**
+     * Whether the given Anthropic model accepts a `temperature` parameter.
+     *
+     * This is an ALLOW-list: a model we do not recognise is assumed NOT to
+     * accept sampling parameters, and temperature is omitted.
+     *
+     * The reason is that the two failure modes are asymmetric:
+     *   - Omitting temperature from a model that accepts it: the model uses
+     *     its own default. Harmless.
+     *   - Sending temperature to a model that rejects it: HTTP 400 on EVERY
+     *     call, surfacing as the generic "something went wrong" error.
+     *
+     * Anthropic has removed sampling parameters from every reasoning-class
+     * model since Opus 4.7 (Opus 4.7/4.8, and the whole Claude 5 family), so
+     * an unrecognised model is now more likely to reject them than accept
+     * them. Defaulting to "omit" means a newly released model works on day
+     * one instead of failing every request until the plugin is updated.
+     *
+     * The list is read from the `claude_temperature_allow_prefixes` setting so
+     * it can be corrected without a plugin release — by an admin, or pushed
+     * fleet-wide via a signed policy bundle (the key is on
+     * {@see \local_ai_course_assistant\policy_bundle::ALLOWED_KEYS}). This
+     * mirrors how `rate_card_overrides` keeps per-model pricing current
+     * without a redeploy.
      *
      * @param string $model
      * @return bool
      */
     private static function model_supports_temperature(string $model): bool {
-        $denyprefixes = [
-            'claude-opus-4-7', 'claude-opus-4-8', 'claude-opus-4-9',
-            'claude-opus-5', 'claude-sonnet-5', 'claude-fable-5', 'claude-mythos-5',
-        ];
-        foreach ($denyprefixes as $prefix) {
+        $model = strtolower(trim($model));
+        if ($model === '') {
+            return false;
+        }
+        foreach (self::temperature_allow_prefixes() as $prefix) {
             if (str_starts_with($model, $prefix)) {
-                return false;
+                return true;
             }
         }
-        return true;
+        return false;
+    }
+
+    /**
+     * The effective allow-list: the admin/policy-bundle setting when set and
+     * parseable, otherwise the shipped default.
+     *
+     * @return string[]
+     */
+    private static function temperature_allow_prefixes(): array {
+        $raw = (string) get_config('local_ai_course_assistant', 'claude_temperature_allow_prefixes');
+        $out = [];
+        foreach (preg_split('/[\r\n,]+/', $raw) as $line) {
+            $line = strtolower(trim($line));
+            if ($line !== '' && $line[0] !== '#') {
+                $out[] = $line;
+            }
+        }
+        return $out ?: self::DEFAULT_TEMPERATURE_ALLOW_PREFIXES;
     }
 
     protected function get_default_base_url(): string {

--- a/classes/provider/claude_provider.php
+++ b/classes/provider/claude_provider.php
@@ -50,16 +50,24 @@ class claude_provider extends base_provider {
 
     /**
      * Whether the given Anthropic model accepts a `temperature` parameter.
-     * Opus 4.7 and 4.8 (reasoning-class models) reject temperature with HTTP
-     * 400; their successors will likely behave the same way. Maintain this
-     * as a per-prefix denylist so the model-specific 400 doesn't bubble up
-     * as the generic "something went wrong" error.
+     * Reasoning-class models reject sampling parameters (temperature, top_p,
+     * top_k) with HTTP 400: Opus 4.7 and 4.8, and the entire Claude 5 family
+     * (Opus 5, Sonnet 5, Fable 5, Mythos 5). Maintain this as a per-prefix
+     * denylist so the model-specific 400 doesn't bubble up as the generic
+     * "something went wrong" error.
+     *
+     * Note the prefixes are deliberately specific: `claude-sonnet-4-6` and
+     * earlier Sonnets DO accept temperature, so a bare `claude-sonnet` prefix
+     * would wrongly strip it from models that support it.
      *
      * @param string $model
      * @return bool
      */
     private static function model_supports_temperature(string $model): bool {
-        $denyprefixes = ['claude-opus-4-7', 'claude-opus-4-8', 'claude-opus-4-9'];
+        $denyprefixes = [
+            'claude-opus-4-7', 'claude-opus-4-8', 'claude-opus-4-9',
+            'claude-opus-5', 'claude-sonnet-5', 'claude-fable-5', 'claude-mythos-5',
+        ];
         foreach ($denyprefixes as $prefix) {
             if (str_starts_with($model, $prefix)) {
                 return false;

--- a/settings.php
+++ b/settings.php
@@ -246,6 +246,21 @@ if ($hassiteconfig) {
         ''
     ));
 
+    // v6.9.5: which Anthropic models accept `temperature`. An ALLOW-list —
+    // an unlisted model has temperature omitted, which is safe, rather than
+    // sent and rejected with a 400. Editable here (and pushable via policy
+    // bundle) so a newly released model never needs a plugin release.
+    $settings->add(new admin_setting_configtextarea(
+        'local_ai_course_assistant/claude_temperature_allow_prefixes',
+        'Claude models accepting temperature',
+        'One model-name prefix per line. Anthropic models whose name starts with one of '
+        . 'these still accept the <code>temperature</code> sampling parameter. Any Claude '
+        . 'model NOT matching a prefix has temperature omitted (reasoning-class models '
+        . 'since Opus 4.7 reject it with an HTTP 400). Leave blank to use the shipped default.',
+        implode("\n", \local_ai_course_assistant\provider\claude_provider::DEFAULT_TEMPERATURE_ALLOW_PREFIXES),
+        PARAM_RAW
+    ));
+
     $settings->add(new admin_setting_configtext(
         'local_ai_course_assistant/apibaseurl',
         get_string('settings:apibaseurl', 'local_ai_course_assistant'),

--- a/tests/claude_provider_temperature_denylist_test.php
+++ b/tests/claude_provider_temperature_denylist_test.php
@@ -116,6 +116,51 @@ final class claude_provider_temperature_denylist_test extends \advanced_testcase
         $this->assertTrue($this->supports('claude-sonnet-4-5'));
     }
 
+    /**
+     * An unrecognised / brand-new model defaults to OMITTING temperature.
+     * This is the point of the allow-list: a model released after this
+     * version of the plugin must not break every call.
+     *
+     * @covers ::model_supports_temperature
+     */
+    public function test_unknown_future_model_omits_temperature(): void {
+        $this->resetAfterTest();
+        $this->assertFalse($this->supports('claude-opus-7'));
+        $this->assertFalse($this->supports('claude-someting-entirely-new'));
+        $this->assertFalse($this->supports(''));
+    }
+
+    /**
+     * The allow-list is config-backed so a correction needs no plugin release.
+     *
+     * @covers ::model_supports_temperature
+     */
+    public function test_allowlist_is_overridable_by_config(): void {
+        $this->resetAfterTest();
+        // A future model can be enabled without a code change...
+        set_config('claude_temperature_allow_prefixes', "claude-opus-7\nclaude-haiku-4-5",
+            'local_ai_course_assistant');
+        $this->assertTrue($this->supports('claude-opus-7'));
+        $this->assertTrue($this->supports('claude-haiku-4-5'));
+        // ...and anything not on the override is omitted, including models
+        // that are on the shipped default.
+        $this->assertFalse($this->supports('claude-sonnet-4-6'));
+    }
+
+    /**
+     * An empty or comment-only setting falls back to the shipped default
+     * rather than denying everything.
+     *
+     * @covers ::model_supports_temperature
+     */
+    public function test_empty_config_falls_back_to_default(): void {
+        $this->resetAfterTest();
+        set_config('claude_temperature_allow_prefixes', "\n  \n# just a comment\n",
+            'local_ai_course_assistant');
+        $this->assertTrue($this->supports('claude-sonnet-4-6'));
+        $this->assertFalse($this->supports('claude-opus-5'));
+    }
+
     public function test_haiku_models_accept_temperature(): void {
         $this->assertTrue($this->supports('claude-haiku-4-5'));
         $this->assertTrue($this->supports('claude-haiku-3-5'));
@@ -126,9 +171,28 @@ final class claude_provider_temperature_denylist_test extends \advanced_testcase
         $this->assertTrue($this->supports('claude-3-5-sonnet-20241022'));
     }
 
-    public function test_empty_model_defaults_to_supports_temperature(): void {
-        // Defensive: a misconfigured row with empty model should not
-        // accidentally trip the deny-list. Default to supporting temp.
-        $this->assertTrue($this->supports(''));
+    public function test_empty_model_omits_temperature(): void {
+        // BEHAVIOUR CHANGE (allow-list migration). Previously an empty model
+        // defaulted to SENDING temperature, on the reasoning that a
+        // misconfigured row should not trip the deny-list. Under the
+        // allow-list the safe default inverts: an unrecognised model omits
+        // temperature, which costs nothing (the model uses its own default)
+        // whereas sending it to a model that rejects it fails every call.
+        $this->assertFalse($this->supports(''));
+    }
+
+    /**
+     * Dated full model IDs must resolve the same way as their aliases —
+     * including claude-sonnet-4-20250514, which is this provider's own
+     * get_default_model() and therefore what an empty config resolves to.
+     *
+     * @covers ::model_supports_temperature
+     */
+    public function test_dated_full_ids_match_their_alias_behaviour(): void {
+        $this->assertTrue($this->supports('claude-sonnet-4-20250514'));
+        $this->assertTrue($this->supports('claude-opus-4-20250514'));
+        $this->assertTrue($this->supports('claude-opus-4-5-20251101'));
+        // Denied models keep being denied in dated form.
+        $this->assertFalse($this->supports('claude-opus-4-8-20260101'));
     }
 }

--- a/tests/claude_provider_temperature_denylist_test.php
+++ b/tests/claude_provider_temperature_denylist_test.php
@@ -91,6 +91,31 @@ final class claude_provider_temperature_denylist_test extends \advanced_testcase
         $this->assertTrue($this->supports('claude-sonnet-4-5'));
     }
 
+    /**
+     * The Claude 5 family removed sampling parameters entirely — temperature,
+     * top_p and top_k all return HTTP 400.
+     *
+     * @covers ::model_supports_temperature
+     */
+    public function test_claude_5_family_rejects_temperature(): void {
+        $this->assertFalse($this->supports('claude-opus-5'));
+        $this->assertFalse($this->supports('claude-sonnet-5'));
+        $this->assertFalse($this->supports('claude-fable-5'));
+        $this->assertFalse($this->supports('claude-mythos-5'));
+    }
+
+    /**
+     * Sonnet 5 is denied but Sonnet 4.6 and 4.5 are not — the denylist must
+     * not be widened to a bare `claude-sonnet` prefix.
+     *
+     * @covers ::model_supports_temperature
+     */
+    public function test_sonnet_5_denied_without_catching_earlier_sonnets(): void {
+        $this->assertFalse($this->supports('claude-sonnet-5'));
+        $this->assertTrue($this->supports('claude-sonnet-4-6'));
+        $this->assertTrue($this->supports('claude-sonnet-4-5'));
+    }
+
     public function test_haiku_models_accept_temperature(): void {
         $this->assertTrue($this->supports('claude-haiku-4-5'));
         $this->assertTrue($this->supports('claude-haiku-3-5'));


### PR DESCRIPTION
**Stacked on #163** — merge that first, or merge this alone (it supersedes #163's deny-list entirely).

## Why
#163 fixed the immediate bug by adding four models to a deny-list. That's the right *immediate* fix, but it's a treadmill: every future model that drops sampling parameters needs a code change **and a plugin release**, which means the next model breaks on arrival for every installed site.

## What changes

**1. Deny-list → allow-list.** An unrecognised model now **omits** temperature rather than sending it. The failure modes are asymmetric:

| | Effect |
|---|---|
| Omit temperature from a model that accepts it | Model uses its own default. Harmless. |
| Send temperature to a model that rejects it | **HTTP 400 on every call.** |

Anthropic has removed sampling parameters from every reasoning-class model since Opus 4.7 (4.7, 4.8, and the whole Claude 5 family), so an unknown model is now *more likely to reject than accept*. Defaulting to omit means a model released after this version works on day one.

**2. The list is config-backed.** New `claude_temperature_allow_prefixes` setting, exposed in admin and added to `policy_bundle::ALLOWED_KEYS` — so a correction ships as a **signed policy bundle, not a release**. This deliberately mirrors `rate_card_overrides`, which already keeps per-model pricing current without a redeploy.

## One trap worth knowing about
Anthropic's ID space is inconsistent: aliases (`claude-opus-4-1`) do **not** prefix-match dated IDs (`claude-sonnet-4-20250514`). A naive allow-list therefore misses the dated 4.0-generation IDs — including `claude-sonnet-4-20250514`, which is **this provider's own `get_default_model()`**. Missing it would have silently stopped sending temperature to the fallback model. Dated prefixes are listed explicitly with a regression test.

## ⚠️ Behaviour change
An **empty** model string previously defaulted to *sending* temperature (defensive: "don't let a misconfigured row trip the deny-list"). It now **omits**. Under allow-list semantics the safe default inverts, and omitting costs nothing. The pre-existing test is updated with that rationale rather than silently deleted.

## Tests
**16 tests / 33 assertions pass.** New coverage: unknown/future model omits; config override works both directions; empty/comment-only config falls back to the shipped default; dated full IDs match their alias behaviour.