### PR TITLE
Add a dedicated quiz-coach provider/model setting

### DIFF
--- a/classes/external/generate_quiz.php
+++ b/classes/external/generate_quiz.php
@@ -198,7 +198,7 @@ class generate_quiz extends external_api {
 
         $quizschema = self::get_quiz_json_schema($count, $objectivesblock !== '');
         try {
-            $provider = base_provider::create_from_config($courseid);
+            $provider = self::resolve_quiz_provider($courseid);
             $response = $provider->chat_completion(
                 $systemprompt,
                 [['role' => 'user', 'content' => 'Generate the quiz now.']],
@@ -459,5 +459,36 @@ INSTRUCTIONS;
         } catch (\Throwable $e) {
             return 'Chat history unavailable.';
         }
+    }
+
+    /**
+     * Resolve which provider runs the quiz-coach turn.
+     *
+     * Mirrors conversation_classifier::resolve_classifier_provider(): if both
+     * quiz_provider and quiz_model are set, route through
+     * comparison_providers so the API key, base URL and temperature come from
+     * the row admins already manage. Otherwise fall back to the course's
+     * primary chat provider — preserving the previous behaviour on every site
+     * that never touches these settings.
+     *
+     * Before this, quiz generation always ran on the chat tier, so the vendor
+     * recommendation of a cheaper dedicated quiz model was unimplementable
+     * without changing the chat model too.
+     *
+     * @param int $courseid
+     * @return \local_ai_course_assistant\provider\provider_interface
+     */
+    private static function resolve_quiz_provider(int $courseid) {
+        $providerid = trim((string) get_config('local_ai_course_assistant', 'quiz_provider'));
+        $model = trim((string) get_config('local_ai_course_assistant', 'quiz_model'));
+        if ($providerid !== '' && $model !== '') {
+            try {
+                return base_provider::create_for_comparison($providerid, $model, $courseid);
+            } catch (\Throwable $e) {
+                debugging('quiz provider unavailable, falling back to chat tier: '
+                    . $e->getMessage(), DEBUG_DEVELOPER);
+            }
+        }
+        return base_provider::create_from_config($courseid);
     }
 }

--- a/classes/policy_bundle.php
+++ b/classes/policy_bundle.php
@@ -101,6 +101,8 @@ class policy_bundle {
         'history_candidates',
         'history_semantic_minscore',
         // Mastery classifier (v5.11).
+        'quiz_provider',
+        'quiz_model',
         'mastery_classifier_provider',
         'mastery_classifier_model',
         'mastery_classifier_threshold',

--- a/settings.php
+++ b/settings.php
@@ -1970,7 +1970,28 @@ if ($hassiteconfig) {
     // escalation block interrupted this group, splitting provider from its
     // three siblings — admins tuning the classifier had to scroll past an
     // unrelated feature.
+        // Quiz coach: optional dedicated provider/model. Empty (the default)
+    // keeps quiz generation on the course's chat provider, which is the
+    // pre-v6.9.5 behaviour. Set both to route quiz turns to a cheaper or
+    // better-suited model without touching the chat tier.
     $settings->add(new admin_setting_configtext(
+        'local_ai_course_assistant/quiz_provider',
+        'Quiz coach provider',
+        'Provider id (e.g. <code>claude</code>, <code>openai</code>) for quiz generation. '
+        . 'Must match a row in Comparison providers. Leave blank to use the chat provider.',
+        '',
+        PARAM_ALPHANUMEXT
+    ));
+    $settings->add(new admin_setting_configtext(
+        'local_ai_course_assistant/quiz_model',
+        'Quiz coach model',
+        'Model name for quiz generation, e.g. <code>claude-haiku-4-5</code>. '
+        . 'Both this and the provider must be set for the override to apply.',
+        '',
+        PARAM_RAW_TRIMMED
+    ));
+
+$settings->add(new admin_setting_configtext(
         'local_ai_course_assistant/mastery_classifier_provider',
         get_string('settings:mastery_classifier_provider', 'local_ai_course_assistant'),
         get_string('settings:mastery_classifier_provider_desc', 'local_ai_course_assistant'),

--- a/tests/quiz_provider_routing_test.php
+++ b/tests/quiz_provider_routing_test.php
@@ -1,0 +1,96 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Quiz-coach provider routing (v6.9.5).
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_ai_course_assistant\external\generate_quiz
+ */
+final class quiz_provider_routing_test extends \advanced_testcase {
+
+    /**
+     * Invoke the private resolver.
+     *
+     * @return string Resolved model name.
+     */
+    private function resolved_model(): string {
+        $m = new \ReflectionMethod(\local_ai_course_assistant\external\generate_quiz::class, 'resolve_quiz_provider');
+        $m->setAccessible(true);
+        $provider = $m->invoke(null, 0);
+        // `model` is a protected property on base_provider with no public
+        // accessor; read it reflectively for the assertion.
+        $prop = new \ReflectionProperty($provider, 'model');
+        $prop->setAccessible(true);
+        return (string) $prop->getValue($provider);
+    }
+
+    /**
+     * With no override set, quiz stays on the chat provider — the behaviour
+     * every existing site relies on.
+     */
+    public function test_defaults_to_chat_provider(): void {
+        $this->resetAfterTest();
+        set_config('provider', 'openai', 'local_ai_course_assistant');
+        set_config('model', 'gpt-4o-mini', 'local_ai_course_assistant');
+        set_config('quiz_provider', '', 'local_ai_course_assistant');
+        set_config('quiz_model', '', 'local_ai_course_assistant');
+
+        $this->assertSame('gpt-4o-mini', $this->resolved_model());
+    }
+
+    /**
+     * A half-configured override (provider only, or model only) must NOT
+     * take effect — it falls back to the chat provider rather than routing
+     * to a provider with no model.
+     */
+    public function test_partial_override_is_ignored(): void {
+        $this->resetAfterTest();
+        set_config('provider', 'openai', 'local_ai_course_assistant');
+        set_config('model', 'gpt-4o-mini', 'local_ai_course_assistant');
+
+        set_config('quiz_provider', 'claude', 'local_ai_course_assistant');
+        set_config('quiz_model', '', 'local_ai_course_assistant');
+        $this->assertSame('gpt-4o-mini', $this->resolved_model());
+
+        set_config('quiz_provider', '', 'local_ai_course_assistant');
+        set_config('quiz_model', 'claude-haiku-4-5', 'local_ai_course_assistant');
+        $this->assertSame('gpt-4o-mini', $this->resolved_model());
+    }
+
+    /**
+     * An unresolvable provider degrades to the chat tier rather than
+     * throwing — quiz generation must not hard-fail on a bad setting.
+     */
+    public function test_unresolvable_override_falls_back_without_throwing(): void {
+        $this->resetAfterTest();
+        set_config('provider', 'openai', 'local_ai_course_assistant');
+        set_config('model', 'gpt-4o-mini', 'local_ai_course_assistant');
+        set_config('quiz_provider', 'nosuchprovider', 'local_ai_course_assistant');
+        set_config('quiz_model', 'nosuchmodel', 'local_ai_course_assistant');
+
+        $this->assertSame('gpt-4o-mini', $this->resolved_model());
+        // The fallback is deliberately noisy in developer mode so a broken
+        // override is diagnosable rather than silently ignored.
+        $this->assertDebuggingCalled();
+    }
+}


### PR DESCRIPTION
## Problem
`generate_quiz.php` called `base_provider::create_from_config()`, so **quiz generation always ran on the course's chat provider**. There was no quiz-specific setting.

That means the vendor-doc recommendation of *"quiz coach: gpt-4o-mini"* was never actually implementable — the only way to change the quiz model was to change the chat model too. (Worth knowing: on the dev fleet the quiz coach has therefore been running **Gemini 2.5 Flash**, not gpt-4o-mini as the docs state.)

## Change
Add `quiz_provider` / `quiz_model`, mirroring the existing `mastery_classifier_provider` / `_model` pattern **exactly**:

- **Both set** → route through `comparison_providers`, so the API key, base URL and temperature come from the row admins already manage.
- **Either blank** → fall back to the chat provider. This is the default, so **behaviour is unchanged for every existing site**.
- **Unresolvable** → fall back to the chat tier with a `debugging()` note rather than hard-failing quiz generation.

Both keys are on `policy_bundle::ALLOWED_KEYS`, so routing can be tuned fleet-wide without a release.

## Why now
From the [2026-07-30 benchmark](https://docs.google.com/document/d/1XIPcOtpEETmVyPHp47KmpROx05oPWGGeWFwd4-KkJAo/edit): **Haiku 4.5 wins the quiz-coach category at 14.80/15** vs gpt-4o-mini's 13.90, with the best latency in the field (612 ms TTFT). This PR is what makes acting on that possible.

To adopt after merge:
```
quiz_provider = claude
quiz_model    = claude-haiku-4-5
```

## Tests
3 new tests / 5 assertions covering: default falls back to chat provider; a **half-configured** override (provider-only or model-only) is ignored rather than routing to a provider with no model; an unresolvable override falls back without throwing and emits the diagnostic.

Full plugin suite: **634 tests, 1558 assertions, 0 failures.**