### PR TITLE
docs: per-course rerank gating scope + retrieval cost projections

### DIFF
--- a/.drafts/sola-per-course-rerank-gating-scope-2026-07-31.md
+++ b/.drafts/sola-per-course-rerank-gating-scope-2026-07-31.md
@@ -1,0 +1,145 @@
+# Scope: per-course rerank gating
+
+**Status:** scoping only, nothing built.
+**Date:** 2026-07-31
+**Source data:** `.drafts/sola-model-benchmark-2026-07-30.md` (1,008-query sweep, 16 courses)
+
+---
+
+## The finding this responds to
+
+Reranking is not uniformly good. On the 1,008-query sweep it helped 14 of 16 courses, was neutral on one, and actively hurt the one course whose embedding recall was already 98.4%. The benefit tracks how *weak* the embedding baseline is.
+
+Per-query, across all 1,008 queries at pool 30:
+
+| Outcome | Queries | Share |
+|---|---|---|
+| Rerank improved the target's rank | 338 | 33.5% |
+| Rerank worsened it | 129 | 12.8% |
+| No change | 541 | 53.7% |
+
+Split by what the embedding stage had already achieved:
+
+| Situation | Count | Outcome |
+|---|---|---|
+| Embedding already had the target at **rank 1** | 557 | Rerank pushed it **out of rank 1 in 67 (12.0%)** |
+| Embedding had the target **outside top 3** | 210 | Rerank pulled it **into top 3 in 130 (61.9%)** |
+
+That is the whole story in two rows. **Reranking is an excellent rescuer and a mediocre custodian.** It fixes 62% of deep misses and breaks 12% of already-perfect results. Whether it is worth enabling depends entirely on how many of each a given course has.
+
+Per course, sorted by baseline recall@3:
+
+| Course | Base R@3 | Already rank 1 | Broken by rerank | Deep misses | Rescued |
+|---|---|---|---|---|---|
+| course43 | 58.7% | 18 | 1 | 26 | 10 |
+| course117 | 65.1% | 29 | 8 | 22 | 14 |
+| course132 | 69.8% | 29 | 3 | 19 | 11 |
+| course130 | 71.4% | 35 | 4 | 18 | 16 |
+| course116 | 74.6% | 35 | 5 | 16 | 10 |
+| course128 | 76.2% | 38 | 2 | 15 | 11 |
+| course149 | 76.2% | 32 | 3 | 15 | 8 |
+| course11 | 77.8% | 36 | 2 | 14 | 7 |
+| course129 | 77.8% | 34 | 2 | 14 | 8 |
+| course3 | 79.4% | 31 | 2 | 13 | 10 |
+| course2 | 82.5% | 32 | 6 | 11 | 8 |
+| course115 | 85.7% | 38 | 5 | 9 | 7 |
+| course8 | 85.7% | 42 | 5 | 9 | 4 |
+| course131 | 93.7% | 46 | 5 | 4 | 2 |
+| course4 | 93.7% | 42 | 5 | 4 | 4 |
+| **course7** | **98.4%** | **40** | **9** | **1** | **0** |
+
+course7 is the clean negative case: 9 correct top-1 results broken, 1 deep miss available, 0 rescued. Pure loss. course43 is the clean positive: 26 deep misses, 10 rescued, 1 broken.
+
+---
+
+## The part that is easy, and the part that is not
+
+**The mechanism is nearly free.** `rag_retriever::retrieve()` already takes `$courseid`, and `feature_flags::resolve()` already implements exactly this override pattern (`<feature>_enabled_course_<id>` beating `<feature>_enabled`, as used by Soapbox and the avatar animation A/B). The gating change at `classes/rag_retriever.php:176` is one line:
+
+```php
+// from
+if ((bool) get_config('local_ai_course_assistant', 'rerank_enabled')) {
+// to
+if (feature_flags::resolve('rerank', $courseid)) {
+```
+
+**The decision procedure is the entire cost of this project.** Deciding *which* courses to enable requires knowing each course's baseline recall, and recall requires ground truth — a set of questions with known correct chunks. Production courses do not have that.
+
+---
+
+## Options
+
+### A. Measure per course with synthetic fixtures, gate on a threshold
+
+Reuse the pipeline from the benchmark: for each course, sample N chunks, generate one question per chunk with gpt-4o-mini, measure embedding-only recall@3, write `rerank_enabled_course_<id>` when below threshold.
+
+- **Pro:** fully automatic; reuses `generate_conversational_fixtures.php` and `run_rag_fixture_benchmark.php`; cheap (~$0.02 and ~2 minutes per course).
+- **Con — and this is serious:** synthetic questions are *easier than real ones*. The same benchmark found baseline R@3 of 79.2% on synthetic questions versus 55.0% on human-written colloquial ones, because a question generated from a chunk inherits that chunk's vocabulary. **A synthetic-derived baseline is optimistic, so a fixed threshold will systematically under-enable reranking on courses that actually need it.**
+- Mitigation: calibrate the threshold against synthetic scale rather than intuition, or gate on *relative* rank (enable on the weakest N courses) rather than an absolute number. Relative ranking is immune to the bias as long as it is uniform across courses — which is plausible but unverified.
+
+### B. Per-query gate on retrieval confidence
+
+Skip the per-course question entirely. Rerank only when the embedding stage looks *unsure* — low top-1 score, or a narrow margin between top-1 and top-3.
+
+- **Pro:** no ground truth needed anywhere; adapts within a course; targets spend precisely; and it attacks the harm directly, since 557 of 1,008 queries were confident top-1 hits and that is where all 67 breakages came from. Skipping those avoids the harm *and* cuts most of the cost.
+- **Con:** unvalidated. The hypothesis that score margin predicts rerank benefit is plausible but untested, and **the benchmark harness does not currently emit the needed signal** — `per_fixture` records the *target's* cosine score (which needs ground truth) but not the top-1 score or the top-k spread of the retrieved set.
+- **Prerequisite:** one harness change (emit top-1 and top-3 cosine scores per query) plus a re-analysis of the existing 1,008-query run. No new API spend — the run can be replayed. This is a few hours, and it either validates the whole approach or kills it cheaply.
+
+### C. Manual override list
+
+Enable reranking globally, then set `rerank_enabled_course_<id> = 0` by hand on the handful of courses measured as already strong.
+
+- **Pro:** ships today, needs only the one-line change, zero new machinery.
+- **Con:** does not scale to 162 courses and goes stale as content changes.
+
+---
+
+## Recommendation
+
+**Do the one-line mechanism change now. Do not build measurement automation yet. Run the Option B prerequisite experiment before committing to anything larger.**
+
+Reasoning:
+
+1. **The mechanism is worth having regardless.** It is one line against existing, tested machinery, and it unblocks C immediately.
+2. **This is a quality project, not a cost project, and it should be justified as one.** At 20,000 SOLA users the entire rerank bill is $65-163/month. Per-course gating might halve it. Nobody should build a measurement subsystem to save $50/month. The real prize is not paying a 12% top-1 breakage tax on courses that gain nothing — and on course7 specifically, reranking is strictly worse than not reranking.
+3. **Option B probably dominates A** if the confidence signal holds, because it addresses the harm at query granularity, needs no ground truth, and saves more money. It is also much less code. Testing it is cheap and can reuse data already paid for.
+4. **Option A's bias is a real trap.** Building automation on a measurement we already know is optimistic would produce a system that looks principled and quietly under-enables the feature where it matters most.
+
+---
+
+## Implementation surface
+
+If Option B validates, the shape is roughly:
+
+| Change | File | Size |
+|---|---|---|
+| Per-course gate | `classes/rag_retriever.php:176` | 1 line |
+| Emit top-k score spread | `admin/cli/run_rag_fixture_benchmark.php` | small |
+| Confidence threshold setting | `settings.php` + `policy_bundle::ALLOWED_KEYS` | small |
+| Per-query gate | `classes/rag_retriever.php` | ~10 lines |
+| Admin visibility | `rag_admin.php` per-course cards | moderate |
+
+Note `policy_bundle::ALLOWED_KEYS` is a fixed list and per-course keys are dynamic (`rerank_enabled_course_<id>`), so per-course overrides are **not** currently pushable via a signed bundle. Either accept that (set them via CLI/UI) or extend the allowlist to support a suffix pattern — the latter needs care, since the allowlist is a security control and pattern-matching weakens it.
+
+---
+
+## Rollout and rollback
+
+- Ship the mechanism behind unchanged defaults: with no per-course key set, `resolve()` returns the global, so **behaviour is identical for every existing site**.
+- Roll out on dev first, per course, watching the analytics comparison card (`analytics::get_experiment_metrics()`) which already supports A/B by course.
+- Rollback is deleting a config row.
+
+---
+
+## Open questions
+
+1. Does embedding-stage confidence actually predict rerank benefit? (Option B prerequisite — answerable from existing data.)
+2. Is the synthetic-vs-real recall bias uniform across courses? If not, relative ranking in Option A is unsafe too.
+3. Does the pattern hold on *real* learner queries? Everything here rests on synthetic questions. Prod now logs real turns; sampling those and hand-labelling a few dozen would be the strongest possible validation, and is the only route to ground truth that has no generation bias.
+4. Should the gate be recall-based at all, rather than "does this course have long, homogeneous chunks that confuse cosine similarity?" There may be a cheaper structural predictor.
+
+---
+
+## What this does not require
+
+Prod changes. Reranking is off in production (`rerank_enabled=0`) and `rerank_candidates` is inert there. Nothing in this scope needs a prod deploy until the feature is actually adopted.

--- a/.drafts/sola-retrieval-cost-projections-2026-07-31.md
+++ b/.drafts/sola-retrieval-cost-projections-2026-07-31.md
@@ -1,0 +1,154 @@
+# SOLA retrieval: benchmark summary and cost projections at 5k / 10k / 25k
+
+**Date:** 2026-07-31
+**Supersedes:** every earlier rerank cost figure in `.drafts/` (see the cleanup list at the end)
+**Benchmark source:** `.drafts/sola-model-benchmark-2026-07-30.md` — 1,008 queries across 16 courses, four pool sizes, run 2026-07-30
+
+---
+
+## Was a re-run needed?
+
+**No.** The retrieval benchmark is one day old and is the most thorough one we have: 1,008 synthetic conversational queries across all 16 indexed courses, four `rerank_candidates` values, plus embeddings scored two independent ways (recall against ground truth, and LLM-judged relevance). Re-running would cost money and change nothing.
+
+What *was* missing is the cost model, because every previous projection multiplied a correct per-query cost by a wrong volume. That is what this document fixes, using production measurements taken today.
+
+---
+
+## Benchmark summary (unchanged, restated)
+
+### Reranker: Voyage rerank-2.5
+
+| Pool | R@1 | R@3 | R@5 | MRR | Delta R@3 | Cost/query |
+|---|---|---|---|---|---|---|
+| Embedding only | 55.3% | 79.2% | 86.8% | 0.687 | — | — |
+| 30 | 72.7% | 89.3% | 93.6% | 0.817 | +10.1 pp | $0.00112 |
+| **20** | 72.3% | 89.0% | 93.5% | 0.813 | +9.8 pp | **$0.00075** |
+| 10 | 71.7% | 87.0% | 90.6% | 0.798 | +7.8 pp | $0.00037 |
+
+Pool 20 gives up 0.3 pp of R@3 against pool 30 for 33% less cost. Pool 10 is where real degradation starts. Pool 5 was never tested — the CLI silently clamps `--candidates` to a floor of 10.
+
+Per query, across all 1,008: rerank improved 33.5%, worsened 12.8%, left 53.7% unchanged. It **rescued 61.9% of targets that were outside the top 3**, and **broke 12.0% of targets the embedding stage had already put at rank 1**. Reranking is an excellent rescuer and a mediocre custodian — which is the basis for the per-course gating scope in `sola-per-course-rerank-gating-scope-2026-07-31.md`.
+
+### Embeddings: OpenAI vs Voyage
+
+| Method | OpenAI text-embedding-3-small | Voyage-3.5 |
+|---|---|---|
+| Recall mode (R@3, curated) | **55.0%** | 52.5% |
+| Recall mode (MRR) | **0.468** | 0.451 |
+| Judged (nDCG@5) | **0.951** | 0.943 |
+| Judged (P@5) | **0.700** | 0.665 |
+| Price per 1M tokens | **$0.02** | $0.06 |
+
+OpenAI leads on both scoring methods and is 3x cheaper. **Keep OpenAI.** No migration case exists; this is now the third measurement agreeing (2026-07-08, plus both methods here).
+
+---
+
+## Cost model inputs (all measured, not assumed)
+
+| Input | Value | Source |
+|---|---|---|
+| Turns per SOLA user per month | **5.07** | prod, July 2026: 6,184 turns / 1,220 users |
+| Prompt tokens per chat call | **~5,110** | prod, `msgs.prompt_tokens` on Gemini rows |
+| Completion tokens per chat call | **~168** | same |
+| Blended chat cost per call | **$0.00184** | 3-provider live mix, below |
+| Rerank cost per query (pool 20) | **$0.00075** | 1,008-query sweep |
+| Message storage per turn | **~2.8 KB** | prod row sizes + row overhead |
+
+Production currently runs a three-provider mix, so chat cost is blended:
+
+| Model | Calls | Prompt / completion | $/call |
+|---|---|---|---|
+| gemini-2.5-flash | 2,733 | 5,110 / 168 | $0.00195 |
+| gpt-4o-mini | 2,463 | 5,127 / 180 | $0.00088 |
+| claude-haiku-4-5 | 1,585 | 1,594 / 312 | $0.00315 |
+| **Blended** | 6,781 | — | **$0.00184** |
+
+> **Note on prompt size.** Real prompts are ~5,110 tokens because they carry the system prompt, retrieved RAG chunks, and history. Benchmark prompts are far smaller. Using a benchmark-derived cost per call against real volume understates chat spend by roughly 4x — that error is what produced the earlier wrong conclusions, and it is worth not repeating.
+
+---
+
+## Projections
+
+**Assumption: "students" = SOLA users active in a given month.** At the 20% adoption rate used previously, these correspond to roughly 25k / 50k / 125k total active learners.
+
+| SOLA users | Turns/month | Chat $/mo | Rerank @10 | **Rerank @20** | Rerank @30 | Rerank @50 | Messages GB/yr |
+|---|---|---|---|---|---|---|---|
+| **5,000** | 25,300 | $47 | $9 | **$19** | $28 | $47 | 0.9 |
+| **10,000** | 50,700 | $93 | $19 | **$38** | $57 | $95 | 1.8 |
+| **25,000** | 126,700 | $234 | $47 | **$95** | $142 | $237 | 4.4 |
+
+Query embedding cost is negligible at every scale (under $0.10/month even at 25,000 users) and is omitted.
+
+### Rerank as a share of chat spend
+
+This ratio is scale-invariant, which makes it the more useful number for a decision:
+
+| Pool | Share of chat spend |
+|---|---|
+| 10 | 20.1% |
+| **20** | **40.7%** |
+| 30 | 60.8% |
+| **50 (prod's current value)** | **101.3%** |
+
+**At prod's configured `rerank_candidates=50`, switching reranking on would roughly double the AI bill.** At pool 20 it adds about 41%. That is the single strongest argument for dropping the setting to 20 before any enable — it is not a rounding-error optimization, it is the difference between a 41% and a 101% increase.
+
+### What does not scale with student count
+
+These are driven by course count (162), not enrolment:
+
+| Quantity | Value |
+|---|---|
+| Chunks | 110,300 |
+| Corpus tokens | 77.5M |
+| One-time full index | **$1.55** |
+| Full index build time | ~14 minutes |
+| Embedding storage (JSON, as stored today) | 3.25 GB |
+| Embedding storage (float32 binary) | 0.68 GB |
+| Embedding storage (512d MRL binary) | 0.23 GB |
+
+Retrieval is scoped per course, so a learner's query is compared against ~681 vectors regardless of catalog size. **Adding courses costs storage, not latency or recall.**
+
+### A storage note worth acting on
+
+The `msgs` table is dominated by non-conversation rows. On prod: 72,982 `system` rows versus 7,050 `user` and 6,798 `assistant` — **84% of rows are telemetry**, averaging 10.9 bytes each. They are only 11% of stored bytes but 12.3 rows are written per learner turn.
+
+At 25,000 users that is ~18.7M rows/year rather than ~3M. Storage stays modest (4.4 GB/yr), but row count drives index size and query plans on a table that already has a `role_timecreated` index. Worth a retention policy or moving telemetry to its own table before the higher scale points, not urgent at 5k.
+
+---
+
+## Recommendations
+
+1. **Keep OpenAI embeddings.** Settled by three independent measurements.
+2. **Set `rerank_candidates=20`** everywhere before any rerank enable. Prod is at 50, which costs 2.5x for no measurable quality gain.
+3. **Do not enable rerank site-wide.** At pool 20 it is +41% on the AI bill for +9.8 pp recall — defensible on weak courses, waste-plus-harm on strong ones. See the gating scope.
+4. **Revisit the `msgs` telemetry rows** before 25k.
+5. **Confirm the Gemini rate.** These figures use the rate card's $0.30/$2.50 per MTok. An earlier doc used $0.10/$0.40. If the lower figure is right, chat costs drop ~3x and reranking looks *worse* by comparison, strengthening recommendations 2 and 3.
+
+---
+
+## Cleanup: documents carrying superseded rerank figures
+
+Every figure below predates the production measurement and is wrong by roughly an order of magnitude in one direction or the other.
+
+**Trash (Google Docs, superseded — I have no delete capability, these need doing by hand):**
+
+| Doc | Problem |
+|---|---|
+| [SOLA Model Benchmark — Claude 5 family vs. incumbents](https://docs.google.com/document/d/1XIPcOtpEETmVyPHp47KmpROx05oPWGGeWFwd4-KkJAo/edit) | rerank projected at $1,346/mo |
+| [SOLA Model Benchmark — Claude 5 family + retrieval layer](https://docs.google.com/document/d/1oqxJDKmyB6zNUt2SYyRKr-AocAtM-i1mhXa26hn_k8E/edit) | rerank projected at $1,346/mo |
+
+**Keep:** [SOLA Model Benchmark + Retrieval + Scale Projection — FINAL](https://docs.google.com/document/d/1rXgU8tJg5bW1lRwI0H254BiIoEeE4ksnlujSWZLy6Zw/edit)
+
+**Correct, do not delete (these are historical records with other still-valid content):**
+
+| File | Stale content |
+|---|---|
+| `sola-vendor-recommendations-2026-06-09.md` | rerank $63/mo; 58k turns/day at 25k users (13.8x too high) |
+| `sola-vendor-optimization-by-mau-2026-06-09.md` | rerank $63/mo |
+| `sola-multi-provider-optimization-plan.md` | rerank $63/mo |
+| `sola-pilot-to-scale-vendor-recommendations-2026-06-01.md` | rerank $63/mo; stale turn assumption |
+| `sola-rag-fixture-benchmark-2026-06-10.md` | rerank $63/mo, $0.00163/query |
+| `sola-v5.11.0-external-actions.md` | stale turn assumption |
+| `v5.11.0-release-notes-and-walkthrough.md` | rerank $63/month (shipped release note — annotate, do not rewrite history) |
+
+The single most load-bearing correction is in `sola-vendor-recommendations-2026-06-09.md`: its capacity table drives the procurement and rate-limit conclusions, and its 70-turns-per-user assumption is 13.8x the measured 5.07.


### PR DESCRIPTION
Two documents. No code changes.

## 1. Per-course rerank gating scope

Scoping only, nothing built. Responds to the 1,008-query sweep finding that reranking helps 14 of 16 courses but hurts the one already at 98.4% baseline recall.

Per-query analysis of the existing sweep data (no new API spend):

| Situation | Count | Outcome |
|---|---|---|
| Embedding already had the target at **rank 1** | 557 | rerank pushed it out in **67 (12.0%)** |
| Embedding had the target **outside top 3** | 210 | rerank pulled it in for **130 (61.9%)** |

Reranking is an excellent rescuer and a mediocre custodian. Whether a course should have it on depends on its ratio of deep misses to confident hits.

**The mechanism is nearly free** — `retrieve()` already takes `$courseid` and `feature_flags::resolve()` already implements this override pattern, so gating is one line at `rag_retriever.php:176`. The decision procedure is the entire cost.

**Recommendation: ship the one-line mechanism, do not build measurement automation yet.** First run a cheap prerequisite experiment on whether embedding-stage confidence predicts rerank benefit — that would need no ground truth at all and can be tested by replaying the existing 1,008-query run once the harness emits top-k score spread.

Two traps recorded:
- Synthetic fixtures measure recall optimistically (79.2% vs 55.0% on the same corpus), because a generated question inherits its source chunk's vocabulary. An absolute threshold built on them would under-enable rerank precisely where it is most needed, while looking rigorous.
- This is a quality project, not a cost one. The whole rerank bill is $19-95/mo at these scale points, so no measurement subsystem can pay for itself on cost. The case is avoiding a 12% top-1 breakage tax on courses that gain nothing.

## 2. Retrieval cost projections at 5k / 10k / 25k

No new benchmark run — the 2026-07-30 retrieval benchmark is a day old and comprehensive. What was missing was a correct cost model, now built entirely on production measurements.

| SOLA users | Turns/mo | Chat $/mo | Rerank @20 | @30 | @50 | Msgs GB/yr |
|---|---|---|---|---|---|---|
| 5,000 | 25,300 | $47 | $19 | $28 | $47 | 0.9 |
| 10,000 | 50,700 | $93 | $38 | $57 | $95 | 1.8 |
| 25,000 | 126,700 | $234 | $95 | $142 | $237 | 4.4 |

The decision-relevant figure is scale-invariant — rerank as a share of chat spend: **20% at pool 10, 41% at pool 20, 61% at pool 30, 101% at pool 50.** Prod is configured at 50, so enabling reranking there today would roughly double the AI bill for no measurable quality gain over pool 20.

Measured inputs: 5.07 turns/user/month; ~5,110 prompt and ~168 completion tokens per call; $0.00184 blended cost per call across the live three-provider mix; ~2.8 KB message storage per turn.

### A near-miss recorded in the doc

A first pass used the golden-set cost per call (0.052c) against real volume and concluded reranking costs more than chat generation. Real prompts are ~5,110 tokens because they carry the system prompt, RAG chunks and history, so real chat cost is ~4x the benchmark figure. This is the same class of error as the earlier $1,346/mo mistake: a benchmark-derived unit multiplied by production volume. Caught before publishing, but it has now happened twice, so the real inputs are written into the doc explicitly.

### Storage finding

84% of `msgs` rows are telemetry — 72,982 `system` rows at 10.9 bytes each versus 7,050 user and 6,798 assistant, i.e. 12.3 rows per learner turn. Bytes stay small but row count reaches ~18.7M/year at 25k users. Worth a retention policy before that scale point.

### Cleanup list

Includes an audit of the seven `.drafts` files and two Google Docs still carrying superseded rerank figures. The load-bearing one is `sola-vendor-recommendations-2026-06-09.md`, whose capacity table drives procurement and rate-limit conclusions on a turns-per-user assumption that is 13.8x the measured value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
