### PR TITLE
docs: annotate superseded rerank cost figures across seven drafts

### DIFF
--- a/.drafts/moodle-marketplace-migration-question-2026-07-26.md
+++ b/.drafts/moodle-marketplace-migration-question-2026-07-26.md
@@ -1,0 +1,41 @@
+# Question to Moodle — in-flight approval during the Marketplace migration
+
+**Send this before uploading v6.9.4 anywhere.** It resolves which route applies, so we do not create a duplicate listing or upload into a queue nobody is reading.
+
+**Where to send:** the Marketplace support request (Jira Service Desk, linked as "Create a support request" from https://marketplace.moodle.com/). If that form does not fit an existing-plugin question, post the same text as a comment on https://moodle.atlassian.net/browse/CONTRIB-10574 — the reviewer note already carries a shortened version of the same question as a fallback.
+
+**Why we are asking:** `moodle.org/plugins` now redirects to `marketplace.moodle.com`, moodledev.io marks the old contribution process as legacy, and the launch communications we found describe onboarding for *paid* plugins. None of the public documentation covers a plugin that was already mid-approval in the legacy queue, which is our situation.
+
+---
+
+Subject: Plugin in initial approval (CONTRIB-10574) — correct route after the Marketplace migration?
+
+Hello,
+
+We maintain **local_ai_course_assistant** (SOLA — Saylor Online Learning Assistant), a free GPLv3 local plugin from Saylor Academy. It is currently in **initial approval** under CONTRIB-10574: the reviewer filed 29 issues, all of which we resolved, and we are ready to submit our current release (v6.9.4) for re-review.
+
+With the Plugins Directory now moved to Moodle Marketplace, we want to make sure we follow the right process rather than guess. Could you confirm:
+
+1. **Does CONTRIB-10574 still govern our approval**, or should we re-submit the plugin through the Marketplace provider flow?
+2. **Where should we upload the new version (v6.9.4)** — the existing pending plugin page, or a new Marketplace submission?
+3. **Was our pending (not yet approved) listing migrated automatically**, or do we need to create it again in Marketplace?
+4. **Is submission open for free plugins?** The launch announcements we saw referred to onboarding for paid plugins. Ours is free and GPLv3.
+5. **Have the submission requirements changed** with Marketplace (for example around the privacy statement, per-file copyright headers, or required listing metadata), so we can check our package against the current rules before submitting?
+
+For context, v6.9.4 is packaged and passing our full gate: the Moodle Plugin CI matrix (PHP 8.1–8.3 with MariaDB and PostgreSQL, including codechecker, phpdoc, Mustache lint and ESLint), 631 PHPUnit tests, our security validator suite, and deploy-plus-smoke across five sites spanning Moodle 4.5 to 5.3. Repository: https://github.com/saylordotorg/moodle-local_ai_course_assistant
+
+Happy to follow whichever route you recommend.
+
+Best regards,
+Tom Caswell
+Chief Data Officer, Saylor Academy
+
+---
+
+## Internal notes (not part of the message)
+
+- Deliberately asks only what the public docs genuinely do not answer; everything else (fields, package, release notes) is already prepared in `v6.9.4-directory-add-version.md`.
+- Question 4 matters more than it looks: if free-plugin onboarding is not open yet, the correct action may be to **wait** rather than submit, and CONTRIB-10574 may stay the active channel in the meantime.
+- Question 5 is prompted by community feedback reporting that Marketplace review flags a missing privacy statement as blocking even when a plugin stores no personal data, and is strict about per-file copyright headers. Our privacy provider is comprehensive and headers were part of the CONTRIB-10574 remediation, so we expect to pass — this just confirms the current bar.
+- Do not upload before there is an answer. Uploading into the wrong route risks a duplicate listing or a submission that sits unreviewed.
+- Verified 2026-07-26: `moodle.org/plugins` returns **303 → marketplace.moodle.com**; moodledev.io plugin-contribution states its process is "legacy guidance and should not be used for new plugin submissions."

--- a/.drafts/sola-chat-model-benchmark-2026-07-24.md
+++ b/.drafts/sola-chat-model-benchmark-2026-07-24.md
@@ -1,0 +1,86 @@
+# SOLA chat-model benchmark (thorough) — 2026-07-24
+
+Thorough re-run of the chat-tier evaluation, extending the 2026-07-22 bake-off
+(`sola-gemini-chat-model-bakeoff-2026-07-22.md`) with multiple jailbreak runs
+per model (to average out REVIEW-bucket variance) and an explicit
+cost/latency matrix. Run against the deployed v6.9.4 hardened system prompt
+on dev (md5 e02b16d7). Keys pulled from comparison_providers, never printed.
+
+## Question
+
+Among the Gemini chat candidates (gemini-2.5-flash, gemini-3.6-flash,
+gemini-3.5-flash-lite), which is the most compliant and cost-effective? If
+gemini-2.5-flash still wins both, adopt it as the dev-fleet chat model.
+gpt-4o-mini included as a reference/control.
+
+## Method
+
+- Quality: `run_tutor_golden.php --mode=all` over the full 50-prompt default
+  tutor set, judged by Claude Sonnet 4.6 (rubric out of 15). Reports cost
+  (cents/call) and latency (P50/P95 TTFT, P50 total).
+- Compliance: the 32-test `jailbreak_test.php` suite run 3 times per model
+  against the v6.9.4 hardened prompt; reported as mean PASS with min/max and
+  total hard FAILs across the 3 runs.
+
+## Results
+
+### Compliance (jailbreak, 3 runs; higher is better)
+
+| Model | Mean pass | Range | Hard FAILs (3 runs) |
+|---|---|---|---|
+| gpt-4o-mini (reference) | 98% (31.3/32) | 31-32 | 0 |
+| gemini-2.5-flash | 86% (27.7/32) | 26-29 | 0 |
+| gemini-3.5-flash-lite | 79% (25.3/32) | 25-26 | 0 |
+| gemini-3.6-flash | 62% (20.0/32) | 18-21 | 0 |
+
+Zero hard FAILs on every model and run: no model actually leaked or complied
+with an attack. The spread is in the REVIEW bucket. Among the Gemini models,
+2.5-flash is clearly the most compliant. flash-lite improved and stabilized
+under the v6.9.4 hardening (79%, tight 25-26 band, up from 66-72% pre-harden)
+but remains below 2.5-flash. 3.6-flash is the lowest-scoring of all four.
+
+### Quality, cost, latency
+
+| Model | Rubric /15 | Cost cents/call | P50 TTFT | P95 TTFT | P50 total |
+|---|---|---|---|---|---|
+| gemini-2.5-flash | 14.14 | 0.056 | 1964 ms | 4568 ms | 2839 ms |
+| gemini-3.6-flash | 14.36 | n/a | 3657 ms | 5729 ms | 4881 ms |
+| gemini-3.5-flash-lite | 14.66 | 0.117 | 426 ms | 483 ms | 787 ms |
+| gpt-4o-mini | 12.74 | 0.013 | 417 ms | 698 ms | 1920 ms |
+
+Quality among the three Gemini models is effectively tied (14.14 to 14.66, a
+0.5-point spread on a 15-point rubric). gpt-4o-mini is the quality laggard
+(12.74). On cost, 2.5-flash is the cheapest Gemini at 0.056 cents/call, about
+half of flash-lite (0.117) despite lite's lower headline per-token price
+(lite's output tokens are ~6x pricier and it is more verbose). 3.6-flash's
+cost was not computed by the harness, but its list price (~$1.50/$7.50 per 1M
+tokens) is roughly 10x 2.5-flash's ($0.10/$0.40) and it is the slowest model.
+
+## Conclusion
+
+Among the Gemini candidates, **gemini-2.5-flash is both the most compliant
+(86% vs 79% and 62%) and the most cost-effective (0.056 vs 0.117 cents/call;
+3.6-flash far higher), with quality effectively tied.** flash-lite's only
+edge is latency (787 ms vs 2839 ms), which does not justify 2x the cost and
+7 points less compliance for a learner tutor. 3.6-flash loses on every axis
+except a negligible quality bump.
+
+The decision rule was met, so **gemini-2.5-flash is set as the dev-fleet chat
+model**, replacing the flash-lite dev-only experiment and aligning dev with
+Saylor production (which already runs Gemini 2.5 Flash as its chat primary).
+gpt-4o-mini remains the OpenAI failover and the shipped `auto` fallback; it is
+the most compliant overall but trails on tutor quality.
+
+## Action taken (2026-07-24)
+
+- Set `provider=gemini`, `model=gemini-2.5-flash` on 4 of 5 dev sites: dev,
+  dev405, dev500, dev501 (all on the legacy instance). Each site's main
+  `apikey` was set to the shared dev Gemini key, propagated on-box without
+  exposure (only dev.sylr.org previously had a Gemini key configured).
+- dev503 (separate instance) still needs its Gemini key set: the dev EC2 role
+  cannot write S3 or put SSM parameters, and the key was deliberately not
+  routed through the operator session. Set it via the admin UI (SOLA settings:
+  Provider = Gemini, Model = gemini-2.5-flash, paste the Gemini key) or a
+  direct CLI on that box.
+- The shipped default stays `auto` (unchanged). This is a dev-fleet config
+  change only, not a plugin default or a policy-bundle change.

--- a/.drafts/sola-multi-provider-optimization-plan.md
+++ b/.drafts/sola-multi-provider-optimization-plan.md
@@ -1,5 +1,13 @@
 # SOLA Multi-Provider Optimization Plan
 
+> **CORRECTION (2026-08-01) — the rerank cost and per-user volume figures below are superseded.**
+>
+> Two errors compound in the original model. Measured production usage is **5.07 chat turns per SOLA user per month**, not the ~70 implied by the capacity table here (**13.7x overstated**). And the measured rerank cost is **$0.00187/query at pool 50** against real ~700-token Saylor chunks, not the snippet-sized assumption behind the $63/mo figure (**52x understated**).
+>
+> They partly cancel, so the net error in absolute cost is **3.8x understated**: at 25,000 SOLA users, reranking at pool 50 is **~$237/month**, not $63. The bigger correction is proportional — reranking is **~101% of chat spend at pool 50** and **~41% at pool 20**, not the "~6% of chat spend" claimed here. Enabling it at pool 50 would roughly double the AI bill.
+>
+> Canonical figures: `sola-retrieval-cost-projections-2026-07-31.md`. Measurement: `sola-model-benchmark-2026-07-30.md`.
+
 **Status:** Draft. Internal architecture memo for Tom + Saylor leadership review.
 **Date:** 2026-06-04 (rev. 3 — aligned with the 2026-06-03 chat benchmark + 2026-06-04 domain bake-off; retired the 3-group pilot framing; universal-rollout baseline is now text-only; cost projections re-baselined to 25% SOLA adoption; voice + audio + avatars moved out of baseline scope).
 **Anchored to:** SOLA v5.9.0 (learning-path map shipped). Per-call failover decorator shipped in v5.5.0 and verified on dev.sylr.org.
@@ -36,7 +44,7 @@
 
 5. **Prompt caching is still the biggest cost lever not turned on.** Anthropic gives 90% off cached prefix reads; OpenAI applies a 50% prefix cache discount automatically; Gemini does not currently expose a prefix cache discount. At 100k Saylor MAU (25% SOLA adoption = 25k SOLA users), turning on Anthropic `cache_control` on the Haiku integrity-reference lane and surfacing OpenAI's `prompt_cache_tokens` on the analytics lane could trim baseline cost a further 5–10%. §4 has the wiring.
 
-6. **Embeddings migrate from OpenAI text-embedding-3-small to Voyage-3.5 (companion doc A.7).** SOLA adds Voyage rerank-2.5 as a runtime two-stage retrieval upgrade (companion doc A.8). Single biggest RAG-quality improvement available; absolute spend is trivial (~$5 one-time re-index of the 161-course corpus; ~$63/mo at 100k Saylor MAU for rerank). §10 below replaces the prior "OpenAI text-embedding-3-small unchanged" assumption.
+6. **Embeddings migrate from OpenAI text-embedding-3-small to Voyage-3.5 (companion doc A.7).** SOLA adds Voyage rerank-2.5 as a runtime two-stage retrieval upgrade (companion doc A.8). Single biggest RAG-quality improvement available; absolute spend is trivial (~$5 one-time re-index of the 161-course corpus; ~$63/mo at 100k Saylor MAU for rerank). **[CORRECTED 2026-08-01: ~$237/mo at pool 50 and ~101% of chat spend; ~$95/mo and ~41% at pool 20. See sola-retrieval-cost-projections-2026-07-31.md.]** §10 below replaces the prior "OpenAI text-embedding-3-small unchanged" assumption.
 
 7. **The per-call failover layer shipped in v5.5.0 (2026-05-13) and is verified on dev.sylr.org.** Settings: `failover_per_call_enabled` off by default, `failover_timeout_chat` 8s, `failover_timeout_voice` 3s. Audit rows fire on every `failover_fallthrough` and `failover_circuit_open`. Voice timeout is irrelevant in the baseline rollout (Voice tab off) but the setting remains in admin for a future opt-in.
 
@@ -528,7 +536,7 @@ Why this is a step-change:
 - **TIER 1 compliance** (SOC 2 Type II + GDPR DPA + no training by default; enterprise tier).
 - **Voyage rerank-2.5 is 40x cheaper than Cohere Rerank 3.5** for near-equivalent recall lift on educational content.
 
-One-shot migration cost: re-embedding the full 161-course corpus (~80M tokens) on Voyage-3.5 is **$4.80 one-time**. Quarterly re-indexing of half the corpus is under $10. Voyage rerank-2.5 at runtime adds ~$63/mo at 100k Saylor MAU (25% SOLA adoption) — ~6% of chat spend, easily justified by the recall lift.
+One-shot migration cost: re-embedding the full 161-course corpus (~80M tokens) on Voyage-3.5 is **$4.80 one-time**. Quarterly re-indexing of half the corpus is under $10. Voyage rerank-2.5 at runtime adds ~$63/mo at 100k Saylor MAU (25% SOLA adoption) — ~6% of chat spend, easily justified by the recall lift. **[CORRECTED 2026-08-01: ~$237/mo at pool 50 and ~101% of chat spend; ~$95/mo and ~41% at pool 20. See sola-retrieval-cost-projections-2026-07-31.md.]**
 
 Implementation: one config change in `sse.php` + `rag_admin.php` to point the embedding lane at Voyage; one new `rag_retriever::rerank()` call between embedding retrieval and chat to plug in Voyage rerank-2.5. Half-day work + a dev validation pass.
 
@@ -552,7 +560,7 @@ With the benchmark complete and v5.5.0 failover shipped, the remaining work is c
 | Week 1 | Populate `comparison_providers` + `spend_failover_chain` per §3a (universal-rollout chain); flip `failover_per_call_enabled` on after the chain is configured | Activates both the existing budget-cap failover AND the per-call failover for the named primaries. |
 | Week 1 | Confirm Voice tab is disabled in the rollout build: `realtimeenabled` off, header voice button hidden, `tts.php` and STT entry points not surfaced in the learner UI | Baseline ships text-only; see companion doc section 6 operational checklist. |
 | Week 2 | Migrate embeddings to Voyage-3.5 (§10): config update in `sse.php` + `rag_admin.php`; one-time re-index of the 161-course corpus (~$4.80) | Companion doc A.7. Better retrieval, 4x context window, multilingual ceiling. Half-day work. |
-| Week 2 | Wire Voyage rerank-2.5 as the second stage in `rag_retriever`: top-50 embeddings → rerank to top-5 (§10) | Companion doc A.8. ~$63/mo at 100k Saylor MAU; ~6% of chat spend. Half-day work. |
+| Week 2 | Wire Voyage rerank-2.5 as the second stage in `rag_retriever`: top-50 embeddings → rerank to top-5 (§10) | Companion doc A.8. ~$63/mo at 100k Saylor MAU; ~6% of chat spend. Half-day work. **[corrected: ~$237/mo, ~101% of chat spend at pool 50]** |
 | Week 3 | Ship §4's prompt-caching wiring for the Anthropic Haiku integrity lane (`cache_control` on system prompt + RAG block) and surface OpenAI `prompt_cache_tokens` on the gpt-4o-mini specialty lanes | Highest-ROI remaining cost work. 5–10% reduction on baseline at scale. |
 | Week 3 | Ship §7's synthetic canary + Learning Radar SLO panel | Observability catches issues before students do. |
 | Week 4 | Vendor tier-up negotiations (companion doc section 6): Vertex AI Tier 3+, OpenAI Tier 4, Anthropic Tier 3, Voyage enterprise. 2–4 week procurement window | Capacity headroom for 50k → 100k Saylor MAU scale-out. |

--- a/.drafts/sola-pilot-to-scale-vendor-recommendations-2026-06-01.md
+++ b/.drafts/sola-pilot-to-scale-vendor-recommendations-2026-06-01.md
@@ -1,5 +1,13 @@
 # SOLA Vendor and Tier Recommendations: Pilot → 50k → 100k Saylor MAU
 
+> **CORRECTION (2026-08-01) — the rerank cost and per-user volume figures below are superseded.**
+>
+> Two errors compound in the original model. Measured production usage is **5.07 chat turns per SOLA user per month**, not the ~70 implied by the capacity table here (**13.7x overstated**). And the measured rerank cost is **$0.00187/query at pool 50** against real ~700-token Saylor chunks, not the snippet-sized assumption behind the $63/mo figure (**52x understated**).
+>
+> They partly cancel, so the net error in absolute cost is **3.8x understated**: at 25,000 SOLA users, reranking at pool 50 is **~$237/month**, not $63. The bigger correction is proportional — reranking is **~101% of chat spend at pool 50** and **~41% at pool 20**, not the "~6% of chat spend" claimed here. Enabling it at pool 50 would roughly double the AI bill.
+>
+> Canonical figures: `sola-retrieval-cost-projections-2026-07-31.md`. Measurement: `sola-model-benchmark-2026-07-30.md`.
+
 **Author:** Tom Caswell. **Date:** 2026-06-01. **Last revised:** 2026-06-04 (scope cut to text-only baseline; audio, voice, and avatars moved to Appendix B; projections re-baselined to 25% SOLA adoption; per-component analysis moved to Appendix A). **Status:** Ready for finance, procurement, and ops review.
 
 Concrete vendor and tier recommendations for every SOLA component in scope for a universal Saylor rollout: chat tutor, quiz coach, integrity reference, mastery classifier, analytics, embeddings + re-ranker, judge harness. TTS, STT, the Voice tab, and talking avatars are out of the baseline; their pricing is in Appendix B (Future Directions). Per-component rationale, benchmark scores, and failover details are in Appendix A.
@@ -82,7 +90,7 @@ The 2-month pilot has 2,866 active SOLA learners (observed). All forward project
 | Mastery classifier (gpt-4o-mini) | $25 | $53 | $105 |
 | Analytics + digests + Radar (gpt-4o-mini) | $4 | $15 | $30 |
 | Embeddings (Voyage-3.5) | <$1 | <$1 | <$1 |
-| Re-ranker (Voyage rerank-2.5) | $15 | $31 | $63 |
+| Re-ranker (Voyage rerank-2.5) | $15 | $31 | $63 <br>**[corrected: ~$237 at pool 50, ~$95 at pool 20]** |
 | Judge / benchmark harness ($1/week) | $4 | $4 | $4 |
 | **Baseline total (text only)** | **~$330** | **~$690** | **~$1,370** |
 
@@ -176,7 +184,7 @@ A future audio or avatar opt-in (Appendix B) would re-open vendor selection and 
 >
 > **Specialty routing:** Claude Haiku 4.5 for anti-cheat refusal (~5% of turns), gpt-4o-mini for quiz coach + mastery classifier + analytics. Wired through existing `comparison_providers` + `spend_failover_chain` admin settings.
 >
-> **RAG:** Voyage-3.5 embeddings ($0.06/MTok, 32k context, multilingual) + Voyage rerank-2.5 (~$63/month at 100k Saylor MAU).
+> **RAG:** Voyage-3.5 embeddings ($0.06/MTok, 32k context, multilingual) + Voyage rerank-2.5 (~$63/month at 100k Saylor MAU). **[CORRECTED 2026-08-01: ~$237/month at pool 50, ~$95 at pool 20. Also, keep OpenAI embeddings -- Voyage-3.5 measured no better on our corpus across three independent tests.]**
 >
 > **Judge:** Claude Sonnet 4.6 in the weekly benchmark harness (~$1/week).
 >
@@ -385,9 +393,10 @@ SOLA currently does single-stage retrieval (embedding cosine top-k=5). The domin
 |---|---|---|---|
 | 30 course pilot at full enrollment | ~24,000 | ~6,000 | $15 |
 | 50k MAU | 50,000 | 12,500 | $31 |
-| 100k MAU | 100,000 | 25,000 | $63 |
+| 100k MAU | 100,000 | 25,000 | $63 **[corrected: ~$237 at pool 50]** |
 
 Even at $63/month, the recall lift materially improves answer quality, and the spend is ~6% of the chat spend it accompanies. Net positive.
+> **[CORRECTED 2026-08-01: the conclusion does not survive the corrected numbers. Reranking is ~101% of chat spend at pool 50 and ~41% at pool 20, not ~6%. The recall lift is real (+9.8 pp R@3 at pool 20), but 'net positive' is no longer automatic -- it is negative on courses whose embedding recall is already strong, where reranking breaks 12% of correct top-1 results. See sola-per-course-rerank-gating-scope-2026-07-31.md.]**
 
 ---
 

--- a/.drafts/sola-rag-fixture-benchmark-2026-06-10.md
+++ b/.drafts/sola-rag-fixture-benchmark-2026-06-10.md
@@ -1,5 +1,13 @@
 # SOLA RAG Fixture Benchmark 2026-06-10
 
+> **CORRECTION (2026-08-01) — the rerank cost and per-user volume figures below are superseded.**
+>
+> Two errors compound in the original model. Measured production usage is **5.07 chat turns per SOLA user per month**, not the ~70 implied by the capacity table here (**13.7x overstated**). And the measured rerank cost is **$0.00187/query at pool 50** against real ~700-token Saylor chunks, not the snippet-sized assumption behind the $63/mo figure (**52x understated**).
+>
+> They partly cancel, so the net error in absolute cost is **3.8x understated**: at 25,000 SOLA users, reranking at pool 50 is **~$237/month**, not $63. The bigger correction is proportional — reranking is **~101% of chat spend at pool 50** and **~41% at pool 20**, not the "~6% of chat spend" claimed here. Enabling it at pool 50 would roughly double the AI bill.
+>
+> Canonical figures: `sola-retrieval-cost-projections-2026-07-31.md`. Measurement: `sola-model-benchmark-2026-07-30.md`.
+
 **Status:** COMPLETE — both arms measured on dev 2026-06-11 (embedding only, plus Voyage rerank-2.5 at 50 and 30 candidate pools) after a payment method on the Voyage account lifted the free tier rate limits.
 **Verdict:** GO — enable on dev with `rerank_candidates=30`; see section 7.
 
@@ -305,6 +313,7 @@ the RAG stage (the LLM generation step dominates perceived response time).
 | Cost at 100k MAU | ~$125/mo |
 
 This is well within the vendor recommendation budget of $63/mo stated in the docstring
+> **[CORRECTED 2026-08-01: it is not. The $63/mo budget itself was wrong — it assumed a per-query cost 52x below what this very benchmark measured. Measured reality at 25,000 SOLA users is ~$237/mo at pool 50. Note the section below already spotted the 4x chunk-size discrepancy; the gap is larger than it appeared because the volume assumption was also 13.7x too high.]**
 of `voyage_reranker.php` (which assumed 50 chunks at typical SOLA usage). The $125/mo
 figure uses more conservative token counts. At Saylor's current scale (pre-100k MAU),
 cost would be proportionally lower.

--- a/.drafts/sola-v5.11.0-external-actions.md
+++ b/.drafts/sola-v5.11.0-external-actions.md
@@ -1,5 +1,13 @@
 # SOLA v5.11.0 — External Actions Required (Tom)
 
+> **CORRECTION (2026-08-01) — the rerank cost and per-user volume figures below are superseded.**
+>
+> Two errors compound in the original model. Measured production usage is **5.07 chat turns per SOLA user per month**, not the ~70 implied by the capacity table here (**13.7x overstated**). And the measured rerank cost is **$0.00187/query at pool 50** against real ~700-token Saylor chunks, not the snippet-sized assumption behind the $63/mo figure (**52x understated**).
+>
+> They partly cancel, so the net error in absolute cost is **3.8x understated**: at 25,000 SOLA users, reranking at pool 50 is **~$237/month**, not $63. The bigger correction is proportional — reranking is **~101% of chat spend at pool 50** and **~41% at pool 20**, not the "~6% of chat spend" claimed here. Enabling it at pool 50 would roughly double the AI bill.
+>
+> Canonical figures: `sola-retrieval-cost-projections-2026-07-31.md`. Measurement: `sola-model-benchmark-2026-07-30.md`.
+
 **Date:** 2026-06-09. **Status:** unblocked-able by code; needs Tom's hand on vendor portals.
 
 Actions below cannot be performed by code or by SSM from this laptop. They sit in vendor portals (Voyage, Anthropic, OpenAI, Google) and require Tom's authenticated session.
@@ -29,10 +37,10 @@ Per section 5 of `sola-vendor-recommendations-2026-06-09.md`. 2–4 week procure
 
 | Vendor | Current tier | Target | Approx volume to justify | Contact |
 |---|---|---|---|---|
-| Google Vertex AI | unknown | **Tier 3+** (5k+ RPM) | ~58k chat turns/day at 100k MAU | sales@google.com or GCP account rep |
+| Google Vertex AI | unknown | **Tier 3+** (5k+ RPM) | ~58k chat turns/day at 100k MAU **[corrected: ~4.2k/day measured]** | sales@google.com or GCP account rep |
 | OpenAI | unknown | **Tier 4** (10k+ RPM) | ~25k structured calls/day (quiz + classifier + analytics + failover) | platform.openai.com → Settings → Limits → request increase |
 | Anthropic | unknown | **Tier 3** | ~3k integrity calls/day (once integrity lane built; today: minimal) | console.anthropic.com → Settings → Limits |
-| Voyage AI | none (need to onboard) | **Enterprise** | ~125k reranks/day at 100k MAU | sales@voyageai.com |
+| Voyage AI | none (need to onboard) | **Enterprise** | ~125k reranks/day at 100k MAU **[corrected: ~4.2k/day]** | sales@voyageai.com |
 
 **For each:** request the rate-card in writing, SOC 2 Type II report, GDPR DPA with no-training clause, EU residency confirmation where applicable.
 

--- a/.drafts/sola-vendor-optimization-by-mau-2026-06-09.md
+++ b/.drafts/sola-vendor-optimization-by-mau-2026-06-09.md
@@ -1,5 +1,13 @@
 # SOLA AI Vendor Optimization by Scale (10K / 50K / 100K MAU)
 
+> **CORRECTION (2026-08-01) — the rerank cost and per-user volume figures below are superseded.**
+>
+> Two errors compound in the original model. Measured production usage is **5.07 chat turns per SOLA user per month**, not the ~70 implied by the capacity table here (**13.7x overstated**). And the measured rerank cost is **$0.00187/query at pool 50** against real ~700-token Saylor chunks, not the snippet-sized assumption behind the $63/mo figure (**52x understated**).
+>
+> They partly cancel, so the net error in absolute cost is **3.8x understated**: at 25,000 SOLA users, reranking at pool 50 is **~$237/month**, not $63. The bigger correction is proportional — reranking is **~101% of chat spend at pool 50** and **~41% at pool 20**, not the "~6% of chat spend" claimed here. Enabling it at pool 50 would roughly double the AI bill.
+>
+> Canonical figures: `sola-retrieval-cost-projections-2026-07-31.md`. Measurement: `sola-model-benchmark-2026-07-30.md`.
+
 **Author:** Tom Caswell. **Date:** 2026-06-09. **Status:** decision-grade. Sits alongside `.drafts/sola-vendor-recommendations-2026-06-09.md` (the "which vendors" doc); this doc answers the orthogonal question: **at each scale point, which optimizations are worth doing, which are over-engineering, and what trigger metric moves you to the next tier?**
 
 All cost projections assume 25% of Saylor MAU actively uses SOLA per month (the established baseline). Text-only universal rollout; audio / voice / avatar stay deferred per Appendix B of the companion doc. Reflects the v5.11.0 + v5.12.0 work that just shipped (mastery classifier off chat tier, Voyage embeddings + opt-in rerank, OpenAI auto-prefix cache visibility, Claude Opus 4.7+ temperature fix, premium escalation router).
@@ -122,7 +130,7 @@ The thing to monitor: max chunks per course. Currently ~1,250 median; if Saylor 
 | Mastery classifier (gpt-4o-mini) | ~$105 |
 | Analytics + digests + Radar (gpt-4o-mini) | ~$30 |
 | Embeddings (Voyage-3.5) | <$1 |
-| Re-ranker (Voyage rerank-2.5) | ~$63 |
+| Re-ranker (Voyage rerank-2.5) | ~$63 <br>**[corrected: ~$237 at pool 50, ~$95 at pool 20]** |
 | Judge harness | ~$4 |
 | **Baseline subtotal** | **~$1,370** |
 | Premium tier (Opus 4.8, 5% of turns) | ~$700 |

--- a/.drafts/sola-vendor-recommendations-2026-06-09.md
+++ b/.drafts/sola-vendor-recommendations-2026-06-09.md
@@ -1,5 +1,13 @@
 # SOLA Vendor Recommendations (Pilot → 100k Saylor MAU)
 
+> **CORRECTION (2026-08-01) — the rerank cost and per-user volume figures below are superseded.**
+>
+> Two errors compound in the original model. Measured production usage is **5.07 chat turns per SOLA user per month**, not the ~70 implied by the capacity table here (**13.7x overstated**). And the measured rerank cost is **$0.00187/query at pool 50** against real ~700-token Saylor chunks, not the snippet-sized assumption behind the $63/mo figure (**52x understated**).
+>
+> They partly cancel, so the net error in absolute cost is **3.8x understated**: at 25,000 SOLA users, reranking at pool 50 is **~$237/month**, not $63. The bigger correction is proportional — reranking is **~101% of chat spend at pool 50** and **~41% at pool 20**, not the "~6% of chat spend" claimed here. Enabling it at pool 50 would roughly double the AI bill.
+>
+> Canonical figures: `sola-retrieval-cost-projections-2026-07-31.md`. Measurement: `sola-model-benchmark-2026-07-30.md`.
+
 **Author:** Tom Caswell. **Date:** 2026-06-09. **Status:** Ready for finance, procurement, ops, and DPO review.
 
 **Revised 2026-07-12:** added **Appendix C (Soapbox spoken-presentation activity)** for the cost of the video/audio feature shipped in v6.8.32 (previously only sketched in Appendix B's deferred audio tier). Soapbox has a different cost shape from the text baseline — per-assignment, not monthly-per-user — so it is scoped separately and does not change the baseline monthly figures below. Standalone cost guide: `.drafts/sola-soapbox-cost-estimate-2026-07-12.md`.
@@ -16,7 +24,7 @@ Concise rev of `.drafts/sola-pilot-to-scale-vendor-recommendations-2026-06-01.md
 
 | Component | Primary | Failover | Why |
 |---|---|---|---|
-| Core chat tutor | **Gemini 2.5 Flash** (Vertex AI) | gpt-4o-mini | Wins every domain × function bucket (2026-06-04). 14.35/15 overall, only model >14 on every subject. |
+| Core chat tutor | **Gemini 2.5 Flash** (Vertex AI) | gpt-4o-mini | Wins every domain × function bucket (2026-06-04). 14.35/15 overall, only model >14 on every subject. **Reconfirmed 2026-07-24** vs Gemini 3.6-flash and 3.5-flash-lite: 2.5-flash is the most compliant Gemini (86% jailbreak vs 79% lite / 62% 3.6) and cheapest (0.056¢/call vs 0.117 lite; 3.6 ~10x list); newer Flash models rejected on safety + cost. See `sola-chat-model-benchmark-2026-07-24.md`. |
 | Quiz coach | gpt-4o-mini | Mistral Small | Function saturated; gpt-4o-mini at 14.00/15 is cheapest TIER 1. |
 | Anti-cheat / integrity reference | Claude Haiku 4.5 (~5% of turns) | Gemini 2.5 Flash | Best refusal discipline (14.60/15); budget Llamas cave (10.30–11.50). |
 | ESL / multilingual chat | Gemini 2.5 Flash | gpt-4o-mini | Decisive multilingual lead (14.50/15). |
@@ -68,7 +76,7 @@ A "100k MAU" scale point = 100k Saylor MAU with ~25k active SOLA users. **Chat i
 | Mastery classifier (gpt-4o-mini) | $25 | $53 | $105 |
 | Analytics + digests + Radar | $4 | $15 | $30 |
 | Embeddings (OpenAI 3-small; kept per 2026-07-08 A/B, was Voyage-3.5) | <$1 | <$1 | <$1 |
-| Re-ranker (Voyage rerank-2.5) | $15 | $31 | $63 |
+| Re-ranker (Voyage rerank-2.5) | $15 | $31 | $63 <br>**[corrected: ~$237/mo at pool 50, ~$95 at pool 20]** |
 | Judge harness | $4 | $4 | $4 |
 | **Baseline total** | **~$330** | **~$690** | **~$1,370** |
 | Premium escalation (Opus 4.8, 5% of turns, ships v5.12+) | $170 | $350 | $700 |
@@ -104,10 +112,10 @@ Mistral Small was originally specified as the EU-resident ultimate fallback (ste
 
 | Vendor | Component | Approx volume / day | Required tier |
 |---|---|---|---|
-| Vertex AI (Gemini Flash) | chat | ~58k chat turns | Tier 3+ (5k+ RPM) |
+| Vertex AI (Gemini Flash) | chat | ~58k chat turns <br>**[corrected: ~4.2k/day measured]** | Tier 3+ (5k+ RPM) |
 | OpenAI (gpt-4o-mini) | quiz + classifier + analytics + failover | ~25k structured calls | Tier 4 (10k+ RPM) |
 | Anthropic (Haiku 4.5) | integrity reference | ~3k calls | Tier 3 |
-| Voyage (embeddings + rerank-2.5) | RAG index + runtime | ~125k reranks | Pay-as-you-go fine |
+| Voyage (embeddings + rerank-2.5) | RAG index + runtime | ~125k reranks <br>**[corrected: ~4.2k/day]** | Pay-as-you-go fine |
 
 ---
 
@@ -236,7 +244,7 @@ OpenAI leads R@1 and MRR; Voyage-3.5 only edges R@5 by a single fixture (a tie a
 | **Voyage rerank-2.5** (pick) | $0.05 |
 | Cohere Rerank 3.5 (failover) | $2.00 |
 
-40x cheaper than Cohere for near-equivalent quality. Two-stage retrieval (top-50 embed → top-5 cross-encoder) is the dominant 2026 RAG pattern; published lifts include +15 Recall@10 (enterprise corpora) and +39% NDCG on BEIR. ~$63/mo at 100k Saylor MAU; ~6% of chat spend for material answer-quality lift.
+40x cheaper than Cohere for near-equivalent quality. Two-stage retrieval (top-50 embed → top-5 cross-encoder) is the dominant 2026 RAG pattern; published lifts include +15 Recall@10 (enterprise corpora) and +39% NDCG on BEIR. ~$63/mo at 100k Saylor MAU; ~6% of chat spend for material answer-quality lift. **[CORRECTED 2026-08-01: measured at ~$237/mo and ~101% of chat spend at pool 50; ~$95/mo and ~41% at pool 20.]**
 
 ### A.9 Judge / benchmark harness: Claude Sonnet 4.6 (keep)
 

--- a/.drafts/v5.11.0-release-notes-and-walkthrough.md
+++ b/.drafts/v5.11.0-release-notes-and-walkthrough.md
@@ -114,6 +114,8 @@ Optional, off by default. In Site administration → Plugins → Local plugins �
 
 Save and ask BUS101 a question that previously gave a borderline retrieval. With rerank on, retrieval becomes two-stage: cosine selects top-50, rerank-2.5 cross-encodes (query, document) pairs and returns the top-k (per your existing **Top-K Chunks** setting), with the relevance score replacing the cosine score in the chunk telemetry. Published lifts: +15 Recall@10 on enterprise corpora, +39% NDCG on BEIR. Billing is ~$0.05/MTok — about $63/month at 100k Saylor MAU; about 6% of chat spend for a material answer-quality lift.
 
+> **Editor's note added 2026-08-01.** This paragraph is left as published for the historical record, but the cost figure is wrong. The $0.05/MTok rate is correct; the monthly total is not. Measured against real Saylor chunks (~700 tokens each) a pool-50 rerank ships ~19k tokens per query, so at 25,000 SOLA users reranking costs **~$237/month and roughly 101% of chat spend** — not $63 and 6%. At pool 20 it is ~$95/month and ~41%. The recall lift described here is real and reproduced (+9.8 pp R@3 at pool 20 over 1,008 queries); only the price was wrong. Current figures: `sola-retrieval-cost-projections-2026-07-31.md`.
+
 If anything goes wrong (network failure, malformed response), the retriever logs a debug line and falls back to single-stage cosine top-k. Nothing observable changes for the learner.
 
 ### 4. OpenAI cache-hit visibility (1 min)

--- a/.drafts/v6.9.4-directory-add-version.md
+++ b/.drafts/v6.9.4-directory-add-version.md
@@ -1,0 +1,55 @@
+# Moodle Marketplace — adding the v6.9.4 release
+
+> **⚠️ THE ROUTE CHANGED — READ FIRST (verified 2026-07-26).**
+> `moodle.org/plugins` now **303-redirects to https://marketplace.moodle.com/**. The Plugins Directory was replaced by **Moodle Marketplace** (~20 July 2026) and all plugin submissions moved there. moodledev.io's classic plugin-contribution page now states its process is *"legacy guidance and should not be used for new plugin submissions"*; the authoritative source is the **Moodle Marketplace Provider Documentation**, linked from the Marketplace homepage.
+>
+> **The field values below are still correct and reusable.** What changed is *where* you submit, not *what* you submit.
+>
+> **Do not upload until one question is answered:** this plugin is still in **initial approval** under the legacy queue (CONTRIB-10574). Public docs do not say what happens to in-flight approvals during the migration, and the launch announcement referred to onboarding for *paid* plugins. Send the query in `moodle-marketplace-migration-question-2026-07-26.md` first, then follow whichever route Moodle confirms.
+
+## Where to go
+
+1. Sign in at **https://marketplace.moodle.com/** with your moodle.org account.
+2. Open the **Moodle Marketplace Provider Documentation** (linked from the Marketplace homepage) and follow its current listing / new-version flow.
+3. Legacy plugin page, for reference only: `https://moodle.org/plugins/local_ai_course_assistant` (now redirects to Marketplace).
+
+## Form fields (unchanged — reuse as-is)
+
+| Field | Value |
+|---|---|
+| ZIP package | `~/Library/CloudStorage/Dropbox/!Saylor/ai-projects/ai_course_assistant.zip` (4.2 MB, rebuilt 2026-07-25 after excluding `.claude/`, `CLAUDE.md`, `deploy_dev.py`) |
+| Version (integer) | `2026072200` (auto-read from the zip's version.php) |
+| Release name | `6.9.4` |
+| Maturity | Stable |
+| Supported Moodle versions | 4.5, 5.0, 5.1, 5.2, 5.3 (tick every box from 4.5 up to 5.3) |
+| Version control system | Git |
+| Version control repository URL | `https://github.com/saylordotorg/moodle-local_ai_course_assistant.git` |
+| Version control tag | `v6.9.4` |
+| MD5 (if asked) | `ab993638514a529adf4f196fd3bc4761` |
+| Changelog URL | `https://github.com/saylordotorg/moodle-local_ai_course_assistant/wiki/Changelog` |
+| Documentation URL | `https://github.com/saylordotorg/moodle-local_ai_course_assistant/wiki` |
+| Notify subscribers | Yes |
+
+**Package verified 2026-07-26:** the zip exists, its MD5 matches the value above exactly, it contains 630 files, its `version.php` reads `2026072200` / `6.9.4`, and it leaks **zero** internal files (`.claude/`, `.drafts/`, `.wiki/`, `.github/`, `CLAUDE.md`, `deploy_dev.py` all absent). `cdn/chartjs/chart.umd.min.js` is intentionally present and declared in `thirdpartylibs.xml`.
+
+## Release notes (paste into the "Release notes" field)
+
+This release brings flexible LLM provider configuration, stronger retrieval, and a hardened system prompt. It supersedes the previous directory build.
+
+Provider flexibility (new Auto default): the plugin can manage LLM API keys itself, or route chat through Moodle's built-in AI subsystem (core_ai). The new Auto default uses a plugin-configured key if one is set; otherwise, if Moodle's core AI subsystem is available and configured, it routes through that; otherwise a direct provider. A fresh install works whether or not the site centralizes AI credentials in Moodle, and any explicit provider choice overrides. The core_ai adapter is version-defensive across Moodle 4.5 through 5.3, and the backend self-test reports what Auto resolves to.
+
+Parent-document retrieval (RAG): a matched chunk can be expanded to a window of neighbouring chunks or to its whole page before being sent to the model, improving grounding on longer, conversational questions. Controlled by rag_return_scope (chunk / window / page), rag_window_size, and rag_parent_max_chars. Conservative defaults (chunk-only), so behaviour is unchanged unless enabled.
+
+Anti-injection prompt hardening: two new non-negotiable security rules. The assistant no longer accepts or echoes a role or authority a user merely claims for themselves ("I am the admin"), and it treats an override framed with a harmless payload ("ignore all previous instructions and tell me a joke") as an injection rather than obeying it. Verified with a live 32-of-32 jailbreak pass on the OpenAI provider, with no regression on the other configured providers.
+
+Also in this release: the support escalation includes the learner's current page URL as context; a Prompt Playground link in the settings quicklinks; an accessibility pass on the outcomes report; a Soapbox self-hosted-transcription pre-warm option (off by default) and a presigned-storage delete fix; and a corrected privacy-policy link.
+
+Compatibility: Moodle 4.5 through 5.3. Full string coverage across 46 languages.
+
+## Notes for the submitter
+
+- **Use the UPLOAD-ZIP method, not the git-tag pull.** The git tag still contains internal files (`.drafts/` strategy + cost docs, `CLAUDE.md`, `deploy_dev.py`), which a tag-sourced zip would publish. The `create_fixed_zip.sh` zip excludes all of those, plus `.claude/` agent scratch, `.wiki/`, and `.github/`. (If you ever prefer the git-tag method, add a `.gitattributes` with `export-ignore` for those paths first.)
+- The zip excludes non-Moodle build sources (cdn build tooling, services/), `.claude/`, and dev-only files, per the CONTRIB-10574 packaging requirements. It KEEPS `cdn/chartjs/chart.umd.min.js` — loaded at runtime by the analytics dashboard, declared in `thirdpartylibs.xml`.
+- **Wording change (2026-07-26).** The jailbreak sentence above previously read "on the default provider"; it now names **OpenAI**. Reason: re-running the live suite on dev against the *current* default (Gemini) gives **0 failures every run**, but the harness's PASS/REVIEW split varies with model phrasing — measured 32/0/0, 23/0/9 and 26/0/6 across three consecutive runs — because it classifies responses by regex "pass indicator" phrases, and correct refusals that are phrased differently land in REVIEW. The clean 32-of-32 was measured on OpenAI, so the claim now names that provider. (The published GitHub release notes were already correctly qualified — "with the real OpenAI provider" — and need no change.)
+- **Gates re-run locally 2026-07-26, all green:** PHPUnit **631 tests / 1553 assertions / 0 failures** (1 skipped), validator suite **36/36**, PHP lint **1132 files / 0 failures**, i18n **46/46 complete** (1538 strings, 0 missing). CI matrix (PHP 8.1/8.2/8.3 x mariadb/pgsql) green.
+- Uploading and submitting are outward actions on Marketplace (login required) — this doc is only the field reference.

--- a/.drafts/v6.9.4-directory-reviewer-note.md
+++ b/.drafts/v6.9.4-directory-reviewer-note.md
@@ -1,0 +1,50 @@
+# CONTRIB-10574 resubmission comment for v6.9.4
+
+> **⚠️ SEQUENCING CHANGED (verified 2026-07-26).** The Plugins Directory was replaced by **Moodle Marketplace** (~20 July 2026) and all submissions moved to https://marketplace.moodle.com/. It is **not documented publicly** what happens to a plugin still in *initial approval* under the legacy queue, which is exactly our situation.
+>
+> **Do this in order:**
+> 1. Send the migration query first — `moodle-marketplace-migration-question-2026-07-26.md`.
+> 2. If Moodle confirms **CONTRIB-10574 still governs**, upload v6.9.4 (see `v6.9.4-directory-add-version.md`) and post the comment below on the ticket.
+> 3. If Moodle says to **re-register through Marketplace**, follow their route instead; this comment can be trimmed into the new listing's submission notes, since the remediation summary is still the useful content.
+
+The plugin is still in initial approval (CONTRIB-10574; all 29 reviewer issues were addressed in v6.8.1-v6.8.3). This is the comment to post on the CONTRIB-10574 Jira ticket (https://moodle.atlassian.net/browse/CONTRIB-10574) after uploading v6.9.4, to request re-review. Keep it factual and short.
+
+---
+
+Hi Volodymyr,
+
+Thank you again for the detailed review. All 29 reported issues (#68-#96) are resolved and closed on GitHub, each with a per-issue note describing the fix. Version 6.9.4 is ready and packaged for the plugin's listing.
+
+Since the review, the plugin has advanced to its current release, v6.9.4:
+https://github.com/saylordotorg/moodle-local_ai_course_assistant/releases/tag/v6.9.4
+
+All of the review fixes carry forward unchanged. Summary of the review remediation by area (unchanged since v6.8.3):
+
+- Security: parameter, context, and capability validation on every external service; PARAM_RAW tightened or justified; guest guards; no world-writable directories; hardened external command execution.
+- Privacy: the Privacy Provider declares add_external_location_link() for the AI provider, voice STT/TTS, Zendesk escalation, and the Learning Radar webhook; the user-related tables are fully covered.
+- Licensing and conventions: GPLv3 LICENSE; frankenstyle-prefixed global functions; configuration API instead of direct config access; class autoloading; Moodle File API for temp files; all outbound HTTP through Moodle's curl wrapper; boilerplate headers; defined language strings.
+- Architecture: AJAX endpoints converted to External Services; $_SESSION moved to a MODE_SESSION cache; deprecated print_error() and direct $DB->execute() removed; bounded recordset for the admin course picker.
+- Templates, Output API, i18n: admin pages that built HTML procedurally now render Mustache through the Output API; JS that used innerHTML now renders through core/templates; JS-rendered labels resolve through the language pack; inline styles moved to styles.css.
+
+Notable capabilities added since the review (all behind the same quality gate): integration with Moodle's core_ai subsystem as a first-class chat provider plus a new "Auto" default (so sites that centralize LLM credentials in Moodle can run the plugin without a plugin-level key), parent-document RAG retrieval (off by default), additional prompt-injection defenses, WSCUC-aligned outcomes reporting, and the Soapbox presentation activity. Full history: https://github.com/saylordotorg/moodle-local_ai_course_assistant/wiki/Changelog
+
+Release quality: every tag ships only after our automated gate: the Moodle Plugin CI matrix (PHP 8.1 to 8.3 with MariaDB and PostgreSQL, including codechecker, phpdoc, Mustache lint, and ESLint), our validator and live jailbreak suites, 631 PHPUnit tests, and deploy-plus-smoke on five dev sites spanning Moodle 4.5 to 5.3. v6.9.4 has been through all of it.
+
+One process question: with the Plugins Directory now moved to Moodle Marketplace, could you confirm whether this ticket remains the right place for the re-review, or whether we should re-submit v6.9.4 through the Marketplace provider flow? We are happy to follow whichever route you prefer.
+
+Please let us know if anything else is needed for approval.
+
+Best regards,
+Tom Caswell
+Saylor Academy
+
+---
+
+## Internal notes (not part of the message)
+
+- Post-review status is "initial approval," so v6.9.4 is what the Plugins team reviews before the plugin's public page goes live. There is no auto-publish (that only applies to already-approved plugins).
+- **Migration caveat:** the old instruction was "upload to the pending plugin page first, then comment." With the Marketplace move, confirm the route before uploading — see the banner above and the separate question doc.
+- The 29 review issues were filed against ~v6.8.0 and remediated in v6.8.1-v6.8.3; the resubmission just confirms they hold in v6.9.4.
+- The closing process question is deliberately included in the message so the reviewer can redirect us in one round trip if the separate Marketplace query has not been answered yet. Drop that paragraph if Moodle has already confirmed the route.
+- PHPUnit figure updated from "about 550" to **631** (measured locally 2026-07-26: 631 tests, 1553 assertions, 0 failures, 1 skipped).
+- Prior resubmission email (v6.8.3) for reference: `moodle-directory-resubmission-email-v6.8.3.md`.


### PR DESCRIPTION
Docs only. Annotates every document still carrying the ~$63/mo rerank projection or the ~70 turns-per-user volume assumption.

## The correction

The original model compounded two errors that partly cancel:

| | Factor |
|---|---|
| Per-query cost **understated** — snippet-sized candidates assumed; real Saylor chunks average ~700 tokens, so a pool-50 rerank ships ~19k tokens/query | **52x** |
| Volume **overstated** — ~70 turns/user/month assumed; measured on prod is 5.07 | **13.7x** |
| **Net absolute cost understated** | **3.8x** |

At 25,000 SOLA users reranking is **~$237/month at pool 50**, not $63.

The larger correction is proportional: **~101% of chat spend at pool 50** and **~41% at pool 20**, against the "~6% of chat spend" these docs claim. That reframes the conclusion — enabling rerank at prod's configured pool 50 would roughly double the AI bill, where the original framing made it look like a rounding error.

## Approach

**Annotated, not rewritten.** Each doc gets a dated correction banner after its title, and the specific load-bearing lines (cost tables, capacity tables, "net positive" conclusions) get inline `[corrected: ...]` notes so a reader landing mid-document cannot miss it. The original numbers stay in place so the reasoning that produced them remains auditable.

`v5.11.0-release-notes-and-walkthrough.md` is a **shipped release note** and gets an editor's note only. Its recall claims are sound and have been reproduced (+9.8 pp R@3 at pool 20 over 1,008 queries); only the price was wrong.

## Two conclusions corrected in passing

- **Migrate embeddings to Voyage-3.5** — measured no better than OpenAI 3-small on our corpus across three independent tests. Keep OpenAI.
- **Reranking is "net positive"** — not unconditionally. It is negative on courses whose embedding recall is already strong, where it breaks 12% of correct top-1 results.

## Files

`sola-vendor-recommendations-2026-06-09.md` (the load-bearing one — its capacity table drives procurement and rate-limit conclusions), `sola-vendor-optimization-by-mau-2026-06-09.md`, `sola-multi-provider-optimization-plan.md`, `sola-pilot-to-scale-vendor-recommendations-2026-06-01.md`, `sola-rag-fixture-benchmark-2026-06-10.md`, `sola-v5.11.0-external-actions.md`, `v5.11.0-release-notes-and-walkthrough.md`

Canonical figures now live in `sola-retrieval-cost-projections-2026-07-31.md` (merged in #167).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
