### PR TITLE
feat(rag): gate reranking on per-query retrieval ambiguity

### DIFF
--- a/classes/policy_bundle.php
+++ b/classes/policy_bundle.php
@@ -126,6 +126,7 @@ class policy_bundle {
         'rerank_enabled',
         'rerank_model',
         'rerank_candidates',
+        'rerank_margin_threshold',
         // Spend policy (v5.13/v6.0).
         'spend_cap_site',
         'spend_cap_chat',

--- a/classes/rag_retriever.php
+++ b/classes/rag_retriever.php
@@ -173,7 +173,8 @@ class rag_retriever {
         // re-score them with rerank-2.5 (cross-encoder), then keep the top-k.
         // Published recall lifts: +15 Recall@10 enterprise / +39% NDCG BEIR.
         // Falls back to single-stage cosine top-k if reranker fails or is unset.
-        if ((bool) get_config('local_ai_course_assistant', 'rerank_enabled')) {
+        if ((bool) get_config('local_ai_course_assistant', 'rerank_enabled')
+                && self::should_rerank($scored)) {
             $rawcand = get_config('local_ai_course_assistant', 'rerank_candidates');
             $candidates = ($rawcand === false || $rawcand === '') ? 50 : (int) $rawcand;
             $candidates = max($topk, min($candidates, count($scored)));
@@ -259,6 +260,47 @@ class rag_retriever {
      * @param float $boost Ordering bonus added to current-page chunks.
      * @return array Filtered, rank-sorted rows (same shape as input).
      */
+    /**
+     * Whether this query is ambiguous enough to be worth reranking.
+     *
+     * Measured 2026-08-01 over 1,008 queries across 16 courses: the cosine
+     * margin between the top-1 and top-3 candidates predicts whether
+     * reranking helps. In the most ambiguous decile reranking gained
+     * +24.8 pp recall@3; in the least ambiguous decile it gained +0.0 pp,
+     * because the embedding stage was already right 99% of the time.
+     * Reranking a confident result is not merely wasted spend — it moved an
+     * already-correct top-1 hit out of rank 1 in 12% of such cases.
+     *
+     * Gating at the default 0.086 kept recall@3 at 89.2% against 89.3% for
+     * always-rerank while skipping ~30% of queries. The absolute *score* is
+     * deliberately not used: it varies with course vocabulary, so a value
+     * meaning "unsure" in one course means "confident" in another, and it
+     * tested non-monotone.
+     *
+     * Set `rerank_margin_threshold` to 0 to disable the gate and rerank
+     * every query, which is the pre-2026-08 behaviour.
+     *
+     * @param array $scored Candidates sorted by descending cosine score.
+     * @return bool True when reranking should run.
+     */
+    public static function should_rerank(array $scored): bool {
+        $raw = get_config('local_ai_course_assistant', 'rerank_margin_threshold');
+        // Unset means "use the measured default"; an explicit 0 disables the
+        // gate. Distinguishing the two matters, so test for false/'' first.
+        $threshold = ($raw === false || $raw === '') ? 0.086 : (float) $raw;
+        if ($threshold <= 0) {
+            return true;
+        }
+        // The margin needs a third candidate to exist. When it does not, the
+        // signal is unmeasurable rather than confident, so fall through to
+        // reranking rather than let a missing measurement disable the feature.
+        if (count($scored) < 3) {
+            return true;
+        }
+        $margin = (float) $scored[0]['score'] - (float) $scored[2]['score'];
+        return $margin < $threshold;
+    }
+
     public static function filter_and_rank(array $scored, float $minscore, int $currentcmid, float $boost): array {
         if ($minscore > 0.0) {
             $scored = array_values(array_filter(

--- a/lang/en/local_ai_course_assistant.php
+++ b/lang/en/local_ai_course_assistant.php
@@ -353,6 +353,8 @@ $string['settings:rerank_apibaseurl'] = 'Rerank API base URL';
 $string['settings:rerank_apibaseurl_desc'] = 'Override the Voyage rerank base URL. Leave blank to use the Embedding API Base URL above, or Voyage default (<code>https://api.voyageai.com/v1</code>).';
 $string['settings:rerank_candidates'] = 'Rerank candidate window';
 $string['settings:rerank_candidates_desc'] = 'How many cosine top-N candidates feed the rerank stage. Default 50. Larger windows give the reranker more material to work with at small extra cost (~10k tokens per rerank op).';
+$string['settings:rerank_margin_threshold'] = 'Rerank ambiguity threshold';
+$string['settings:rerank_margin_threshold_desc'] = 'Only rerank when the cosine margin between the top-1 and top-3 candidates is below this value, i.e. when retrieval is ambiguous. Measured over 1,008 queries: at the default 0.086 this skips about 30% of queries with no measurable recall loss, and avoids cases where reranking displaces an already-correct top result. Set to 0 to rerank every query.';
 
 // Selfhosted Whisper STT server (v6.2.0).
 $string['settings:stt_selfhosted_heading'] = 'Selfhosted transcription (Whisper)';

--- a/settings.php
+++ b/settings.php
@@ -759,6 +759,14 @@ if ($hassiteconfig) {
         PARAM_INT
     ));
 
+    $settings->add(new admin_setting_configtext(
+        'local_ai_course_assistant/rerank_margin_threshold',
+        get_string('settings:rerank_margin_threshold', 'local_ai_course_assistant'),
+        get_string('settings:rerank_margin_threshold_desc', 'local_ai_course_assistant'),
+        '0.086',
+        PARAM_FLOAT
+    ));
+
     $ragadminurl = new moodle_url('/local/ai_course_assistant/rag_admin.php');
     $settings->add(new admin_setting_description(
         'local_ai_course_assistant/rag_admin_link',

--- a/tests/rag_retriever_rerank_gate_test.php
+++ b/tests/rag_retriever_rerank_gate_test.php
@@ -1,0 +1,162 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+
+/**
+ * Tests for the per-query rerank ambiguity gate.
+ *
+ * Reranking only helps when the embedding stage is unsure. Measured
+ * 2026-08-01 over 1,008 queries across 16 courses: the most ambiguous decile
+ * gained +24.8 pp recall@3 from reranking, the least ambiguous gained
+ * +0.0 pp, and reranking displaced an already-correct top-1 result in 12% of
+ * confident cases. The gate uses the cosine margin between the top-1 and
+ * top-3 candidates as the ambiguity signal.
+ *
+ * These tests pin the decision boundary and, more importantly, the failure
+ * modes: a gate that silently returns false would disable reranking site-wide
+ * without any error, which is exactly the kind of regression that would not
+ * surface until someone measured recall again.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Tom Caswell / Saylor University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_ai_course_assistant\rag_retriever::should_rerank
+ */
+final class rag_retriever_rerank_gate_test extends \advanced_testcase {
+
+    /**
+     * Build a descending-scored candidate list.
+     *
+     * @param array $scores
+     * @return array
+     */
+    private function candidates(array $scores): array {
+        return array_map(fn($s) => ['id' => 1, 'score' => $s, 'content' => 'x'], $scores);
+    }
+
+    public function test_ambiguous_query_is_reranked(): void {
+        $this->resetAfterTest();
+        // margin = 0.700 - 0.660 = 0.040, below the 0.086 default.
+        $this->assertTrue(rag_retriever::should_rerank(
+            $this->candidates([0.700, 0.680, 0.660])));
+    }
+
+    public function test_confident_query_is_not_reranked(): void {
+        $this->resetAfterTest();
+        // margin = 0.800 - 0.600 = 0.200, well above the default.
+        $this->assertFalse(rag_retriever::should_rerank(
+            $this->candidates([0.800, 0.700, 0.600])));
+    }
+
+    /**
+     * The comparison is strict less-than, so margins clearly below the
+     * threshold rerank and margins clearly above do not.
+     *
+     * Behaviour for a margin *exactly* equal to the threshold is deliberately
+     * NOT pinned: cosine scores are binary floats, so a nominal 0.900 - 0.800
+     * evaluates to 0.09999999999999998 and lands below a 0.100 threshold.
+     * Asserting exact-boundary behaviour would be testing IEEE-754 rounding,
+     * not the gate. Nothing depends on it — a query sitting within 1e-16 of
+     * the threshold is a coin flip either way, and both outcomes are correct.
+     */
+    public function test_threshold_separates_clearly_ambiguous_from_clearly_confident(): void {
+        $this->resetAfterTest();
+        set_config('rerank_margin_threshold', '0.100', 'local_ai_course_assistant');
+        // Margin 0.05, unambiguously below.
+        $this->assertTrue(rag_retriever::should_rerank(
+            $this->candidates([0.900, 0.870, 0.850])));
+        // Margin 0.15, unambiguously above.
+        $this->assertFalse(rag_retriever::should_rerank(
+            $this->candidates([0.900, 0.820, 0.750])));
+    }
+
+    /**
+     * Only the first and third scores matter. A different second-place score
+     * must not change the decision.
+     */
+    public function test_only_top1_and_top3_are_used(): void {
+        $this->resetAfterTest();
+        $a = rag_retriever::should_rerank($this->candidates([0.700, 0.699, 0.660]));
+        $b = rag_retriever::should_rerank($this->candidates([0.700, 0.661, 0.660]));
+        $this->assertSame($a, $b);
+        $this->assertTrue($a);
+    }
+
+    /**
+     * Setting the threshold to 0 restores the pre-2026-08 behaviour of
+     * reranking every query.
+     */
+    public function test_zero_threshold_disables_the_gate(): void {
+        $this->resetAfterTest();
+        set_config('rerank_margin_threshold', '0', 'local_ai_course_assistant');
+        // Would otherwise be far too confident to rerank.
+        $this->assertTrue(rag_retriever::should_rerank(
+            $this->candidates([0.990, 0.500, 0.100])));
+    }
+
+    /**
+     * An unset config must fall back to the measured default, NOT to zero.
+     * get_config() returns false when unset, and casting false to float
+     * yields 0.0 -- which would silently disable the gate.
+     */
+    public function test_unset_config_uses_the_measured_default_not_zero(): void {
+        $this->resetAfterTest();
+        unset_config('rerank_margin_threshold', 'local_ai_course_assistant');
+        // Confident: would rerank only if the gate had collapsed to 0.
+        $this->assertFalse(rag_retriever::should_rerank(
+            $this->candidates([0.800, 0.700, 0.600])));
+        // Ambiguous: still reranks.
+        $this->assertTrue(rag_retriever::should_rerank(
+            $this->candidates([0.700, 0.680, 0.660])));
+    }
+
+    /**
+     * With fewer than three candidates the margin cannot be computed. The
+     * signal is then unmeasurable rather than confident, so reranking must
+     * still run -- a missing measurement must never silently disable it.
+     */
+    public function test_fewer_than_three_candidates_still_reranks(): void {
+        $this->resetAfterTest();
+        $this->assertTrue(rag_retriever::should_rerank($this->candidates([0.9, 0.1])));
+        $this->assertTrue(rag_retriever::should_rerank($this->candidates([0.9])));
+        $this->assertTrue(rag_retriever::should_rerank([]));
+    }
+
+    /**
+     * A negative threshold is nonsense but must not invert the gate.
+     */
+    public function test_negative_threshold_behaves_as_disabled(): void {
+        $this->resetAfterTest();
+        set_config('rerank_margin_threshold', '-1', 'local_ai_course_assistant');
+        $this->assertTrue(rag_retriever::should_rerank(
+            $this->candidates([0.800, 0.700, 0.600])));
+    }
+
+    /**
+     * The shipped default must remain the measured value. If someone changes
+     * it, that should be a conscious edit with new evidence behind it.
+     */
+    public function test_default_threshold_is_the_measured_value(): void {
+        $this->resetAfterTest();
+        unset_config('rerank_margin_threshold', 'local_ai_course_assistant');
+        // Margin 0.0859 is just inside 0.086; 0.0861 is just outside.
+        $this->assertTrue(rag_retriever::should_rerank(
+            $this->candidates([0.9000, 0.8900, 0.8141])));
+        $this->assertFalse(rag_retriever::should_rerank(
+            $this->candidates([0.9000, 0.8900, 0.8139])));
+    }
+}


### PR DESCRIPTION
Wires the confidence gate measured in #170 into the live retrieval path. Reranking now runs only when the cosine margin between the top-1 and top-3 candidates is below `rerank_margin_threshold` (default **0.086**).

## Validated end-to-end on the live path

The experiment in #170 was computed offline from recorded ranks. This runs all 1,008 fixtures through the real `rag_retriever::retrieve()` on dev, three arms, identical settings:

| Arm | R@3 | Reranked | ms/query |
|---|---|---|---|
| Never rerank | 79.2% | 0 / 1008 (0%) | 288 |
| Always rerank | 89.1% | 1008 / 1008 (100%) | 534 |
| **Gated (0.086)** | **88.9%** | **702 / 1008 (70%)** | **471** |

**gate vs always: −0.2 pp recall, 30% of reranks skipped, 63 ms/query faster.**

Coverage landed on the predicted 70% exactly, and the arms reproduce the offline benchmark — never-rerank matches 79.2% precisely, always-rerank 89.1% against 89.0% offline at pool 20. Latency was previously unmeasured; the gate saves ~12% of rerank-enabled query time.

## Why the margin, not the score

The absolute top-1 score was tested and **rejected** — non-monotone across deciles, needing 90% coverage to retain the lift, because absolute cosine varies with course vocabulary so a value meaning "unsure" in one course means "confident" in another.

The margin is close to monotone: +24.8 pp recall in the most ambiguous decile, +0.0 pp in the least. Where the embedding stage is decisive it is already right 99% of the time, and reranking a confident result is not merely wasted spend — it displaced an already-correct top-1 hit in 12% of such cases.

## Implementation

Extracted as `rag_retriever::should_rerank()` rather than written inline, so the decision is unit-testable without a live index or a Voyage key.

Two failure modes are pinned by tests because **both would silently disable reranking site-wide with no error** — nothing would surface until someone measured recall again:
- `get_config()` returns `false` when unset, and `(float) false` is `0.0`, which would collapse the gate. Unset must fall back to 0.086, not zero.
- Fewer than three candidates makes the margin unmeasurable. That is not the same as confident, so it still reranks.

Exact-boundary behaviour is deliberately **not** pinned: cosine scores are binary floats, so a nominal `0.900 - 0.800` evaluates to `0.09999999999999998` and falls below a `0.100` threshold. My first version of that test asserted IEEE-754 rounding rather than the gate and failed; it now asserts separation either side.

`rerank_margin_threshold` is on the `policy_bundle` allowlist, so it can be tuned without a code deploy. That matters — the threshold is tuned on synthetic questions that are easier than real learner queries, so it will likely need revisiting against production traffic.

## Backwards compatibility

Reranking is **off by default**, so this changes nothing for any site that has not enabled it. For sites that have, set `rerank_margin_threshold=0` to restore the previous always-rerank behaviour.

## Testing

- 9 new unit tests covering the decision boundary and both silent-failure modes
- Full plugin suite: **652 tests, 1599 assertions, 0 failures**
- Live three-arm validation above; dev config restored afterwards and verified

## Incidental finding, not addressed here

`retrieve()` fetches and decodes **every chunk embedding for the course on each call** — ~20 MB at average course size, 58 MB on the largest. That is why the live baseline is 288 ms where the benchmark harness (which preloads once) measured ~200 ms. A caching opportunity worth its own change, and it means retrieval latency figures in the cost report are optimistic for real traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
