### PR TITLE
fix(rag): invalidate the retriever vector cache when the index changes

### DIFF
--- a/classes/content_indexer.php
+++ b/classes/content_indexer.php
@@ -195,6 +195,11 @@ class content_indexer {
         // Otherwise (sources existed but embeds errored) leave the existing
         // index untouched rather than risk wiping good data on a flaky run.
 
+        // The retriever caches decoded vectors for the life of the process.
+        // Reindexing inside a long-running CLI would otherwise keep scoring
+        // against the vectors this run just replaced.
+        rag_retriever::flush_cache($courseid);
+
         return $stats;
     }
 
@@ -212,6 +217,7 @@ class content_indexer {
         if ($mod === null) {
             // Nothing extractable — delete any stale chunks.
             $DB->delete_records('local_ai_course_assistant_chunks', ['cmid' => $cmid]);
+            rag_retriever::flush_cache();
             return true;
         }
 
@@ -276,6 +282,7 @@ class content_indexer {
             $DB->insert_record('local_ai_course_assistant_chunks', $record);
         }
 
+        rag_retriever::flush_cache();
         return true;
     }
 
@@ -302,5 +309,6 @@ class content_indexer {
     public static function delete_course_index(int $courseid): void {
         global $DB;
         $DB->delete_records('local_ai_course_assistant_chunks', ['courseid' => $courseid]);
+        rag_retriever::flush_cache($courseid);
     }
 }

--- a/classes/rag_retriever.php
+++ b/classes/rag_retriever.php
@@ -37,6 +37,34 @@ use local_ai_course_assistant\embedding_provider\base_embedding_provider;
 class rag_retriever {
 
     /**
+     * @var array Decoded chunk vectors, keyed "course_<id>".
+     *
+     * Avoids re-decoding every vector on repeated retrievals. Lives for the
+     * life of the PHP process, so it MUST be flushed whenever the index
+     * changes -- see flush_cache(). For a web request that window is a single
+     * page load, but CLI processes (reindex tools, benchmark harnesses,
+     * scheduled tasks) can hold it across an entire run and would otherwise
+     * score against vectors that no longer exist.
+     */
+    private static array $vectorcache = [];
+
+    /**
+     * Discard cached vectors after the index changes.
+     *
+     * Called by content_indexer on every path that inserts or deletes chunks.
+     * Cheap: the cache is per-process and rebuilt on the next retrieval.
+     *
+     * @param int|null $courseid Course to flush, or null for every course.
+     */
+    public static function flush_cache(?int $courseid = null): void {
+        if ($courseid === null) {
+            self::$vectorcache = [];
+            return;
+        }
+        unset(self::$vectorcache["course_{$courseid}"]);
+    }
+
+    /**
      * Retrieve the top-k most relevant chunks for a user query.
      *
      * @param int    $courseid
@@ -61,9 +89,6 @@ class rag_retriever {
 
         $final = null;
 
-        // Static cache of decoded embeddings — avoids re-decoding JSON on
-        // subsequent RAG queries within the same PHP request.
-        static $embedding_cache = [];
         $cache_key = "course_{$courseid}";
 
         // Relevance gate + current-page bias, admin-tunable. The floor drops
@@ -105,7 +130,7 @@ class rag_retriever {
         }
 
         // Load and decode embeddings (cached per-course within the request).
-        if (!isset($embedding_cache[$cache_key])) {
+        if (!isset(self::$vectorcache[$cache_key])) {
             $rows = $DB->get_records_select(
                 'local_ai_course_assistant_chunks',
                 'courseid = :courseid AND embedding IS NOT NULL',
@@ -121,12 +146,12 @@ class rag_retriever {
                 'id, embedding, embedding_bin, cmid, modtype, chunkindex'
             );
 
-            $embedding_cache[$cache_key] = [];
+            self::$vectorcache[$cache_key] = [];
             if (!empty($rows)) {
                 foreach ($rows as $row) {
                     $vec = self::decode_vector($row->embedding_bin ?? null, $row->embedding ?? null);
                     if (is_array($vec) && !empty($vec)) {
-                        $embedding_cache[$cache_key][$row->id] = [
+                        self::$vectorcache[$cache_key][$row->id] = [
                             'vec'        => $vec,
                             'cmid'       => isset($row->cmid) ? (int) $row->cmid : null,
                             'modtype'    => (string) ($row->modtype ?? ''),
@@ -137,7 +162,7 @@ class rag_retriever {
             }
         }
 
-        if (empty($embedding_cache[$cache_key])) {
+        if (empty(self::$vectorcache[$cache_key])) {
             return [];
         }
 
@@ -152,7 +177,7 @@ class rag_retriever {
         $qnorm = sqrt($qnorm);
 
         $scored = [];
-        foreach ($embedding_cache[$cache_key] as $chunkid => $entry) {
+        foreach (self::$vectorcache[$cache_key] as $chunkid => $entry) {
             $score    = self::cosine_against_query($queryvec, $qnorm, $entry['vec']);
             $scored[] = [
                 'id'         => $chunkid,

--- a/tests/rag_retriever_cache_invalidation_test.php
+++ b/tests/rag_retriever_cache_invalidation_test.php
@@ -1,0 +1,137 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+
+/**
+ * Tests that the retriever's per-process vector cache is invalidated when the
+ * index changes.
+ *
+ * The cache lives for the life of the PHP process. In a web request that is a
+ * single page load, so a stale entry is nearly harmless. In a CLI process —
+ * the reindex tools, the benchmark harnesses, scheduled tasks — it can live
+ * for an entire run, and retrieval would keep scoring against vectors for
+ * chunks that have since been deleted or replaced.
+ *
+ * These tests drive the cache directly through reflection rather than through
+ * retrieve(), because retrieve() needs a live embedding provider and the
+ * behaviour under test is purely the cache lifecycle.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Tom Caswell / Saylor University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_ai_course_assistant\rag_retriever::flush_cache
+ */
+final class rag_retriever_cache_invalidation_test extends \advanced_testcase {
+
+    /**
+     * Read the private cache.
+     *
+     * @return array
+     */
+    private function cache(): array {
+        $p = new \ReflectionProperty(rag_retriever::class, 'vectorcache');
+        $p->setAccessible(true);
+        return $p->getValue();
+    }
+
+    /**
+     * Seed the private cache as though a retrieval had populated it.
+     *
+     * @param array $courseids
+     */
+    private function seed(array $courseids): void {
+        $p = new \ReflectionProperty(rag_retriever::class, 'vectorcache');
+        $p->setAccessible(true);
+        $val = [];
+        foreach ($courseids as $cid) {
+            $val["course_{$cid}"] = [1 => ['vec' => [0.1, 0.2], 'cmid' => 1,
+                'modtype' => 'page', 'chunkindex' => 0]];
+        }
+        $p->setValue(null, $val);
+    }
+
+    protected function tearDown(): void {
+        rag_retriever::flush_cache();
+        parent::tearDown();
+    }
+
+    public function test_flush_removes_only_the_named_course(): void {
+        $this->resetAfterTest();
+        $this->seed([11, 22]);
+        $this->assertArrayHasKey('course_11', $this->cache());
+
+        rag_retriever::flush_cache(11);
+
+        $after = $this->cache();
+        $this->assertArrayNotHasKey('course_11', $after);
+        $this->assertArrayHasKey('course_22', $after,
+            'flushing one course must not discard another course\'s vectors');
+    }
+
+    public function test_flush_without_argument_clears_everything(): void {
+        $this->resetAfterTest();
+        $this->seed([11, 22, 33]);
+
+        rag_retriever::flush_cache();
+
+        $this->assertSame([], $this->cache());
+    }
+
+    public function test_flushing_an_uncached_course_is_harmless(): void {
+        $this->resetAfterTest();
+        $this->seed([11]);
+
+        rag_retriever::flush_cache(999);
+
+        $this->assertArrayHasKey('course_11', $this->cache());
+    }
+
+    /**
+     * The real regression: deleting a course index must drop its cached
+     * vectors. Without the flush this test leaves stale entries behind, and a
+     * long-running process would score against chunks that no longer exist.
+     */
+    public function test_delete_course_index_invalidates_the_cache(): void {
+        $this->resetAfterTest();
+        $this->seed([11, 22]);
+
+        content_indexer::delete_course_index(11);
+
+        $after = $this->cache();
+        $this->assertArrayNotHasKey('course_11', $after,
+            'delete_course_index must invalidate the retriever cache');
+        $this->assertArrayHasKey('course_22', $after);
+    }
+
+    /**
+     * Guards the assumption the cache key encodes: entries are per course, so
+     * two courses never collide. A key format change that broke this would
+     * leak one course's content into another's retrieval, which is a privacy
+     * problem rather than merely a staleness one.
+     */
+    public function test_course_entries_do_not_collide(): void {
+        $this->resetAfterTest();
+        $this->seed([1, 11, 111]);
+
+        rag_retriever::flush_cache(1);
+
+        $after = $this->cache();
+        $this->assertArrayNotHasKey('course_1', $after);
+        $this->assertArrayHasKey('course_11', $after);
+        $this->assertArrayHasKey('course_111', $after);
+    }
+}


### PR DESCRIPTION
`rag_retriever` kept decoded chunk vectors in a method-local static that was **never invalidated**. Nothing cleared it when chunks were reindexed or deleted, so retrieval could keep scoring against vectors for chunks that no longer exist.

Flagged during the review of #172 as out of scope there.

## Why it went unnoticed, and where it actually bites

For a **web request** the exposure is a single page load — which is why this survived this long.

It is materially worse in a **long-running process**. The reindex CLI, the benchmark harnesses and scheduled tasks all hold one PHP process across many operations, so a reindex mid-run leaves every subsequent retrieval scoring the pre-reindex index. Any benchmark that reindexes and then measures is silently measuring the old vectors.

## The fix

The static is promoted to a private class property, and `content_indexer` flushes it on every path that inserts or deletes chunks:

| Entry point | Flush |
|---|---|
| `index_course()` | that course |
| `index_module()` | all — cmid does not cheaply give a course |
| `delete_course_index()` | that course |

`flush_cache(null)` clears everything, `flush_cache($id)` one course. The cache is per-process and rebuilt on the next retrieval, so flushing costs nothing beyond one extra load.

## The regression test earns its place

Removing the flush from `delete_course_index()` makes it fail:

```
delete_course_index must invalidate the retriever cache
Failed asserting that an array does not have the key 'course_11'.
```

Restoring it passes. I checked this rather than assuming — a test that passes with and without the fix documents nothing.

## One test that is not about staleness

`test_course_entries_do_not_collide` pins that course 1, 11 and 111 occupy distinct keys. A key format that collided would serve **one course's content into another course's retrieval** — a privacy failure rather than a correctness one, and worth a standing guard even though the current format is obviously safe.

## Testing

Full suite: **669 tests, 3194 assertions, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
