### PR TITLE
fix(settings): mask redash_api_key in config_log; default rerank pool to 20

### DIFF
--- a/analytics.php
+++ b/analytics.php
@@ -505,19 +505,22 @@ $templatedata = [
         $since30 = $now - 30 * 86400;
         $since7 = $now - 7 * 86400;
 
-        // Tokens this month.
-        $toktotal = (int) $DB->get_field_sql(
-            "SELECT COALESCE(SUM(COALESCE(prompt_tokens, 0) + COALESCE(completion_tokens, 0)), 0)
-               FROM {local_ai_course_assistant_msgs}
-              WHERE role = 'assistant' AND timecreated > ?",
-            [$since30]) ?: 0;
+        // Tokens this month. Site-wide, so it includes the background RAG spend
+        // ledger (embedding + rerank) as well as chat. This used to filter
+        // role='assistant' inline and therefore undercounted by the whole of RAG.
+        $toktotal = \local_ai_course_assistant\analytics::get_total_tokens(0, $since30);
         $chips[] = [
             'value' => number_format($toktotal),
             'label' => 'Tokens (30d)',
             'query' => 'Break down token spend by provider and course for the last 30 days.',
         ];
 
-        // Top-cost course (30d).
+        // Top-cost course (30d). Deliberately still role='assistant': this chip
+        // attributes spend to a course, and the embedding/rerank ledger is written
+        // against SITEID rather than the course whose content was indexed, so
+        // including it would crown the site course as top consumer. Consequence
+        // to expect, not a bug: "Tokens (30d)" above is larger than the sum of
+        // per-course token totals, by the amount of background RAG spend.
         $topcourse = $DB->get_record_sql(
             "SELECT c.id, c.shortname, c.fullname,
                     SUM(COALESCE(m.prompt_tokens, 0) + COALESCE(m.completion_tokens, 0)) AS tokens

--- a/classes/analytics.php
+++ b/classes/analytics.php
@@ -55,10 +55,22 @@ class analytics {
         // Total conversations.
         $totalconvs = $DB->count_records('local_ai_course_assistant_convs', ['courseid' => $courseid]);
 
-        // Total messages.
+        // Total messages. Restricted to conversation roles: the msgs table also
+        // carries role='system' telemetry rows that are not learner messages at
+        // all (embedding cost rows from base_embedding_provider, which are
+        // written against SITEID, plus premium_router and reranker rows written
+        // against the real course id). Counting those overstated the metric --
+        // a site course with no learner activity reported tens of thousands of
+        // "messages" that were really background indexing ledger entries, and it
+        // inflated avg_messages_per_student and the has_data flag with it. An
+        // allowlist rather than a telemetry denylist, so any future role='system'
+        // writer is excluded without needing to update this query. The sibling
+        // counters (get_daily_usage, get_student_usage, instructor_analytics)
+        // already filter by role; this one was the outlier.
         $sql = "SELECT COUNT(m.id)
                   FROM {local_ai_course_assistant_msgs} m
-                 WHERE m.courseid = :courseid{$timewhere}";
+                 WHERE m.courseid = :courseid
+                   AND m.role IN ('user', 'assistant'){$timewhere}";
         $totalmessages = $DB->count_records_sql($sql, $params);
 
         // Active students (users who sent at least one message).

--- a/classes/analytics.php
+++ b/classes/analytics.php
@@ -365,6 +365,67 @@ class analytics {
     }
 
     /**
+     * SQL predicate matching rows that represent a real billable API call.
+     *
+     * Single definition on purpose. This predicate was previously written inline
+     * in each place that summed spend, and they drifted: every one of them said
+     * role='assistant', which silently omitted the embedding and rerank cost
+     * ledger (written with role='system' by base_embedding_provider and
+     * voyage_reranker). Any new spend total must use this rather than hand-roll
+     * the condition again.
+     *
+     * Matches on interaction_type rather than role for the background rows,
+     * because premium_router also writes role='system' -- with zero tokens and
+     * the escalation target's model name, while the escalated call itself is
+     * logged separately as an assistant row. Including it would double-count.
+     *
+     * @param string $alias table alias used in the calling query.
+     * @return string SQL boolean expression, already parenthesised.
+     */
+    private static function spend_rows_predicate(string $alias = 'm'): string {
+        return "({$alias}.role = 'assistant'
+                 OR {$alias}.interaction_type IN ('embedding', 'rerank'))";
+    }
+
+    /**
+     * Total tokens (prompt + completion) across all billable rows.
+     *
+     * Powers the site-wide "Tokens (30d)" figure. Unlike get_token_costs() this
+     * does not require a model_name, so it keeps counting rows whose model was
+     * never recorded; the two therefore need not agree exactly, and this one is
+     * the more complete total.
+     *
+     * Background embedding/rerank spend is written against SITEID, so a
+     * whole-site call ($courseid = 0) includes it and a per-course call does not.
+     * That means this total legitimately exceeds the sum of per-course totals.
+     *
+     * @param int $courseid 0 for the whole site, or a specific course.
+     * @param int $since Unix timestamp lower bound; 0 for no bound.
+     * @return int Total tokens.
+     */
+    public static function get_total_tokens(int $courseid = 0, int $since = 0): int {
+        global $DB;
+
+        $where = self::spend_rows_predicate('m');
+        $params = [];
+        if ($courseid > 0) {
+            $where .= ' AND m.courseid = :courseid';
+            $params['courseid'] = $courseid;
+        }
+        if ($since > 0) {
+            $where .= ' AND m.timecreated >= :since';
+            $params['since'] = $since;
+        }
+
+        $sql = "SELECT COALESCE(SUM(COALESCE(m.prompt_tokens, 0)
+                               + COALESCE(m.completion_tokens, 0)), 0)
+                  FROM {local_ai_course_assistant_msgs} m
+                 WHERE {$where}";
+
+        return (int) $DB->get_field_sql($sql, $params);
+    }
+
+    /**
      * Aggregate token spend per model, including background RAG spend.
      *
      * Chat spend is the role='assistant' rows. Background spend is the ledger
@@ -404,8 +465,7 @@ class analytics {
 
         // Rows that represent a real billable API call.
         $where = "m.model_name IS NOT NULL AND m.model_name != ''
-                  AND (m.role = 'assistant'
-                       OR m.interaction_type IN ('embedding', 'rerank'))";
+                  AND " . self::spend_rows_predicate('m');
         $params = [];
         if ($courseid > 0) {
             $where .= ' AND m.courseid = :courseid';

--- a/classes/analytics.php
+++ b/classes/analytics.php
@@ -365,6 +365,96 @@ class analytics {
     }
 
     /**
+     * Aggregate token spend per model, including background RAG spend.
+     *
+     * Chat spend is the role='assistant' rows. Background spend is the ledger
+     * that base_embedding_provider::log_embedding_cost() and
+     * voyage_reranker::log_rerank_cost() write with role='system' -- those exist
+     * specifically to make indexing and rerank cost visible, so a filter of
+     * role='assistant' alone silently hid real API spend.
+     *
+     * premium_router also writes role='system' rows, but with zero tokens and
+     * the escalation target's model_name. Those are metadata, not spend: the
+     * escalated call itself is logged separately as an assistant row, so
+     * counting them would double-count each escalated turn against that model.
+     * They are excluded by matching on interaction_type rather than on role.
+     *
+     * `category` ('chat' / 'embedding' / 'rerank') is part of the grouping so
+     * background spend can never merge into a chat bucket, and so a consumer can
+     * split RAG cost from chat cost. `response_count` means assistant responses
+     * for chat rows and API calls for embedding/rerank rows.
+     *
+     * NOTE on scope: embedding and rerank rows are written against SITEID rather
+     * than the course whose content was indexed, so they appear only in a
+     * whole-site aggregate ($courseid = 0). A per-course call legitimately
+     * returns chat spend only.
+     *
+     * estimated_cost_usd is null when the model is absent from the rate card,
+     * which is currently the case for Voyage embedding and rerank models. Null
+     * means unknown, not free.
+     *
+     * @param int $courseid 0 for the whole site, or a specific course.
+     * @param int $since Unix timestamp lower bound; 0 for no bound.
+     * @return array List of ['model', 'category', 'response_count',
+     *               'total_prompt_tokens', 'total_completion_tokens',
+     *               'total_tokens', 'estimated_cost_usd'].
+     */
+    public static function get_token_costs(int $courseid = 0, int $since = 0): array {
+        global $DB;
+
+        // Rows that represent a real billable API call.
+        $where = "m.model_name IS NOT NULL AND m.model_name != ''
+                  AND (m.role = 'assistant'
+                       OR m.interaction_type IN ('embedding', 'rerank'))";
+        $params = [];
+        if ($courseid > 0) {
+            $where .= ' AND m.courseid = :courseid';
+            $params['courseid'] = $courseid;
+        }
+        if ($since > 0) {
+            $where .= ' AND m.timecreated >= :since';
+            $params['since'] = $since;
+        }
+
+        $category = "CASE WHEN m.interaction_type IN ('embedding', 'rerank')
+                          THEN m.interaction_type ELSE 'chat' END";
+
+        // Recordset, not get_records_sql: the grouping key is (model, category),
+        // so model_name is not unique across rows and would silently collapse
+        // two groups into one if it were used as the array key.
+        $sql = "SELECT m.model_name,
+                       {$category} AS category,
+                       COUNT(m.id) AS response_count,
+                       SUM(COALESCE(m.prompt_tokens, 0)) AS total_prompt_tokens,
+                       SUM(COALESCE(m.completion_tokens, 0)) AS total_completion_tokens,
+                       SUM(COALESCE(m.tokens_used, 0)) AS total_tokens
+                  FROM {local_ai_course_assistant_msgs} m
+                 WHERE {$where}
+              GROUP BY m.model_name, {$category}
+              ORDER BY total_tokens DESC";
+
+        $result = [];
+        $rs = $DB->get_recordset_sql($sql, $params);
+        foreach ($rs as $row) {
+            $prompttokens = (int) $row->total_prompt_tokens;
+            $completiontokens = (int) $row->total_completion_tokens;
+            $result[] = [
+                'model' => $row->model_name,
+                'category' => $row->category,
+                'response_count' => (int) $row->response_count,
+                'total_prompt_tokens' => $prompttokens,
+                'total_completion_tokens' => $completiontokens,
+                'total_tokens' => (int) $row->total_tokens,
+                'estimated_cost_usd' => token_cost_manager::estimate_cost(
+                    $row->model_name, $prompttokens, $completiontokens),
+            ];
+        }
+        $rs->close();
+
+        return $result;
+    }
+
+    /**
      * Get per-student usage summary for a course.
      *
      * @param int $courseid

--- a/classes/rag_retriever.php
+++ b/classes/rag_retriever.php
@@ -216,7 +216,7 @@ class rag_retriever {
         if ((bool) get_config('local_ai_course_assistant', 'rerank_enabled')) {
             $rawcand = get_config('local_ai_course_assistant', 'rerank_candidates');
             $hydratelimit = max($topk,
-                ($rawcand === false || $rawcand === '') ? 50 : (int) $rawcand);
+                ($rawcand === false || $rawcand === '') ? 20 : (int) $rawcand);
         }
         $scored = self::hydrate_content(array_slice($scored, 0, $hydratelimit));
         if (empty($scored)) {
@@ -225,14 +225,14 @@ class rag_retriever {
 
         // Optional stage 2: two-stage retrieval with Voyage rerank-2.5.
         // When `rerank_enabled` is on AND a Voyage rerank API key is configured,
-        // take the top `rerank_candidates` cosine matches (default 50) and
+        // take the top `rerank_candidates` cosine matches (default 20) and
         // re-score them with rerank-2.5 (cross-encoder), then keep the top-k.
         // Published recall lifts: +15 Recall@10 enterprise / +39% NDCG BEIR.
         // Falls back to single-stage cosine top-k if reranker fails or is unset.
         if ((bool) get_config('local_ai_course_assistant', 'rerank_enabled')
                 && self::should_rerank($scored)) {
             $rawcand = get_config('local_ai_course_assistant', 'rerank_candidates');
-            $candidates = ($rawcand === false || $rawcand === '') ? 50 : (int) $rawcand;
+            $candidates = ($rawcand === false || $rawcand === '') ? 20 : (int) $rawcand;
             $candidates = max($topk, min($candidates, count($scored)));
             $stage1 = array_slice($scored, 0, $candidates);
             try {

--- a/classes/redash_export_request.php
+++ b/classes/redash_export_request.php
@@ -1,0 +1,181 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+
+/**
+ * Request shaping for the Redash analytics export endpoint (v6.8.6).
+ *
+ * `redash_export.php` used to emit every section on every call, over all of
+ * time, and let any holder of the API key de-anonymize the payload. All three
+ * are decided here so they are unit-testable without an HTTP round trip:
+ *
+ *  - `parse_sections()` turns the `sections` parameter into an allow-list, so a
+ *    dashboard that only needs cost data never pulls raw transcript text.
+ *  - `resolve_since()` applies a default lookback window, so an absent `since`
+ *    no longer means "every row ever recorded".
+ *  - `deanonymize_allowed()` gates `anonymize=0` behind its own admin setting
+ *    rather than leaving it to the caller.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Tom Caswell / Saylor University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class redash_export_request {
+
+    /**
+     * Every section the export can emit, in response order.
+     *
+     * `student_usage` and `hotspots` are per-course blocks nested inside
+     * `courses`; they are listed separately because they are the expensive
+     * parts of a course row and are usually not wanted.
+     */
+    public const SECTIONS = [
+        'courses',
+        'student_usage',
+        'hotspots',
+        'feedback',
+        'token_costs',
+        'survey_responses',
+        'meta_ai',
+        'learning_radar_queries',
+    ];
+
+    /** Fallback lookback window (days) when the admin setting is unset. */
+    public const DEFAULT_WINDOW_DAYS = 90;
+
+    /**
+     * Resolve the `sections` parameter into an ordered allow-list.
+     *
+     * An absent or empty parameter keeps the historical behaviour and returns
+     * every section, so existing Redash data sources do not silently lose data
+     * on upgrade. `sections=all` is accepted as an explicit synonym.
+     *
+     * A parameter that names only unknown sections returns an empty array; the
+     * caller is expected to reject the request rather than fall back to
+     * everything, so that a typo (`tokencosts`) fails loudly instead of
+     * quietly exporting the full payload.
+     *
+     * @param string $raw Raw comma-separated parameter value.
+     * @return array List of valid section names in canonical order, deduplicated.
+     */
+    public static function parse_sections(string $raw): array {
+        $raw = trim($raw);
+        if ($raw === '' || strtolower($raw) === 'all') {
+            return self::SECTIONS;
+        }
+
+        $requested = [];
+        foreach (explode(',', $raw) as $piece) {
+            $name = strtolower(trim($piece));
+            if ($name !== '') {
+                $requested[$name] = true;
+            }
+        }
+
+        // Iterate SECTIONS rather than the caller's list so the response order
+        // is stable regardless of the order the parameter was written in.
+        $out = [];
+        foreach (self::SECTIONS as $section) {
+            if (isset($requested[$section])) {
+                $out[] = $section;
+            }
+        }
+        return $out;
+    }
+
+    /**
+     * Names in a `sections` parameter that match no known section.
+     *
+     * Reported back in the error response so a misconfigured data source says
+     * which word was wrong instead of just "invalid".
+     *
+     * @param string $raw Raw comma-separated parameter value.
+     * @return array List of unrecognised names, in the order supplied.
+     */
+    public static function unknown_sections(string $raw): array {
+        $raw = trim($raw);
+        if ($raw === '' || strtolower($raw) === 'all') {
+            return [];
+        }
+
+        $out = [];
+        foreach (explode(',', $raw) as $piece) {
+            $name = strtolower(trim($piece));
+            if ($name !== '' && !in_array($name, self::SECTIONS, true) && !in_array($name, $out, true)) {
+                $out[] = $name;
+            }
+        }
+        return $out;
+    }
+
+    /**
+     * Resolve the effective `since` timestamp.
+     *
+     * The endpoint passes -1 as the "parameter absent" sentinel, which maps to
+     * the configured lookback window. An explicit `since=0` still means all of
+     * time, so a deliberate backfill remains possible.
+     *
+     * @param int $raw Caller-supplied value, or a negative sentinel when absent.
+     * @param int $now Current Unix timestamp.
+     * @param int|null $windowdays Window override; null reads the admin setting.
+     * @return int Unix timestamp to filter from; 0 means no lower bound.
+     */
+    public static function resolve_since(int $raw, int $now, ?int $windowdays = null): int {
+        if ($raw > 0) {
+            return $raw;
+        }
+        if ($raw === 0) {
+            // Explicit opt-in to an all-time export.
+            return 0;
+        }
+
+        $days = $windowdays ?? self::window_days();
+        if ($days <= 0) {
+            // An admin can restore the old all-time default by setting 0 days.
+            return 0;
+        }
+
+        $since = $now - ($days * DAYSECS);
+        return $since > 0 ? $since : 0;
+    }
+
+    /**
+     * Configured default lookback window in days.
+     *
+     * @return int Days; 0 or less means "no default window" (all time).
+     */
+    public static function window_days(): int {
+        $configured = get_config('local_ai_course_assistant', 'redash_export_window_days');
+        if ($configured === false || trim((string) $configured) === '') {
+            return self::DEFAULT_WINDOW_DAYS;
+        }
+        return (int) $configured;
+    }
+
+    /**
+     * Whether `anonymize=0` (real learner names) is permitted at all.
+     *
+     * The export authenticates by shared API key, not by a logged-in admin, so
+     * without this gate the key alone is enough to pull de-anonymized learner
+     * data. Off unless an admin deliberately turns it on.
+     *
+     * @return bool
+     */
+    public static function deanonymize_allowed(): bool {
+        return !empty(get_config('local_ai_course_assistant', 'redash_allow_deanonymized'));
+    }
+}

--- a/lang/en/local_ai_course_assistant.php
+++ b/lang/en/local_ai_course_assistant.php
@@ -352,7 +352,7 @@ $string['settings:rerank_model_desc'] = 'Default <code>rerank-2.5</code>. Newer 
 $string['settings:rerank_apibaseurl'] = 'Rerank API base URL';
 $string['settings:rerank_apibaseurl_desc'] = 'Override the Voyage rerank base URL. Leave blank to use the Embedding API Base URL above, or Voyage default (<code>https://api.voyageai.com/v1</code>).';
 $string['settings:rerank_candidates'] = 'Rerank candidate window';
-$string['settings:rerank_candidates_desc'] = 'How many cosine top-N candidates feed the rerank stage. Default 50. Larger windows give the reranker more material to work with at small extra cost (~10k tokens per rerank op).';
+$string['settings:rerank_candidates_desc'] = 'How many cosine top-N candidates feed the rerank stage. Default 20. Measured over 1,008 queries: 20 matches 30 on recall (R@3 89.0% vs 89.3%) for a third less cost, and 50 costs 2.5x with no measurable gain. Below 10 recall degrades. Cost scales linearly with this value.';
 $string['settings:rerank_margin_threshold'] = 'Rerank ambiguity threshold';
 $string['settings:rerank_margin_threshold_desc'] = 'Only rerank when the cosine margin between the top-1 and top-3 candidates is below this value, i.e. when retrieval is ambiguous. Measured over 1,008 queries: at the default 0.086 this skips about 30% of queries with no measurable recall loss, and avoids cases where reranking displaces an already-correct top result. Set to 0 to rerank every query.';
 

--- a/lang/en/local_ai_course_assistant.php
+++ b/lang/en/local_ai_course_assistant.php
@@ -585,6 +585,10 @@ $string['redash_heading'] = 'Analytics Export';
 $string['redash_heading_desc'] = 'Configure API key access for external analytics platforms like Redash. The export endpoint provides read-only JSON access to usage data, feedback, and cost analytics.';
 $string['redash_api_key'] = 'Redash API Key';
 $string['redash_api_key_desc'] = 'API key for external analytics platforms like Redash. Provides read-only access to usage data, feedback, and cost analytics. Leave blank to disable the export endpoint.';
+$string['settings:redash_export_window_days'] = 'Export lookback window (days)';
+$string['settings:redash_export_window_days_desc'] = 'How far back the export reaches when the caller does not pass a "since" timestamp. The default of 90 days keeps a data source that omits the parameter from pulling every row ever recorded; a caller can still request a specific window, or pass since=0 for an all-time backfill. Set to 0 to make all-time the default again.';
+$string['settings:redash_allow_deanonymized'] = 'Allow de-anonymized export';
+$string['settings:redash_allow_deanonymized_desc'] = 'Off by default. When off, a request for anonymize=0 is refused and learners always appear as pseudonyms. Turn this on only if an external report genuinely needs real learner names, and remember that the export authenticates with a shared API key rather than a signed-in administrator, so anyone holding the key can then retrieve those names. De-anonymized requests are audit-logged with the requesting IP either way.';
 
 // v6.1.0: web emergency panel.
 $string['emergency:title'] = '[[tutorshort]] Emergency Controls';

--- a/redash_export.php
+++ b/redash_export.php
@@ -50,7 +50,6 @@ require_once(__DIR__ . '/../../config.php');
 
 use local_ai_course_assistant\analytics;
 use local_ai_course_assistant\redash_export_request;
-use local_ai_course_assistant\token_cost_manager;
 
 // Content type. This endpoint is server-to-server (Redash pulls it with the
 // API key); it is NOT meant to be read cross-origin from a browser. A wildcard
@@ -283,45 +282,11 @@ foreach ($feedbackrecords as $record) {
     }
 }
 
-// Token costs: aggregate by model.
-$tokenwhere = " WHERE role = 'assistant' AND model_name IS NOT NULL AND model_name != ''";
-$tokenparams = [];
-if ($courseid > 0) {
-    $tokenwhere .= ' AND courseid = :courseid';
-    $tokenparams['courseid'] = $courseid;
-}
-if ($since > 0) {
-    $tokenwhere .= ' AND timecreated >= :since';
-    $tokenparams['since'] = $since;
-}
-
-$tokenrecords = $wants('token_costs') ? $DB->get_records_sql(
-    "SELECT model_name,
-            COUNT(id) AS response_count,
-            SUM(COALESCE(prompt_tokens, 0)) AS total_prompt_tokens,
-            SUM(COALESCE(completion_tokens, 0)) AS total_completion_tokens,
-            SUM(COALESCE(tokens_used, 0)) AS total_tokens
-       FROM {local_ai_course_assistant_msgs}" . $tokenwhere .
-    " GROUP BY model_name
-      ORDER BY total_tokens DESC",
-    $tokenparams
-) : [];
-
-$tokencosts = [];
-foreach ($tokenrecords as $record) {
-    $prompttokens = (int) $record->total_prompt_tokens;
-    $completiontokens = (int) $record->total_completion_tokens;
-    $cost = token_cost_manager::estimate_cost($record->model_name, $prompttokens, $completiontokens);
-
-    $tokencosts[] = [
-        'model' => $record->model_name,
-        'response_count' => (int) $record->response_count,
-        'total_prompt_tokens' => $prompttokens,
-        'total_completion_tokens' => $completiontokens,
-        'total_tokens' => (int) $record->total_tokens,
-        'estimated_cost_usd' => $cost,
-    ];
-}
+// Token costs: aggregate by model, chat plus the background RAG spend ledger.
+// The aggregation lives in analytics::get_token_costs() so it is unit-testable;
+// see that method for why embedding/rerank rows are included and premium_router
+// rows are not, and for the SITEID scoping of background spend.
+$tokencosts = $wants('token_costs') ? analytics::get_token_costs($courseid, $since) : [];
 
 // Survey response data.
 $surveydata = [];

--- a/redash_export.php
+++ b/redash_export.php
@@ -21,9 +21,23 @@
  * for external analytics platforms like Redash. Authenticated via API key.
  *
  * GET parameters:
- *   apikey   (required) - must match the configured redash_api_key setting
- *   courseid (optional) - specific course ID, or 0 for all courses (default: 0)
- *   since    (optional) - Unix timestamp to filter data from (default: 0 = all time)
+ *   apikey    (required) - must match the configured redash_api_key setting
+ *                          (an Authorization: Bearer header is preferred)
+ *   courseid  (optional) - specific course ID, or 0 for all courses (default: 0)
+ *   since     (optional) - Unix timestamp to filter data from. Absent means the
+ *                          configured lookback window (redash_export_window_days,
+ *                          default 90 days); an explicit since=0 means all time.
+ *   sections  (optional) - comma-separated allow-list of sections to build, e.g.
+ *                          sections=courses,feedback,token_costs. Absent (or
+ *                          "all") emits everything, which includes raw chat
+ *                          transcript text; name the sections you need instead.
+ *                          Valid: courses, student_usage, hotspots, feedback,
+ *                          token_costs, survey_responses, meta_ai,
+ *                          learning_radar_queries.
+ *   anonymize (optional) - 1 (default) pseudonymizes learners. anonymize=0 is
+ *                          refused with 403 unless an admin has enabled the
+ *                          redash_allow_deanonymized setting, and is always
+ *                          audit-logged with the requesting IP.
  *
  * @package    local_ai_course_assistant
  * @copyright  2025-2026 Tom Caswell & David Ta / Saylor University
@@ -35,6 +49,7 @@ define('NO_MOODLE_COOKIES', true);
 require_once(__DIR__ . '/../../config.php');
 
 use local_ai_course_assistant\analytics;
+use local_ai_course_assistant\redash_export_request;
 use local_ai_course_assistant\token_cost_manager;
 
 // Content type. This endpoint is server-to-server (Redash pulls it with the
@@ -90,12 +105,46 @@ if (empty($apikey) || !hash_equals($configuredkey, $apikey)) {
 
 // Parse parameters.
 $courseid = optional_param('courseid', 0, PARAM_INT);
-$since = optional_param('since', 0, PARAM_INT);
+
+// -1 is the "parameter absent" sentinel: absent means the configured lookback
+// window, while an explicit since=0 still means an all-time export.
+$since = redash_export_request::resolve_since(
+    optional_param('since', -1, PARAM_INT), time());
+
+// Section allow-list. Building only what the caller asked for keeps the heavy
+// blocks (raw transcript excerpt, Learning Radar query/response bodies) out of
+// a payload that only wants usage, feedback and cost.
+$rawsections = optional_param('sections', '', PARAM_RAW_TRIMMED);
+$sections = redash_export_request::parse_sections($rawsections);
+if (empty($sections)) {
+    // Every name supplied was unrecognised. Fail loudly rather than falling
+    // back to the full export, so a typo cannot quietly widen the payload.
+    http_response_code(400);
+    echo json_encode([
+        'error' => 'No valid sections requested',
+        'unknown_sections' => redash_export_request::unknown_sections($rawsections),
+        'valid_sections' => redash_export_request::SECTIONS,
+    ]);
+    exit;
+}
+$wants = function(string $section) use ($sections): bool {
+    return in_array($section, $sections, true);
+};
 
 // v5.10.x (security finding #3.7): a de-anonymized export (anonymize=0) reveals
 // real learner names. This endpoint authenticates by API key, not a logged-in
-// admin, so audit the access with the requesting IP to keep it traceable.
-if (optional_param('anonymize', 1, PARAM_INT) === 0) {
+// admin, so the key alone must not be enough to de-anonymize: require an admin
+// to have enabled it, and audit the access with the requesting IP either way.
+$anonymize = optional_param('anonymize', 1, PARAM_INT) !== 0;
+if (!$anonymize) {
+    if (!redash_export_request::deanonymize_allowed()) {
+        http_response_code(403);
+        echo json_encode([
+            'error' => 'De-anonymized export is disabled. Enable the '
+                . '"Allow de-anonymized export" plugin setting to permit anonymize=0.',
+        ]);
+        exit;
+    }
     try {
         \local_ai_course_assistant\audit_logger::log(
             'redash_export_deanonymized', 0, $courseid,
@@ -111,15 +160,19 @@ $plugin = new stdClass();
 require(__DIR__ . '/version.php');
 $pluginversion = $plugin->release ?? 'unknown';
 
-// Determine which courses to export.
+// Determine which courses to export. Skipped entirely when the caller did not
+// ask for the courses section (the per-course analytics are the bulk of a
+// full-site export).
 $courseids = [];
-if ($courseid > 0) {
-    $courseids = [$courseid];
-} else {
-    // Get all courses that have at least one message.
-    $courseids = $DB->get_fieldset_sql(
-        "SELECT DISTINCT courseid FROM {local_ai_course_assistant_msgs}"
-    );
+if ($wants('courses')) {
+    if ($courseid > 0) {
+        $courseids = [$courseid];
+    } else {
+        // Get all courses that have at least one message.
+        $courseids = $DB->get_fieldset_sql(
+            "SELECT DISTINCT courseid FROM {local_ai_course_assistant_msgs}"
+        );
+    }
 }
 
 // Build course data.
@@ -143,31 +196,35 @@ foreach ($courseids as $cid) {
     ];
 
     // Hotspots require course modinfo, which may fail for deleted/broken courses.
-    try {
-        $coursedata['hotspots'] = analytics::get_hotspots($cid, $since);
-    } catch (\Throwable $e) {
-        $coursedata['hotspots'] = [];
+    if ($wants('hotspots')) {
+        try {
+            $coursedata['hotspots'] = analytics::get_hotspots($cid, $since);
+        } catch (\Throwable $e) {
+            $coursedata['hotspots'] = [];
+        }
     }
 
-    // Student usage: anonymize by default; pass ?anonymize=0 to reveal real names.
-    $anonymize = optional_param('anonymize', 1, PARAM_INT);
-    $studentrecords = analytics::get_student_usage($cid, $since);
-    $studentusage = [];
-    foreach ($studentrecords as $record) {
-        $entry = [
-            'userid' => (int) $record->userid,
-            'message_count' => (int) $record->message_count,
-            'last_active' => (int) $record->last_active,
-        ];
-        if ($anonymize) {
-            $entry['name'] = \local_ai_course_assistant\anonymizer::name((int) $record->userid);
-        } else {
-            $entry['firstname'] = $record->firstname;
-            $entry['lastname'] = $record->lastname;
+    // Student usage: one row per learner, so it is opt-in. Anonymized unless an
+    // admin has enabled de-anonymized exports and the caller asked for one.
+    if ($wants('student_usage')) {
+        $studentrecords = analytics::get_student_usage($cid, $since);
+        $studentusage = [];
+        foreach ($studentrecords as $record) {
+            $entry = [
+                'userid' => (int) $record->userid,
+                'message_count' => (int) $record->message_count,
+                'last_active' => (int) $record->last_active,
+            ];
+            if ($anonymize) {
+                $entry['name'] = \local_ai_course_assistant\anonymizer::name((int) $record->userid);
+            } else {
+                $entry['firstname'] = $record->firstname;
+                $entry['lastname'] = $record->lastname;
+            }
+            $studentusage[] = $entry;
         }
-        $studentusage[] = $entry;
+        $coursedata['student_usage'] = $studentusage;
     }
-    $coursedata['student_usage'] = $studentusage;
 
     $courses[] = $coursedata;
 }
@@ -184,13 +241,13 @@ if ($since > 0) {
     $feedbackparams['since'] = $since;
 }
 
-$feedbackrecords = $DB->get_records_sql(
+$feedbackrecords = $wants('feedback') ? $DB->get_records_sql(
     "SELECT id, userid, courseid, rating, comment, browser, os, device,
             screen_size, user_agent, page_url, timecreated
        FROM {local_ai_course_assistant_feedback}" . $feedbackwhere .
     " ORDER BY timecreated DESC",
     $feedbackparams
-);
+) : [];
 
 // Feedback PII gate: under the default anonymized export, do not emit the
 // fields that re-identify or fingerprint a learner (real userid, user agent,
@@ -238,7 +295,7 @@ if ($since > 0) {
     $tokenparams['since'] = $since;
 }
 
-$tokenrecords = $DB->get_records_sql(
+$tokenrecords = $wants('token_costs') ? $DB->get_records_sql(
     "SELECT model_name,
             COUNT(id) AS response_count,
             SUM(COALESCE(prompt_tokens, 0)) AS total_prompt_tokens,
@@ -248,7 +305,7 @@ $tokenrecords = $DB->get_records_sql(
     " GROUP BY model_name
       ORDER BY total_tokens DESC",
     $tokenparams
-);
+) : [];
 
 $tokencosts = [];
 foreach ($tokenrecords as $record) {
@@ -280,14 +337,14 @@ try {
         $surveyparams['since'] = $since;
     }
 
-    $surveyrecords = $DB->get_records_sql(
+    $surveyrecords = $wants('survey_responses') ? $DB->get_records_sql(
         "SELECT r.id, r.surveyid, r.userid, r.courseid, r.question_index, r.answer, r.timecreated,
                 s.title AS survey_title
            FROM {local_ai_course_assistant_survey_resp} r
            JOIN {local_ai_course_assistant_surveys} s ON s.id = r.surveyid" .
         $surveywhere . " ORDER BY r.timecreated DESC",
         $surveyparams
-    );
+    ) : [];
 
     foreach ($surveyrecords as $record) {
         // Same PII gate as feedback: pseudonymous learner ref under anonymize.
@@ -309,11 +366,16 @@ try {
     $surveydata = [];
 }
 
-// Learning Radar analytics: anonymized stats and transcript excerpt for Redash dashboards.
-$metaai = [
-    'summary' => \local_ai_course_assistant\meta_ai_data_builder::build_stats_summary($courseid, $since),
-    'transcript_excerpt' => \local_ai_course_assistant\meta_ai_data_builder::build_transcript($courseid, $since, 50000),
-];
+// Learning Radar analytics: anonymized stats and transcript excerpt for Redash
+// dashboards. The transcript excerpt is up to 50,000 characters of raw learner
+// conversation, so this section is only built when explicitly requested.
+$metaai = [];
+if ($wants('meta_ai')) {
+    $metaai = [
+        'summary' => \local_ai_course_assistant\meta_ai_data_builder::build_stats_summary($courseid, $since),
+        'transcript_excerpt' => \local_ai_course_assistant\meta_ai_data_builder::build_transcript($courseid, $since, 50000),
+    ];
+}
 
 // Learning Radar query log: every admin query (ad-hoc + scheduled) and its
 // response, paired by (conversationid, sequential timecreated). Each record
@@ -331,14 +393,14 @@ if ($since > 0) {
 // timestamp), and the pairing walk below would cross-pair them. `id` is
 // monotonic at insertion and preserves insertion order regardless of
 // timestamp ties.
-$radarrecords = $DB->get_records_sql(
+$radarrecords = $wants('learning_radar_queries') ? $DB->get_records_sql(
     "SELECT id, conversationid, userid, role, message, prompt_tokens, completion_tokens,
             model_name, provider, interaction_type, timecreated
        FROM {local_ai_course_assistant_msgs}
       WHERE {$radarwhere}
       ORDER BY conversationid ASC, id ASC",
     $radarparams
-);
+) : [];
 
 $radarpairs = [];
 $pendinguser = null;
@@ -366,11 +428,21 @@ foreach ($radarrecords as $row) {
     }
 }
 
-// Build response.
+// Build response. `sections` and `since` are echoed back so a consumer can
+// assert that the endpoint actually honoured its allow-list: a site still
+// running a pre-sections version of the plugin ignores the parameter and
+// returns everything, and the echoed values are how that is detected.
 $response = [
     'generated_at' => date('c'),
     'plugin_version' => $pluginversion,
-    'anonymized' => !empty($anonymize),
+    'anonymized' => $anonymize,
+    'sections' => $sections,
+    'since' => $since,
+];
+
+// Only emit the sections that were requested. `student_usage` and `hotspots`
+// are nested inside each course row, so they have no top-level key here.
+$payload = [
     'courses' => $courses,
     'feedback' => $feedback,
     'token_costs' => $tokencosts,
@@ -378,5 +450,10 @@ $response = [
     'meta_ai' => $metaai,
     'learning_radar_queries' => $radarpairs,
 ];
+foreach ($payload as $key => $value) {
+    if ($wants($key)) {
+        $response[$key] = $value;
+    }
+}
 
 echo json_encode($response, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);

--- a/settings.php
+++ b/settings.php
@@ -755,7 +755,7 @@ if ($hassiteconfig) {
         'local_ai_course_assistant/rerank_candidates',
         get_string('settings:rerank_candidates', 'local_ai_course_assistant'),
         get_string('settings:rerank_candidates_desc', 'local_ai_course_assistant'),
-        '50',
+        '20',
         PARAM_INT
     ));
 
@@ -2378,7 +2378,14 @@ $settings->add(new admin_setting_configtext(
         get_string('redash_heading_desc', 'local_ai_course_assistant')
     ));
 
-    $settings->add(new admin_setting_configtext(
+    // Password type, not configtext: Moodle only writes '********' into
+    // config_log for password settings. A plain configtext credential has
+    // every historical value recorded in the clear in mdl_config_log, which is
+    // never purged and is readable by anything with DB or reporting access.
+    // Confirmed on production 2026-08-03 -- a retired key was recoverable in
+    // full from the log. Its siblings redash_user_api_key and github_token
+    // were already declared correctly; this one was missed.
+    $settings->add(new admin_setting_configpasswordunmask(
         'local_ai_course_assistant/redash_api_key',
         get_string('redash_api_key', 'local_ai_course_assistant'),
         get_string('redash_api_key_desc', 'local_ai_course_assistant'),

--- a/settings.php
+++ b/settings.php
@@ -2392,6 +2392,25 @@ $settings->add(new admin_setting_configtext(
         ''
     ));
 
+    // Default lookback window applied when a caller omits `since`, so a data
+    // source that forgets the parameter cannot pull every row ever recorded.
+    $settings->add(new admin_setting_configtext(
+        'local_ai_course_assistant/redash_export_window_days',
+        get_string('settings:redash_export_window_days', 'local_ai_course_assistant'),
+        get_string('settings:redash_export_window_days_desc', 'local_ai_course_assistant'),
+        \local_ai_course_assistant\redash_export_request::DEFAULT_WINDOW_DAYS,
+        PARAM_INT
+    ));
+
+    // Gate on anonymize=0. Without it the shared API key alone is enough to
+    // pull real learner names out of the export.
+    $settings->add(new admin_setting_configcheckbox(
+        'local_ai_course_assistant/redash_allow_deanonymized',
+        get_string('settings:redash_allow_deanonymized', 'local_ai_course_assistant'),
+        get_string('settings:redash_allow_deanonymized_desc', 'local_ai_course_assistant'),
+        0
+    ));
+
     // v4.3.0: Real Redash integration. Three settings together let SOLA
     // push a Learning Radar query/response to Redash as a new saved query
     // via Redash's /api/queries endpoint. All three must be set for the

--- a/tests/analytics_overview_roles_test.php
+++ b/tests/analytics_overview_roles_test.php
@@ -1,0 +1,178 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Regression tests: analytics::get_overview() must count learner messages only.
+ *
+ * The msgs table is not only chat. Three writers persist role='system' telemetry
+ * into it: base_embedding_provider::log_embedding_cost() (one row per embedding
+ * call, written against SITEID), premium_router (one row per escalated turn,
+ * written against the real course id) and voyage_reranker. get_overview's
+ * total_messages had no role filter, so it counted all of them as learner
+ * messages. Observed on dev.sylr.org 2026-08-03: the site course reported 50,766
+ * "messages" alongside 0 conversations and 0 active students, because every one
+ * of those rows was a RAG indexing cost-ledger entry.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_ai_course_assistant\analytics::get_overview
+ */
+final class analytics_overview_roles_test extends \advanced_testcase {
+
+    /**
+     * Insert one msgs row.
+     *
+     * @param int $courseid
+     * @param string $role
+     * @param int $userid
+     * @param int $convid
+     * @param string $text
+     * @param string $itype interaction_type
+     * @param int $timecreated 0 for now.
+     */
+    private function msg(int $courseid, string $role, int $userid, int $convid,
+            string $text, string $itype, int $timecreated = 0): void {
+        global $DB;
+        $DB->insert_record('local_ai_course_assistant_msgs', (object) [
+            'conversationid' => $convid,
+            'userid' => $userid,
+            'courseid' => $courseid,
+            'role' => $role,
+            'message' => $text,
+            'tokens_used' => 5,
+            'prompt_tokens' => 5,
+            'completion_tokens' => 0,
+            'model_name' => 'test-model',
+            'provider' => 'test',
+            'interaction_type' => $itype,
+            'timecreated' => $timecreated ?: time(),
+        ]);
+    }
+
+    /**
+     * Mirror of base_embedding_provider::log_embedding_cost(): role=system,
+     * courseid=SITEID, userid 0, conversationid 0.
+     *
+     * @param int $count how many rows to write.
+     */
+    private function embedding_telemetry(int $count): void {
+        for ($i = 0; $i < $count; $i++) {
+            $this->msg(SITEID, 'system', 0, 0, '[Embedding]', 'embedding');
+        }
+    }
+
+    public function test_site_course_with_only_embedding_telemetry_reports_no_messages(): void {
+        $this->resetAfterTest();
+        $this->embedding_telemetry(3);
+
+        $overview = analytics::get_overview(SITEID, 0);
+
+        // The three numbers must agree: no learner activity anywhere.
+        $this->assertSame(0, (int) $overview['total_messages']);
+        $this->assertSame(0, (int) $overview['total_conversations']);
+        $this->assertSame(0, (int) $overview['active_students']);
+    }
+
+    public function test_premium_router_telemetry_does_not_inflate_a_real_course(): void {
+        $this->resetAfterTest();
+        $course = $this->getDataGenerator()->create_course();
+        $user = $this->getDataGenerator()->create_user();
+
+        $this->msg($course->id, 'user', $user->id, 11, 'hello', 'chat');
+        $this->msg($course->id, 'assistant', $user->id, 11, 'hi', 'chat');
+        // What premium_router writes: role=system against the REAL course id.
+        $this->msg($course->id, 'system', $user->id, 11, '[PremiumRouter] stem', 'premium_route');
+
+        $overview = analytics::get_overview($course->id, 0);
+
+        $this->assertSame(2, (int) $overview['total_messages']);
+        $this->assertSame(1, (int) $overview['active_students']);
+        // Derived metric moves with the corrected count: 2 messages / 1 student.
+        $this->assertEquals(2.0, (float) $overview['avg_messages_per_student']);
+    }
+
+    public function test_reranker_telemetry_is_also_excluded(): void {
+        $this->resetAfterTest();
+        $course = $this->getDataGenerator()->create_course();
+        $user = $this->getDataGenerator()->create_user();
+
+        $this->msg($course->id, 'user', $user->id, 12, 'q', 'chat');
+        $this->msg($course->id, 'system', $user->id, 12, '[Rerank] 30 candidates', 'rerank');
+
+        $this->assertSame(1, (int) analytics::get_overview($course->id, 0)['total_messages']);
+    }
+
+    public function test_has_data_flag_is_false_for_a_telemetry_only_course(): void {
+        $this->resetAfterTest();
+        $this->embedding_telemetry(5);
+
+        // analytics.php gates the dashboard on total_messages > 0, so telemetry
+        // alone must not make an empty course look active.
+        $this->assertSame(0, (int) analytics::get_overview(SITEID, 0)['total_messages']);
+    }
+
+    public function test_genuine_messages_are_still_counted_both_sides(): void {
+        $this->resetAfterTest();
+        $course = $this->getDataGenerator()->create_course();
+        $one = $this->getDataGenerator()->create_user();
+        $two = $this->getDataGenerator()->create_user();
+
+        $this->msg($course->id, 'user', $one->id, 21, 'a', 'chat');
+        $this->msg($course->id, 'assistant', $one->id, 21, 'b', 'chat');
+        $this->msg($course->id, 'user', $two->id, 22, 'c', 'chat');
+        $this->msg($course->id, 'assistant', $two->id, 22, 'd', 'chat');
+
+        $overview = analytics::get_overview($course->id, 0);
+        // Both halves of the exchange count; only telemetry is excluded.
+        $this->assertSame(4, (int) $overview['total_messages']);
+        $this->assertSame(2, (int) $overview['active_students']);
+    }
+
+    public function test_role_filter_composes_with_the_since_window(): void {
+        $this->resetAfterTest();
+        $course = $this->getDataGenerator()->create_course();
+        $user = $this->getDataGenerator()->create_user();
+        $now = time();
+
+        $this->msg($course->id, 'user', $user->id, 31, 'old', 'chat', $now - (30 * DAYSECS));
+        $this->msg($course->id, 'user', $user->id, 32, 'new', 'chat', $now - HOURSECS);
+        $this->msg($course->id, 'system', $user->id, 32, '[Rerank]', 'rerank', $now - HOURSECS);
+
+        // Inside the window: the recent learner message only, not the telemetry.
+        $this->assertSame(1, (int) analytics::get_overview($course->id, $now - DAYSECS)['total_messages']);
+        // All time: both learner messages, still no telemetry.
+        $this->assertSame(2, (int) analytics::get_overview($course->id, 0)['total_messages']);
+    }
+
+    public function test_other_courses_are_unaffected_by_site_level_telemetry(): void {
+        $this->resetAfterTest();
+        $course = $this->getDataGenerator()->create_course();
+        $user = $this->getDataGenerator()->create_user();
+
+        $this->embedding_telemetry(4);
+        $this->msg($course->id, 'user', $user->id, 41, 'hello', 'chat');
+
+        // Embedding rows land on SITEID, so they never belonged to this course,
+        // but pin it so a future courseid change in the writer is caught here.
+        $this->assertSame(1, (int) analytics::get_overview($course->id, 0)['total_messages']);
+        $this->assertSame(0, (int) analytics::get_overview(SITEID, 0)['total_messages']);
+    }
+}

--- a/tests/analytics_token_costs_test.php
+++ b/tests/analytics_token_costs_test.php
@@ -1,0 +1,219 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Tests for analytics::get_token_costs(), the Redash export's cost section.
+ *
+ * The old inline filter in redash_export.php was role='assistant', which hid the
+ * background RAG spend that log_embedding_cost()/log_rerank_cost() write with
+ * role='system'. Confirmed live on dev.sylr.org 2026-08-03: token_costs returned
+ * one gpt-4o-mini row and no embedding row, despite roughly 50k embedding rows in
+ * the table. These tests pin that background spend is reported, that
+ * premium_router metadata is not counted as spend, and that the two never merge.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_ai_course_assistant\analytics::get_token_costs
+ */
+final class analytics_token_costs_test extends \advanced_testcase {
+
+    /**
+     * Insert one msgs row.
+     *
+     * @param array $overrides field overrides.
+     */
+    private function msg(array $overrides): void {
+        global $DB;
+        $DB->insert_record('local_ai_course_assistant_msgs', (object) ($overrides + [
+            'conversationid' => 0,
+            'userid' => 0,
+            'courseid' => SITEID,
+            'role' => 'assistant',
+            'message' => 'x',
+            'tokens_used' => 0,
+            'prompt_tokens' => 0,
+            'completion_tokens' => 0,
+            'model_name' => 'gpt-4o-mini',
+            'provider' => 'openai',
+            'interaction_type' => 'chat',
+            'timecreated' => time(),
+        ]));
+    }
+
+    /**
+     * Mirror of base_embedding_provider::log_embedding_cost().
+     *
+     * @param int $tokens
+     * @param string $model
+     */
+    private function embedding_row(int $tokens, string $model = 'text-embedding-3-small'): void {
+        $this->msg(['role' => 'system', 'message' => '[Embedding]', 'model_name' => $model,
+            'provider' => 'embedding', 'interaction_type' => 'embedding',
+            'tokens_used' => $tokens, 'prompt_tokens' => $tokens, 'completion_tokens' => 0]);
+    }
+
+    /**
+     * Mirror of voyage_reranker::log_rerank_cost().
+     *
+     * @param int $tokens
+     */
+    private function rerank_row(int $tokens): void {
+        $this->msg(['role' => 'system', 'message' => '[Rerank]', 'model_name' => 'rerank-2.5',
+            'provider' => 'rerank', 'interaction_type' => 'rerank',
+            'tokens_used' => $tokens, 'prompt_tokens' => $tokens, 'completion_tokens' => 0]);
+    }
+
+    /**
+     * Find one row of the result by model name.
+     *
+     * @param array $rows
+     * @param string $model
+     * @return array|null
+     */
+    private function row(array $rows, string $model): ?array {
+        foreach ($rows as $row) {
+            if ($row['model'] === $model) {
+                return $row;
+            }
+        }
+        return null;
+    }
+
+    public function test_embedding_spend_is_reported(): void {
+        $this->resetAfterTest();
+        $this->embedding_row(1000);
+        $this->embedding_row(500);
+
+        $row = $this->row(analytics::get_token_costs(0, 0), 'text-embedding-3-small');
+        $this->assertNotNull($row, 'embedding spend must appear in the cost aggregate');
+        $this->assertSame('embedding', $row['category']);
+        $this->assertSame(2, $row['response_count']);
+        $this->assertSame(1500, $row['total_prompt_tokens']);
+        $this->assertSame(1500, $row['total_tokens']);
+        // Priced in the rate card at $0.02 per million input tokens.
+        $this->assertEqualsWithDelta(1500 / 1_000_000 * 0.02, $row['estimated_cost_usd'], 1e-12);
+    }
+
+    public function test_rerank_spend_is_reported_with_unknown_cost_not_zero(): void {
+        $this->resetAfterTest();
+        $this->rerank_row(800);
+
+        $row = $this->row(analytics::get_token_costs(0, 0), 'rerank-2.5');
+        $this->assertNotNull($row);
+        $this->assertSame('rerank', $row['category']);
+        $this->assertSame(800, $row['total_tokens']);
+        // rerank-2.5 is absent from the rate card: null means unknown, not free.
+        $this->assertNull($row['estimated_cost_usd']);
+    }
+
+    public function test_chat_spend_still_reported(): void {
+        $this->resetAfterTest();
+        $this->msg(['prompt_tokens' => 100, 'completion_tokens' => 20, 'tokens_used' => 120]);
+
+        $row = $this->row(analytics::get_token_costs(0, 0), 'gpt-4o-mini');
+        $this->assertNotNull($row);
+        $this->assertSame('chat', $row['category']);
+        $this->assertSame(1, $row['response_count']);
+        $this->assertSame(120, $row['total_tokens']);
+        $this->assertNotNull($row['estimated_cost_usd']);
+    }
+
+    public function test_premium_router_metadata_is_not_counted_as_spend(): void {
+        $this->resetAfterTest();
+        // The real escalated call.
+        $this->msg(['model_name' => 'claude-opus-4-8', 'provider' => 'claude',
+            'prompt_tokens' => 300, 'completion_tokens' => 100, 'tokens_used' => 400]);
+        // premium_router's telemetry row: same model name, zero tokens, role=system.
+        $this->msg(['role' => 'system', 'message' => '[PremiumRouter] stem',
+            'model_name' => 'claude-opus-4-8', 'provider' => 'premium_router',
+            'interaction_type' => 'premium_route']);
+
+        $rows = analytics::get_token_costs(0, 0);
+        $opus = array_values(array_filter($rows, fn($r) => $r['model'] === 'claude-opus-4-8'));
+        // Exactly one bucket, counting the call once. Counting the telemetry row
+        // would report two responses for a single escalated turn.
+        $this->assertCount(1, $opus);
+        $this->assertSame(1, $opus[0]['response_count']);
+        $this->assertSame(400, $opus[0]['total_tokens']);
+        $this->assertSame('chat', $opus[0]['category']);
+    }
+
+    public function test_chat_and_background_spend_never_merge_into_one_bucket(): void {
+        $this->resetAfterTest();
+        // Same model name used for chat and for embedding: the category is part of
+        // the grouping key, so these must stay two rows.
+        $this->msg(['model_name' => 'shared-model', 'prompt_tokens' => 10,
+            'completion_tokens' => 5, 'tokens_used' => 15]);
+        $this->embedding_row(70, 'shared-model');
+
+        $rows = array_values(array_filter(analytics::get_token_costs(0, 0),
+            fn($r) => $r['model'] === 'shared-model'));
+        $this->assertCount(2, $rows);
+        $categories = array_column($rows, 'category');
+        sort($categories);
+        $this->assertSame(['chat', 'embedding'], $categories);
+    }
+
+    public function test_per_course_call_excludes_site_level_background_spend(): void {
+        $this->resetAfterTest();
+        $course = $this->getDataGenerator()->create_course();
+        $this->msg(['courseid' => $course->id, 'prompt_tokens' => 50,
+            'completion_tokens' => 10, 'tokens_used' => 60]);
+        // Background indexing is logged against SITEID, not the indexed course.
+        $this->embedding_row(9000);
+
+        $rows = analytics::get_token_costs($course->id, 0);
+        $this->assertNotNull($this->row($rows, 'gpt-4o-mini'));
+        $this->assertNull($this->row($rows, 'text-embedding-3-small'),
+            'site-level indexing spend must not be attributed to one course');
+
+        // The whole-site aggregate sees both.
+        $all = analytics::get_token_costs(0, 0);
+        $this->assertNotNull($this->row($all, 'text-embedding-3-small'));
+        $this->assertNotNull($this->row($all, 'gpt-4o-mini'));
+    }
+
+    public function test_since_window_applies_to_background_spend_too(): void {
+        $this->resetAfterTest();
+        $now = time();
+        $this->msg(['role' => 'system', 'message' => '[Embedding]',
+            'model_name' => 'text-embedding-3-small', 'provider' => 'embedding',
+            'interaction_type' => 'embedding', 'tokens_used' => 400,
+            'prompt_tokens' => 400, 'timecreated' => $now - (30 * DAYSECS)]);
+        $this->embedding_row(100);
+
+        $recent = $this->row(analytics::get_token_costs(0, $now - DAYSECS), 'text-embedding-3-small');
+        $this->assertSame(100, $recent['total_tokens']);
+        $alltime = $this->row(analytics::get_token_costs(0, 0), 'text-embedding-3-small');
+        $this->assertSame(500, $alltime['total_tokens']);
+    }
+
+    public function test_rows_without_a_model_name_are_ignored(): void {
+        $this->resetAfterTest();
+        $this->msg(['model_name' => '', 'tokens_used' => 999]);
+        $this->msg(['model_name' => null, 'tokens_used' => 999]);
+        $this->embedding_row(10);
+
+        $rows = analytics::get_token_costs(0, 0);
+        $this->assertCount(1, $rows);
+        $this->assertSame('text-embedding-3-small', $rows[0]['model']);
+    }
+}

--- a/tests/analytics_total_tokens_test.php
+++ b/tests/analytics_total_tokens_test.php
@@ -1,0 +1,155 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Tests for analytics::get_total_tokens(), which powers the "Tokens (30d)" chip.
+ *
+ * The chip used to run its own inline SQL filtered on role='assistant', so it
+ * undercounted by the entire embedding and rerank spend ledger. The predicate now
+ * lives in one place (analytics::spend_rows_predicate) shared with
+ * get_token_costs(), and the last two tests here pin that the two stay in
+ * agreement about what counts as spend, since drift between duplicated copies of
+ * that condition is what caused the original bug.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_ai_course_assistant\analytics::get_total_tokens
+ */
+final class analytics_total_tokens_test extends \advanced_testcase {
+
+    /**
+     * Insert one msgs row; overrides win over the defaults.
+     *
+     * @param array $overrides
+     */
+    private function msg(array $overrides): void {
+        global $DB;
+        $DB->insert_record('local_ai_course_assistant_msgs', (object) ($overrides + [
+            'conversationid' => 0,
+            'userid' => 0,
+            'courseid' => SITEID,
+            'role' => 'assistant',
+            'message' => 'x',
+            'tokens_used' => 0,
+            'prompt_tokens' => 0,
+            'completion_tokens' => 0,
+            'model_name' => 'gpt-4o-mini',
+            'provider' => 'openai',
+            'interaction_type' => 'chat',
+            'timecreated' => time(),
+        ]));
+    }
+
+    public function test_chat_and_background_spend_are_both_counted(): void {
+        $this->resetAfterTest();
+        $this->msg(['prompt_tokens' => 100, 'completion_tokens' => 20]);
+        $this->msg(['role' => 'system', 'interaction_type' => 'embedding',
+            'provider' => 'embedding', 'model_name' => 'text-embedding-3-small',
+            'prompt_tokens' => 5000]);
+        $this->msg(['role' => 'system', 'interaction_type' => 'rerank',
+            'provider' => 'rerank', 'model_name' => 'rerank-2.5', 'prompt_tokens' => 300]);
+
+        // 120 chat + 5000 embedding + 300 rerank.
+        $this->assertSame(5420, analytics::get_total_tokens(0, 0));
+    }
+
+    public function test_premium_router_metadata_adds_nothing(): void {
+        $this->resetAfterTest();
+        $this->msg(['prompt_tokens' => 100, 'completion_tokens' => 20]);
+        // Zero-token metadata row; must not change the total either way.
+        $this->msg(['role' => 'system', 'interaction_type' => 'premium_route',
+            'provider' => 'premium_router', 'model_name' => 'claude-opus-4-8']);
+
+        $this->assertSame(120, analytics::get_total_tokens(0, 0));
+    }
+
+    public function test_learner_messages_are_not_spend(): void {
+        $this->resetAfterTest();
+        // A user row carrying token counts must not be added on top of the
+        // assistant row that already accounts for the same exchange.
+        $this->msg(['role' => 'user', 'prompt_tokens' => 999, 'interaction_type' => 'chat']);
+        $this->msg(['prompt_tokens' => 10, 'completion_tokens' => 5]);
+
+        $this->assertSame(15, analytics::get_total_tokens(0, 0));
+    }
+
+    public function test_counts_rows_with_no_model_name(): void {
+        $this->resetAfterTest();
+        // Unlike get_token_costs(), this total does not require a model name, so a
+        // row whose model was never recorded still counts toward spend.
+        $this->msg(['model_name' => null, 'prompt_tokens' => 40, 'completion_tokens' => 10]);
+
+        $this->assertSame(50, analytics::get_total_tokens(0, 0));
+        $this->assertSame([], analytics::get_token_costs(0, 0));
+    }
+
+    public function test_since_window_is_applied(): void {
+        $this->resetAfterTest();
+        $now = time();
+        $this->msg(['prompt_tokens' => 700, 'timecreated' => $now - (40 * DAYSECS)]);
+        $this->msg(['prompt_tokens' => 30, 'timecreated' => $now - HOURSECS]);
+        $this->msg(['role' => 'system', 'interaction_type' => 'embedding',
+            'provider' => 'embedding', 'model_name' => 'text-embedding-3-small',
+            'prompt_tokens' => 90, 'timecreated' => $now - HOURSECS]);
+
+        // 30-day window as the chip uses: recent chat plus recent embedding.
+        $this->assertSame(120, analytics::get_total_tokens(0, $now - (30 * DAYSECS)));
+        $this->assertSame(820, analytics::get_total_tokens(0, 0));
+    }
+
+    public function test_per_course_total_excludes_site_level_background_spend(): void {
+        $this->resetAfterTest();
+        $course = $this->getDataGenerator()->create_course();
+        $this->msg(['courseid' => $course->id, 'prompt_tokens' => 200]);
+        $this->msg(['role' => 'system', 'interaction_type' => 'embedding',
+            'provider' => 'embedding', 'model_name' => 'text-embedding-3-small',
+            'prompt_tokens' => 9000]);
+
+        // Per-course attribution: chat only, because indexing is logged on SITEID.
+        $this->assertSame(200, analytics::get_total_tokens($course->id, 0));
+        // Site-wide total is deliberately larger than the sum of course totals.
+        $this->assertSame(9200, analytics::get_total_tokens(0, 0));
+    }
+
+    public function test_empty_table_returns_zero_not_null(): void {
+        $this->resetAfterTest();
+        $this->assertSame(0, analytics::get_total_tokens(0, 0));
+    }
+
+    public function test_agrees_with_get_token_costs_on_what_counts_as_spend(): void {
+        $this->resetAfterTest();
+        // Every row here carries a model name, so the two aggregates cover exactly
+        // the same population and must reconcile. This is the guard against the
+        // shared spend predicate drifting apart again.
+        $this->msg(['prompt_tokens' => 100, 'completion_tokens' => 20]);
+        $this->msg(['role' => 'system', 'interaction_type' => 'embedding',
+            'provider' => 'embedding', 'model_name' => 'text-embedding-3-small',
+            'prompt_tokens' => 5000]);
+        $this->msg(['role' => 'system', 'interaction_type' => 'premium_route',
+            'provider' => 'premium_router', 'model_name' => 'claude-opus-4-8']);
+
+        $bymodel = 0;
+        foreach (analytics::get_token_costs(0, 0) as $row) {
+            $bymodel += $row['total_prompt_tokens'] + $row['total_completion_tokens'];
+        }
+        $this->assertSame(analytics::get_total_tokens(0, 0), $bymodel);
+    }
+}

--- a/tests/redash_export_request_test.php
+++ b/tests/redash_export_request_test.php
@@ -1,0 +1,175 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Unit tests for redash_export_request: section allow-list, default lookback
+ * window, and the de-anonymization gate on redash_export.php.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_ai_course_assistant\redash_export_request
+ */
+final class redash_export_request_test extends \advanced_testcase {
+
+    public function test_absent_sections_keeps_the_full_export(): void {
+        // Backward compatibility: an existing data source that passes no
+        // sections parameter must keep receiving every section.
+        $this->assertSame(
+            redash_export_request::SECTIONS,
+            redash_export_request::parse_sections(''));
+        $this->assertSame(
+            redash_export_request::SECTIONS,
+            redash_export_request::parse_sections('   '));
+        $this->assertSame(
+            redash_export_request::SECTIONS,
+            redash_export_request::parse_sections('all'));
+        $this->assertSame(
+            redash_export_request::SECTIONS,
+            redash_export_request::parse_sections('ALL'));
+    }
+
+    public function test_named_sections_are_the_only_ones_returned(): void {
+        $this->assertSame(
+            ['courses', 'feedback', 'token_costs'],
+            redash_export_request::parse_sections('courses,feedback,token_costs'));
+
+        // The heavy sections stay out unless asked for by name.
+        $selected = redash_export_request::parse_sections('token_costs');
+        $this->assertSame(['token_costs'], $selected);
+        $this->assertNotContains('meta_ai', $selected);
+        $this->assertNotContains('learning_radar_queries', $selected);
+    }
+
+    public function test_parsing_is_forgiving_about_formatting(): void {
+        // Whitespace, case, and duplicates are all tolerated.
+        $this->assertSame(
+            ['courses', 'feedback'],
+            redash_export_request::parse_sections(' Feedback , courses ,feedback, '));
+    }
+
+    public function test_response_order_is_canonical_not_caller_order(): void {
+        // Written back to front; still returned in SECTIONS order so the
+        // response shape does not depend on how the URL was typed.
+        $this->assertSame(
+            ['courses', 'feedback', 'meta_ai'],
+            redash_export_request::parse_sections('meta_ai,feedback,courses'));
+    }
+
+    public function test_unknown_sections_are_dropped_but_reported(): void {
+        // A typo alongside a valid name: the valid name still works.
+        $this->assertSame(
+            ['token_costs'],
+            redash_export_request::parse_sections('token_costs,tokencosts'));
+        $this->assertSame(
+            ['tokencosts'],
+            redash_export_request::unknown_sections('token_costs,tokencosts'));
+    }
+
+    public function test_all_unknown_sections_yields_empty_so_caller_can_reject(): void {
+        // The endpoint turns this into a 400. It must NOT fall back to the full
+        // export, or a typo would silently widen the payload.
+        $this->assertSame([], redash_export_request::parse_sections('tokencosts,feedbck'));
+        $this->assertSame(
+            ['tokencosts', 'feedbck'],
+            redash_export_request::unknown_sections('tokencosts,feedbck'));
+    }
+
+    public function test_unknown_sections_empty_for_valid_input(): void {
+        $this->assertSame([], redash_export_request::unknown_sections('courses,feedback'));
+        $this->assertSame([], redash_export_request::unknown_sections(''));
+        $this->assertSame([], redash_export_request::unknown_sections('all'));
+    }
+
+    public function test_absent_since_applies_the_default_window(): void {
+        $now = 1785600000;
+        // -1 is the endpoint's "parameter absent" sentinel.
+        $this->assertSame(
+            $now - (90 * DAYSECS),
+            redash_export_request::resolve_since(-1, $now, 90));
+        $this->assertSame(
+            $now - (30 * DAYSECS),
+            redash_export_request::resolve_since(-1, $now, 30));
+    }
+
+    public function test_explicit_since_is_honoured(): void {
+        $now = 1785600000;
+        $this->assertSame(1780000000, redash_export_request::resolve_since(1780000000, $now, 90));
+    }
+
+    public function test_explicit_zero_still_means_all_time(): void {
+        // A deliberate backfill must remain possible.
+        $now = 1785600000;
+        $this->assertSame(0, redash_export_request::resolve_since(0, $now, 90));
+    }
+
+    public function test_zero_window_restores_the_all_time_default(): void {
+        $now = 1785600000;
+        $this->assertSame(0, redash_export_request::resolve_since(-1, $now, 0));
+        $this->assertSame(0, redash_export_request::resolve_since(-1, $now, -5));
+    }
+
+    public function test_window_never_produces_a_negative_timestamp(): void {
+        // A clock early in the epoch must not yield a negative lower bound.
+        $this->assertSame(0, redash_export_request::resolve_since(-1, 1000, 90));
+    }
+
+    public function test_window_days_falls_back_when_unset(): void {
+        $this->resetAfterTest();
+        $this->assertSame(
+            redash_export_request::DEFAULT_WINDOW_DAYS,
+            redash_export_request::window_days());
+
+        set_config('redash_export_window_days', '', 'local_ai_course_assistant');
+        $this->assertSame(
+            redash_export_request::DEFAULT_WINDOW_DAYS,
+            redash_export_request::window_days());
+    }
+
+    public function test_window_days_reads_the_admin_setting(): void {
+        $this->resetAfterTest();
+        set_config('redash_export_window_days', '14', 'local_ai_course_assistant');
+        $this->assertSame(14, redash_export_request::window_days());
+
+        set_config('redash_export_window_days', '0', 'local_ai_course_assistant');
+        $this->assertSame(0, redash_export_request::window_days());
+    }
+
+    public function test_resolve_since_uses_the_setting_when_no_override_given(): void {
+        $this->resetAfterTest();
+        set_config('redash_export_window_days', '7', 'local_ai_course_assistant');
+        $now = 1785600000;
+        $this->assertSame($now - (7 * DAYSECS), redash_export_request::resolve_since(-1, $now));
+    }
+
+    public function test_deanonymize_is_denied_by_default(): void {
+        $this->resetAfterTest();
+        $this->assertFalse(redash_export_request::deanonymize_allowed());
+    }
+
+    public function test_deanonymize_requires_the_setting_to_be_on(): void {
+        $this->resetAfterTest();
+        set_config('redash_allow_deanonymized', 0, 'local_ai_course_assistant');
+        $this->assertFalse(redash_export_request::deanonymize_allowed());
+
+        set_config('redash_allow_deanonymized', 1, 'local_ai_course_assistant');
+        $this->assertTrue(redash_export_request::deanonymize_allowed());
+    }
+}

--- a/tests/settings_secret_masking_test.php
+++ b/tests/settings_secret_masking_test.php
@@ -1,0 +1,124 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+
+/**
+ * Guards that credential settings are declared as password types.
+ *
+ * Moodle writes '********' into mdl_config_log for password settings only. A
+ * credential declared as admin_setting_configtext has every historical value
+ * recorded in the clear, in a table that is never purged and is readable by
+ * anything with database or reporting access.
+ *
+ * Found on production 2026-08-03: redash_api_key was a plain configtext, and a
+ * retired key was recoverable in full from config_log. Its siblings
+ * redash_user_api_key and github_token were already correct, which is exactly
+ * why a standing test is worth more than the one-line fix -- the next
+ * credential setting someone adds will be copied from whichever neighbour they
+ * happened to look at.
+ *
+ * This scans settings.php as text rather than instantiating the admin tree,
+ * which needs a full admin bootstrap and would make the test slow and fragile.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Tom Caswell / Saylor University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @coversNothing
+ */
+final class settings_secret_masking_test extends \advanced_testcase {
+
+    /**
+     * Setting-name fragments that indicate a stored credential.
+     */
+    private const SECRET_HINTS = ['apikey', 'api_key', 'secret', 'token', 'password'];
+
+    /**
+     * Names that match a hint but are NOT credentials, with the reason.
+     *
+     * Kept explicit so adding an exemption is a visible decision rather than a
+     * quietly loosened regex.
+     */
+    private const NOT_SECRETS = [
+        // Ed25519 *public* key -- verification material, safe in the clear.
+        'policy_bundle_pubkey'    => 'public key, not a secret',
+        // Token budgets, not credentials. They match on the substring "token".
+        'max_tokens'              => 'token budget',
+        'backend_context_tokens'  => 'token budget',
+        'prompt_budget_chars'     => 'budget',
+    ];
+
+    public function test_every_credential_setting_is_a_password_type(): void {
+        $this->resetAfterTest();
+
+        $path = __DIR__ . '/../settings.php';
+        $this->assertFileExists($path);
+        $src = file_get_contents($path);
+
+        // Each declaration: the class name, then the setting name a few lines on.
+        $pattern = '/new\s+(admin_setting_config\w+)\s*\(\s*\'local_ai_course_assistant\/([a-z0-9_]+)\'/i';
+        $this->assertMatchesRegularExpression($pattern, $src,
+            'no settings found -- the scan pattern has drifted from settings.php');
+        preg_match_all($pattern, $src, $m, PREG_SET_ORDER);
+
+        $offenders = [];
+        $checked = 0;
+        foreach ($m as $decl) {
+            [$all, $class, $name] = $decl;
+            if (array_key_exists($name, self::NOT_SECRETS)) {
+                continue;
+            }
+            $looks = false;
+            foreach (self::SECRET_HINTS as $hint) {
+                if (str_contains($name, $hint)) {
+                    $looks = true;
+                    break;
+                }
+            }
+            if (!$looks) {
+                continue;
+            }
+            $checked++;
+            if (!str_contains(strtolower($class), 'password')) {
+                $offenders[] = "{$name} (declared {$class})";
+            }
+        }
+
+        $this->assertGreaterThan(0, $checked,
+            'no credential-looking settings matched -- the hint list may be stale');
+        $this->assertSame([], $offenders,
+            "Credential settings must use a password type so Moodle masks them in "
+            . "mdl_config_log. Plain configtext records every historical value in "
+            . "the clear. Offenders: " . implode(', ', $offenders));
+    }
+
+    /**
+     * The exemption list must not rot into a way of silencing the test. Every
+     * entry has to still exist in settings.php.
+     */
+    public function test_exemptions_still_exist_and_are_justified(): void {
+        $this->resetAfterTest();
+        $src = file_get_contents(__DIR__ . '/../settings.php');
+
+        foreach (self::NOT_SECRETS as $name => $reason) {
+            $this->assertNotEmpty($reason, "exemption {$name} has no stated reason");
+            if (!str_contains($src, "local_ai_course_assistant/{$name}'")) {
+                $this->addWarning("exemption '{$name}' no longer exists in settings.php; remove it");
+            }
+        }
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
Two unrelated settings changes, both small.

## 1. `redash_api_key` was leaking into `config_log` in plaintext

Moodle writes `********` into `mdl_config_log` for **password settings only**. `redash_api_key` was declared `admin_setting_configtext`, so every historical value it has ever held is recorded in the clear — in a table that is never purged and is readable by anything with database or reporting access.

Found on production while diagnosing an unrelated settings problem: **a retired key was recoverable in full from `config_log`.**

Its siblings `redash_user_api_key` and `github_token` were already declared correctly, which is exactly how this one went unnoticed.

**Scope is one setting.** My first reading of `config_log` suggested seven, but that came from matching names containing "token" — `max_tokens` and `backend_context_tokens` are budgets, and `policy_bundle_pubkey` is an Ed25519 **public** key that is meant to be readable. The `did_*` and `heygen_*` rows belong to settings that no longer exist in `settings.php`.

**This does not scrub what is already logged.** Existing plaintext values remain in `mdl_config_log` and need a separate, deliberate cleanup against production.

### The guard matters more than the fix

Two of the three sibling settings were already correct, so the next credential setting will be copied from whichever neighbour the author happens to look at. The test scans `settings.php` for credential-looking names declared without a password type, with an explicit exemption list carrying a stated reason per entry — so adding an exemption is a visible decision rather than a quietly loosened regex. A second test fails the exemptions if they stop matching a real setting.

Verified it earns its place: reverting the one-line fix makes it fail.

## 2. `rerank_candidates` default 50 → 20

Changed in the shipped setting and both code fallbacks in `rag_retriever`.

Measured over 1,008 queries across 16 courses:

| Pool | R@3 | Cost/query |
|---|---|---|
| 30 | 89.3% | $0.00112 |
| **20** | **89.0%** | **$0.00075** |
| 10 | 87.0% | $0.00037 |

Pool 20 matches pool 30 on recall for a third less cost; pool 50 costs 2.5x pool 20 with no measurable gain. At 25,000 SOLA users, reranking at 50 is **~101% of chat spend** against **~41%** at 20 — enabling it at the old default roughly doubled the AI bill.

The description previously argued *for* larger windows ("larger windows give the reranker more material to work with at small extra cost"), which the measurement contradicts. It now carries the numbers.

**Behaviour change on upgrade:** sites that never set the value explicitly move from 50 to 20. That is the intended direction, and reranking is off by default, so only sites that opted in are affected.

## Testing

Full suite: **711 tests, 3289 assertions, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
