### PR TITLE
chore(zip): exclude scripts/ from the Moodle upload package

### DIFF
--- a/create_fixed_zip.sh
+++ b/create_fixed_zip.sh
@@ -35,7 +35,8 @@ zip -r ai_course_assistant.zip ai_course_assistant/ \
   -x "*/.wiki/*" \
   -x "*/.drafts/*" \
   -x "*/__pycache__/*" \
-  -x "*.pyc"
+  -x "*.pyc" \
+  -x "*/scripts/*"
 
 echo "✅ Created: ${SCRIPT_DIR}/ai_course_assistant.zip"
 echo ""


### PR DESCRIPTION
echo "(merge watcher armed)"
Follow-up to #175, which flagged this rather than assuming it.

`scripts/new_release_notes.py` seeds templated release docs in `.drafts/`. It's maintainer tooling in the same category as `deploy_dev.py` and `create_fixed_zip.sh` — both of which the zip already excludes. It has no runtime role, and `CLAUDE.md` documents it as a release-checklist step rather than a plugin feature.

## Checked before excluding

- `scripts/` contains exactly one file
- **No PHP, JS or Mustache references it.** The single grep hit was a false positive — `DEFAULT_TRANSCRIPT_PATTERN` contains `"transcripts/"`, which matches the substring `"scripts/"`
- No other tracked path contains `/scripts/`, so the `*/scripts/*` pattern can't catch anything unintended

## Verified against a real build

Rather than trusting the pattern by reading it, I ran `create_fixed_zip.sh` and inspected the output:

```
entries: 641
scripts/ .pyc or __pycache__ entries: NONE
core files present: settings.php, version.php, lib.php
deploy_dev.py excluded: True
```

That also confirms #175's `__pycache__` exclusion works in the produced package, which hadn't been checked end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
