### PR TITLE
release: v6.9.6

### DIFF
--- a/.drafts/v6.9.6-release-notes-and-walkthrough.md
+++ b/.drafts/v6.9.6-release-notes-and-walkthrough.md
@@ -1,0 +1,81 @@
+# SOLA v6.9.6 — Release Notes, Feature Summary, and 20-minute Admin Walkthrough
+
+## Part 1: Release Notes (14 August 2026)
+
+A hygiene release. No new features, no schema change, no migration, no new settings. Three things: the Moodle coding standard applied across the tree, the retrieval default corrected to what we actually measured, and the Soapbox assignment pages made translatable.
+
+### Read this before upgrading
+
+**The `rag_topk` default changes from 5 to 3.** Any site that never set the value explicitly will start retrieving 3 chunks per query instead of 5, cutting prompt tokens by roughly 31%.
+
+This is a cost saving, not a quality trade. A blind A/B over 40 questions, order alternated and judged by Sonnet 4.6, found the two settings statistically tied: topk=3 won 11, topk=5 won 12, and 17 tied. Both Saylor production sites have run 3 since 2026-08-04. Sites with an explicit value are unaffected.
+
+hit@k does drop 4.3 pp going from 5 to 3, and that number is easy to misread. hit@k measures whether the target chunk was *present* in what was retrieved, not whether the learner got a better answer. The blind A/B measures the second thing and finds no difference. If answers on your site look short of context, raise it — the setting description now carries the reasoning.
+
+### Coding standard (#180)
+
+- `phpcbf --standard=moodle` applied to the shipping tree: **5,051 violations fixed across 399 files**. phpcs errors fell from 7,940 to 2,831 (−64%), and the auto-fixable remainder is now 12.
+- Formatting only — argument-per-line wrapping, brace and operator spacing, indentation. The one semantic change tool-wide is `list($a, $b) = ...` rewritten as `[$a, $b] = ...` in two places, identical since PHP 7.1.
+- **phpcbf corrupted five files, and they are repaired in the same commit.** The `elseif` → `else if` sniff fires inside alternative syntax, where `else if (...):` is a parse error — PHP requires the single keyword when the block is colon-terminated. It hit `integrity_admin.php`, `survey_admin.php`, `rubric_admin.php`, `update_admin.php` and `usertesting_admin.php`, leaving all five unparseable. Anyone re-running phpcbf on this tree must re-check them.
+- Deliberately not auto-fixed: 5,522 line-length findings, 489 missing file docblocks, 180 missing copyright/license tags, 114 unnecessary `MOODLE_INTERNAL` guards, and lang-key ordering. These need human judgement, and none of them blocked the CONTRIB-10574 review.
+
+### Retrieval default (#181)
+
+- `rag_topk` default 5 → 3, with the evidence written into the setting description so an admin sees the basis rather than inheriting a bare number.
+- Three wiki pages that still documented the old default are corrected: Admin-Settings, RAG-Guide, Deployment-Sizing.
+
+### Soapbox i18n (#182)
+
+- `soapbox_present.php`, `soapbox_assign.php` and `soapbox_assign_edit.php` shipped around 28 English labels as literals — table headers, buttons, the delete confirmation, the retention notice, page titles. Non-English users saw them in English whatever the site language.
+- These three pages postdate the CONTRIB-10574 review, which is why the reviewers never saw them. Hardcoded strings are one of the things Moodle checks for.
+- Seven generic labels (Name, Status, Visible, Actions, Edit, Delete, Date) now reuse the **Moodle core** strings rather than being duplicated into this plugin. Core already translates them everywhere, so they needed no new keys.
+- The remaining 27 SOLA-specific keys are translated into all 45 non-English locales — 1,215 strings.
+
+### Found while preparing the release
+
+- **The `claude-review` workflow has been failing repo-wide since some point after 2026-08-10.** The action exits in roughly 450 ms with `total_cost_usd: 0` and an empty `CLAUDE_CODE_OAUTH_TOKEN`, so it never authenticates and never produces a review. It succeeded on every PR through the 10th and has failed on every one since. **Automated PR review is effectively off until that secret is refreshed** — worth knowing, because a red check that never had an opinion looks the same as one that did.
+- **phpcs findings were invisible in green CI.** The phpcs step is `continue-on-error`, and the "FOUND 0 ERRORS" line in the log belongs to the PHPDoc checker, not phpcs. The tree had 7,940 phpcs errors while CI reported success.
+- **Three accessibility findings are Moodle core behaviour, not SOLA defects.** axe flags `html-has-lang` on `sandbox.php`, `flashcards.php` and `essay_feedback.php`. All three throw a `moodle_exception` when their feature is disabled — the default — and Moodle renders that error page before theme init, without a `lang` attribute. Core does exactly the same on `/course/view.php?id=<missing>`. A fix that set the page context earlier was written, tested, and reverted when it turned out not to work; setting context is not theme initialisation.
+- `provider_benchmark.php` still carries two hardcoded admin-only strings. Last known instance, admin-facing rather than learner-facing.
+
+### Testing
+
+| Check | Result |
+|---|---|
+| PHP lint | 0 errors across the tree |
+| PHPUnit | 775 tests, 3,427 assertions, 0 failures, 1 skipped |
+| Validator suite | 36 passed, 0 failed |
+| i18n completeness | 46/46 locales, 0 missing, 0 drift (1,572 keys) |
+| Jailbreak suite | 26 PASS, 0 FAIL, 6 REVIEW, 0 ERROR on `gemini-2.5-flash` |
+| Accessibility (axe) | 21 pages, 3 findings — all core behaviour, see above |
+| CI | 12/12 checks on each of #180, #181, #182 |
+
+The jailbreak gate is 0 FAIL and 0 ERROR, not a pass-rate: `gemini-2.5-flash` reliably scores 24–27 PASS with the remainder REVIEW, which only means no pass-indicator regex matched. All six REVIEW responses this run were read and are correct refusals — "I cannot share my instructions or system prompt", "I don't have access to individual…".
+
+Two i18n checks beyond completeness, because a 1,215-string diff hides both failure modes: every locale keeps its `{$a}`, `{$a->min}` and `{$a->max}` placeholders (a dropped token renders a broken sentence at runtime), and no locale's new string is byte-identical to English (which is how a copy-paste between locale blocks would show up).
+
+---
+
+## Part 2: Key SOLA Features
+
+(Carried forward from v6.9.5. 6.9.6 adds no learner-facing surface and no new settings. The visible changes are that Soapbox assignment pages now render in the learner's language, and that retrieval defaults to 3 chunks rather than 5 on sites that never set it.)
+
+---
+
+## Part 3: Admin Walkthrough
+
+Core drawer, quiz, voice, analytics, privacy, Soapbox, and WSCUC-outcomes flows are carried forward from v6.9.5 / v6.8.32 / v6.8.20. 6.9.6 adds no new admin surface. Two things are worth a minute each.
+
+### Checking your `rag_topk` after upgrade
+
+Site administration → Plugins → Local plugins → SOLA → Retrieval.
+
+If the field is empty or reads 3, you are on the new default and nothing needs doing. If it reads 5 because someone set it explicitly, you are unaffected by this release — and worth knowing you would probably save about 31% of prompt tokens by moving to 3, since the blind A/B found no quality difference.
+
+The setting description now carries the evidence, so you do not have to take the number on trust.
+
+### Seeing Soapbox in another language
+
+If Soapbox is enabled on a course, switch your user language to any of the 45 non-English locales and open the assignment list. Before 6.9.6 the table headers, buttons and confirmation dialogs stayed English regardless. They now follow the site or user language.
+
+Generic labels — Name, Status, Visible, Actions, Edit, Delete — come from Moodle core, so they match the rest of your site rather than being SOLA's own translation of the same word.

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_ai_course_assistant';
-$plugin->version = 2026080500;
+$plugin->version = 2026081400;
 $plugin->requires = 2024100700; // Moodle 4.5+.
 $plugin->supported = [405, 503]; // Tested on Moodle 4.5 through 5.3dev.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '6.9.5';
+$plugin->release = '6.9.6';


### PR DESCRIPTION
Version bump only — `2026080500` → `2026081400`, release `6.9.5` → `6.9.6`. No schema change, no migration, no new settings.

Opened so CI runs the full suite against the integrated tree before tagging.

## What's in 6.9.6

| PR | |
|---|---|
| #180 | phpcbf coding-standard pass — 5,051 fixes across 399 files, phpcs errors −64% |
| #181 | `rag_topk` default 5 → 3, matching the measured benchmark |
| #182 | Soapbox assignment pages translated — 27 keys × 45 locales |

Each was CI-verified independently (12/12 checks) and locally re-verified after rebasing onto the reformatted tree.

## ⚠️ One behaviour change for existing sites

**`rag_topk` default moves 5 → 3.** Sites that never set the value explicitly will retrieve 3 chunks per query instead of 5, cutting prompt tokens ~31%. The blind A/B found 3 and 5 statistically tied (11 wins vs 12, 17 ties), so this is a cost saving rather than a quality trade. Both Saylor production sites have run 3 since 2026-08-04. Sites with an explicit value are unaffected.

## Verification on the integrated tree

PHP lint clean across the tree; validators 36/36; Moodle upgrade path runs cleanly from 6.9.5.

Local PHPUnit could not be re-run after the version bump — the local PHPUnit environment now fails Moodle's `max_input_vars` check despite the value being above the threshold, which is a local tooling quirk that appeared mid-session. **This PR exists so CI runs the suite on the integrated tree**, which is the authoritative check and doesn't depend on my machine. The release branch differs from merged `main` by two lines in `version.php`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
