### PR TITLE
docs: v6.9.8 release notes and walkthrough

### DIFF
--- a/.drafts/v6.9.8-release-notes-and-walkthrough.md
+++ b/.drafts/v6.9.8-release-notes-and-walkthrough.md
@@ -1,0 +1,96 @@
+# SOLA v6.9.8 — Release Notes, Feature Summary, and 20-minute Admin Walkthrough
+
+## Part 1: Release Notes (19 August 2026)
+
+A small release with one large lesson in it. No schema change, no migration, no new setting.
+
+Both fixes came out of a single report — a Moodle user tour on a Saylor course was being covered by the auto-opened SOLA drawer — and the second one turned out to matter more than the first.
+
+### Auto-open defers to a pending user tour (#188)
+
+A user tour and the auto-opened drawer both claim the screen on a learner's first visit to a course, and the drawer wins. The result is a half-covered tour sitting behind a chat window the learner did not ask for.
+
+The widget now advertises whether a tour will **actually run for this user on this page**, using the same predicate core uses for its own bootstrap (`manager::get_current_tours()` plus `should_show_for_user()`). A tour that is disabled, scoped to a different page, carries no steps, or has already been completed suppresses nothing. When one really is pending, the drawer waits for `tool_usertours/tourEnded` rather than racing it.
+
+There is deliberately no timeout fallback. If the tour never ends, the learner is still inside it, and opening on top is the exact behaviour being guarded against. Because the first-visit marker is left unclaimed, the next page load in that course auto-opens normally.
+
+### Background tabs no longer burn the one auto-open (#188)
+
+Found while testing the above, and older than it. The first-visit `localStorage` key was written *before* the animation frame that opens the drawer. `requestAnimationFrame` does not run while a tab is hidden, so a course opened in a background tab — a restored session, a middle-click — consumed the single auto-open without ever showing the drawer, and never retried, because the key was already set.
+
+The key is now claimed inside the frame that opens the drawer.
+
+### CDN-mode string keys no longer leak to learners (#188)
+
+The more serious half, and the reason this release exists.
+
+In CDN mode — which is what Saylor production runs — `core/str` is not Moodle's string API. It is a shim that resolves **only** from the `window.SOLA_I18N` map injected by PHP, and otherwise **returns the key itself**:
+
+```js
+var s = strings[key] !== undefined ? strings[key] : key;
+```
+
+That map is built from `hook_callbacks::get_js_strings()`, a hand-maintained list. Twelve keys used by bundled modules had been added to the JavaScript without being added to the list. Every one of them rendered to the learner as a raw string identifier.
+
+This is the actual mechanism behind `active_learners:line_global` appearing in the chat drawer on learn.saylor.org.
+
+**The v6.9.7 diagnosis was wrong.** That release attributed it to Moodle caching JS strings in `localStorage` keyed without the parameter, so a parameterised lookup could be served from cache and skip the server. That is a real Moodle pitfall and the guard against it still stands — but it is not what happened here. In CDN mode there is no server round-trip to skip. The observation recorded at the time, that `core_get_string` was never requested, is fully explained by the shim: the key was simply never in the map. The comment in `chat.js` asserting the cache explanation has been corrected.
+
+Fixed by adding the twelve missing keys, plus the four assembled at runtime (`active_learners:line`, `active_learners:line_global`, `learner_digest:optin_thanks`, `learner_digest:optin_declined`) which no static analysis can see.
+
+More importantly, `cdn/rollup.config.mjs` now asserts that the declared list covers every literal key the bundled modules request, and **fails the CDN deploy** when it does not. This is the same shape as the module dependency check added after the June outage, and it exists for the same reason: this class of bug is invisible on AMD-mode installs, where the real string API serves any key on demand, and surfaces only on production. The check parses the PHP rather than duplicating the key list, and throws loudly if it can no longer find `get_js_strings()` — a check that silently passes reads as coverage it is not providing.
+
+### Testing
+
+| Check | Result |
+|---|---|
+| PHPUnit | **801 tests, 3,472 assertions, 0 failures** |
+| CDN build guards | 14/14 |
+| Validator suite | 36/36 |
+| PHP lint | 0 errors |
+| i18n completeness | 46/46, no missing keys, no drift |
+| Moodle Plugin CI | 13/13 across PHP 8.1–8.3, MariaDB and PostgreSQL |
+
+Verified end-to-end on local Moodle against a real user tour, not just in unit tests:
+
+| Case | Observed |
+|---|---|
+| Tour pending, before `tourEnded` | drawer closed, first-visit key unclaimed |
+| After `tourEnded` | drawer opens, key claimed |
+| No tour at all | drawer opens immediately |
+
+The jailbreak suite was not run. Nothing in this release touches prompts, providers, or routing.
+
+### Read this before upgrading
+
+Behaviour is unchanged on any site without user tours.
+
+**A plugin upgrade alone does not deliver JavaScript to a CDN-mode install.** The standalone bundle is published separately from `amd/src` by the `Deploy CDN Assets` workflow, which fires on merge to `main`. The PHP half of both fixes ships with the plugin; the JS half arrives with the bundle. On a site running the bundle, the two halves can be live at different times — the tour guard is simply inert until both are present, which is safe in either order.
+
+### Known and not fixed
+
+- Failover remains **unverified in practice**. It was configured on both production sites during the August incident and never engaged.
+- `provider_benchmark.php` still carries two hardcoded admin-only strings.
+- `get_js_strings()` is still a hand-maintained list. It is now guarded against omission, but keys assembled at runtime remain invisible to that guard and must be added by hand.
+
+---
+
+## Part 2: Key SOLA Features
+
+Carried forward from v6.9.7. This release adds no learner-facing surface; the visible change is the absence of two defects.
+
+---
+
+## Part 3: Admin Walkthrough
+
+Core drawer, quiz, voice, analytics, privacy, Soapbox and WSCUC-outcomes flows carry forward from v6.9.7. One thing is new and worth a few minutes.
+
+### When auto-open and a user tour both want the screen
+
+If you run Moodle user tours on course pages and also have SOLA's auto-open enabled, they used to collide. They no longer do — but it is worth knowing how to check.
+
+Site administration → Appearance → User tours will show which tours apply to `/course/view.php`. On a course where one applies, open the page as a learner with a cleared browser profile. You should see the tour, with the SOLA drawer still closed behind it. Finish or dismiss the tour and the drawer opens.
+
+If the drawer opens on top of the tour anyway, the usual cause on a CDN-mode install is that the plugin has been upgraded but the CDN bundle has not, so the browser is running JavaScript that predates the guard. Check which bundle the page is loading before looking anywhere else.
+
+A tour that never appears is a separate matter and usually means it has no steps: Moodle only serves tours that have at least one.


### PR DESCRIPTION
Release-notes draft required by the release process, used as the body source for the `v6.9.8` GitHub release.

Records the correction to the v6.9.7 diagnosis of `active_learners:line_global`, and documents that a plugin upgrade alone does not deliver JavaScript to a CDN-mode install.

Docs only — no code, no version change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)