### PR TITLE
ci: grant the code-review workflow the tools it actually needs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -45,5 +45,27 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+
+          # Without this the review runs, reports success, bills for the tokens
+          # and posts nothing -- v7.0.1's run finished with
+          # permission_denials_count: 21 and "No buffered inline comments",
+          # which is indistinguishable from "found no issues".
+          #
+          # The /code-review command declares only its gh calls and the inline
+          # comment tool in its own frontmatter, but it fans the review out
+          # across Haiku/Sonnet/Opus subagents. Launching those needs Task, and
+          # the subagents need Read/Grep/Glob to look at the code, none of which
+          # the frontmatter covers -- so those were the denied calls.
+          #
+          # Bash stays scoped to the specific gh subcommands rather than being
+          # granted wholesale: pull_request runs check out an untrusted head, so
+          # a blanket Bash grant would let a contributor's branch run arbitrary
+          # commands with a token that has pull-requests: write.
+          #
+          # Edit and Write are deliberately absent. A reviewer reports; it does
+          # not rewrite the branch it is reviewing.
+          claude_args: >-
+            --allowedTools
+            Task,Read,Grep,Glob,TodoWrite,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),mcp__github_inline_comment__create_inline_comment
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## The problem

The v7.0.1 review run finished **successfully** with `permission_denials_count: 21` and `No buffered inline comments`, after billing $3.42 for nine turns. A review that reports success and posts nothing is indistinguishable from a review that found no issues — the worst possible failure mode for this workflow, because it produces false confidence on every PR.

## This is not the PR #108 problem

Worth stating plainly, since `CLAUDE.md` documents that earlier bug with the same visible symptom. PR #108 was a read-only `GITHUB_TOKEN`, and it is **still fixed** — the job log shows:

```
Contents: read
Issues: write
Metadata: read
PullRequests: write
```

So posting was possible. The 21 denials were **tool** permissions, not API permissions. Same symptom, different cause.

## Cause

`/code-review` declares only its `gh` calls and the inline-comment tool in its own frontmatter:

```
Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*),
Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*),
Bash(gh pr list:*), mcp__github_inline_comment__create_inline_comment
```

But the plugin's own description is *"code review for pull requests using multiple specialized agents with confidence-based scoring"* — it fans the work out across Haiku, Sonnet and Opus subagents. Launching those needs `Task`, and the subagents need `Read`/`Grep`/`Glob` to read the code they are reviewing. None of that is in the frontmatter, and the action grants nothing else by default, so those calls were refused.

## The fix

`claude_args: --allowedTools` with 13 entries: `Task`, `Read`, `Grep`, `Glob`, `TodoWrite`, the seven scoped `gh` Bash grants, and the inline-comment MCP tool.

Two deliberate choices:

- **`Bash` is scoped per gh subcommand, not granted wholesale.** `pull_request` runs check out an untrusted head. A blanket `Bash` grant would let a contributor's branch execute arbitrary commands while holding a token with `pull-requests: write`.
- **`Edit` and `Write` are withheld.** A reviewer reports; it does not rewrite the branch under review. Verified there is no `Edit`, `Write`, `MultiEdit`, `NotebookEdit`, `WebFetch` or `WebSearch` in the list, and no bare `Bash`.

`fetch-depth: 1` is left alone. I checked before touching it: the command reads the diff through `gh pr diff`, which is API-based and needs no local git history, so deepening the clone would cost time for nothing.

## Verification

The YAML parses and the folded scalar collapses to a single line (confirmed by loading it and inspecting the resolved `claude_args` string, since a broken fold would silently pass the tool list as separate arguments).

**This PR's own review still runs with the old config** — `pull_request` workflows are taken from the base branch, so the fix cannot test itself. Expect this PR to be reviewed with the broken permissions. It applies from the first PR opened after it lands on `main`, which I'll verify with a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)