### PR TITLE
v7.0.4: a quantized index was invisible to everything in front of the retriever

### DIFF
--- a/.drafts/contrib-10574-comment-wrong-test-report.txt
+++ b/.drafts/contrib-10574-comment-wrong-test-report.txt
@@ -1,0 +1,30 @@
+Reporting what looks like a Marketplace-side data problem rather than anything about our code, in case it affects the review here.
+
+We uploaded version 7.0.3 (build 2026082200) to the Marketplace listing for local_ai_course_assistant on 22 August. The version card shows an "Automated test passed" badge, but the test-results report attached to that version is for a different plugin, mod_playercross. It contains no reference to our component at all.
+
+We cannot tell from the Marketplace UI which of two things happened, and the difference matters for this review:
+
+1. Our zip was tested and the wrong report is being rendered, which would be cosmetic.
+2. The wrong zip was tested, in which case the pass badge on our version is not backed by a run against our code.
+
+What the report contains
+
+The run is described as "RUN PHP Lint on mod_playercross" over 80 files, and refers to mod_form.php, playercross_add_instance, mod/playercross:addinstance, and tests/behat/mod_playercross_*.feature. None of those can belong to our plugin: local_ai_course_assistant is a local plugin, so it has no mod_form.php, no mod/* capability namespace and no *_add_instance function, and it contains considerably more than 80 files. Counting occurrences in the rendered report: 31 mentions of "playercross", zero of "ai_course_assistant".
+
+Why we are confident this is bound to our version
+
+The report is in the modal with id testResultsModal26709, scoped to version id 26709, and the corresponding pluginDetailsModal26709 correctly describes our upload: local_ai_course_assistant, build 2026082200, release 7.0.3, repository tag v7.0.3, Moodle 4.5 / 5.0 / 5.1 / 5.2.
+
+It is also server-rendered into our version's page rather than fetched separately: a same-origin fetch of the raw page HTML (71,561 bytes) contains the same 31 occurrences of "playercross" as the rendered modal.
+
+The summary line and the mismatched detail are one block, so the summary is not independent of the wrong report. Offsets in the raw HTML: the "Automated test passed" badge at 38159 (version card), "0 test problems found" at 47084 (inside .modal-body), and the first "playercross" at 48579 (same .modal-body).
+
+What we are asking
+
+Whether our 7.0.3 zip was in fact tested. If it was, we would appreciate the correct report being re-attached so it is visible here. If it was not, we would rather the badge were cleared and the version re-queued than have the review rest on a result that is not ours. It would also be worth checking whether other versions or plugins are affected by the same mismatch.
+
+One side effect worth flagging: another plugin's lint output is currently visible on our version's page. If that submission is not yet public, this discloses more than intended.
+
+For reference, our own CI runs moodle-plugin-ci against the same commit that tag v7.0.3 points at (729b33e8) across PHP 8.1, 8.2 and 8.3 on both MariaDB and PostgreSQL on MOODLE_405_STABLE, and all checks pass, so we have no reason to expect a genuine failure hiding behind this. The concern is only that the result displayed is not ours.
+
+Happy to supply the raw page HTML or anything else useful.

--- a/.drafts/marketplace-description-v7.0.3.txt
+++ b/.drafts/marketplace-description-v7.0.3.txt
@@ -1,0 +1,58 @@
+The AI Course Assistant (also known as the Saylor Online Learning Assistant or SOLA) is an AI-powered learning coach embedded directly in Moodle course pages. Students open it from a side tab to get context-aware help grounded in the course they are studying and the page they are viewing, all without leaving Moodle.
+
+Developed at Saylor University and open-sourced under the GNU GPL v3 with simple white-labeling for other institutions (see below). Used in production on Saylor's Learn and Degrees sites.
+
+Works with Moodle 4.5 through Moodle 5.3 LTS.
+
+Available in 46 languages. The learner interface is fully localized, and so are the conversation starters and the speech input and output. The assistant also detects the language a learner writes in and replies in it, so a student can ask about an English-language course in their own language and read the answer in their own language. No separate configuration is needed; detection is automatic and per-message.
+
+Out of the box it can use Moodle's own AI provider (the core_ai subsystem). The shipped chat provider setting is "Auto", which resolves at call time: if you have entered an API key of your own, SOLA uses that provider; if you have not, and a Moodle AI provider is configured at Site administration > AI, it routes through core_ai instead. So the plugin can be installed and used without holding a separate API key. Choosing a specific provider from the dropdown overrides Auto entirely.
+
+WHAT STUDENTS GET
+
+- A tutor that knows the course. Answers are grounded in the actual course content, pages, books, files and activities, not generic web knowledge. Optional semantic retrieval indexes PDF, DOCX, PPTX, H5P and SCORM content, plus transcripts for embedded video. Where the chosen embedding provider supports it, each passage can be indexed together with the document it came from, which helps most with the short, keyword-style questions learners actually ask.
+
+- Practice quizzes generated from course material, answered inside the drawer, with per-question feedback and a score summary.
+
+- Study plans and reminders. Learners set goals and preferred study days; optional email reminders respect their schedule and their opt-out.
+
+- Voice. Speech input and spoken responses, plus an optional live conversational voice mode. Speech-to-text can run on a self-hosted Whisper server at no per-minute cost. Speech recognition and playback cover the same 46 languages as the interface.
+
+- Spoken presentation practice. Learners record a talk, get it transcribed, and receive rubric-based feedback with per-criterion scores. Audio is deleted on a retention schedule; only the transcript and score are kept.
+
+- 46 languages with automatic detection, including speech input and output.
+
+WHAT ADMINISTRATORS GET
+
+- White-labeling. Four admin settings rename the product throughout the learner interface, the system prompt, emails and the admin pages. The plugin does not assume it is called SOLA.
+
+- Provider choice, not lock-in. Moodle core_ai, OpenAI, Anthropic, Google Gemini, DeepSeek, Together AI, Mistral, xAI, OpenRouter, and any OpenAI-compatible endpoint, including models you host yourself. Where an embedding vendor offers a shared embedding space across its models, the model used for learner questions can be changed later without re-indexing your whole catalog.
+
+- Spend controls that actually stop spending. Caps per period, per capability and per course, with notification at 80/95/100 percent, an optional failover chain to cheaper providers, a daily cost-anomaly check, and a site-wide kill switch reachable from both the admin UI and the CLI.
+
+- Per-course configuration. Any course can override the provider, model, system prompt and feature set, so one course can run a different model from the rest of the site.
+
+- Analytics. Usage, token cost, provider comparison and per-course engagement, with an A/B comparison view for running experiments across two courses.
+
+- Control over index size. Stored vectors can be kept at full precision or compressed to roughly a quarter, or about a thirtieth, of the space, so a large catalog does not force a large disk. The RAG admin page shows what the index occupies now and what each option would occupy instead, before you commit to a re-index.
+
+- A settings page that stays readable. Feature configuration stays hidden until the feature is switched on, so a default install shows the switches rather than 200+ controls.
+
+PRIVACY AND DATA PROTECTION
+
+- Full Moodle Privacy API implementation, including export and erasure, with external-location links declared for every third-party service the plugin can call.
+
+- A first-run consent notice the learner must scroll before accepting, gating any escalation of their conversation to a human support desk.
+
+- Configurable retention for conversations and audit records; presentation recordings are deleted automatically on a schedule of your choosing.
+
+- Per-recipient email opt-out honored across every message type the plugin sends.
+
+- Outbound requests are checked against Moodle's SSRF allowlist, with the resolved address pinned to close the DNS-rebinding window.
+
+REQUIREMENTS
+
+Moodle 4.5 or later, including Moodle 5.3 LTS. Either a configured Moodle core_ai provider or an API key for at least one AI provider. No other server dependencies are required for the core experience; optional features note their own requirements in the settings page.
+
+Source, issue tracker and release notes:
+https://github.com/saylordotorg/moodle-local_ai_course_assistant

--- a/.drafts/moodle-directory-bug-wrong-test-report.md
+++ b/.drafts/moodle-directory-bug-wrong-test-report.md
@@ -1,0 +1,98 @@
+Automated test results shown for the wrong plugin
+=================================================
+
+Plugin: local_ai_course_assistant (plugin id 3808)
+Version affected: 7.0.3, build 2026082200, version record id 26709
+Review ticket: CONTRIB-10574
+Observed: 2026-08-22
+
+Summary
+-------
+
+The version card for our 7.0.3 upload shows an "Automated test passed" badge, but
+the test-results report attached to that version is for a different plugin,
+mod_playercross. The report contains no reference to our component at all.
+
+We cannot tell from the directory UI whether this is a display-layer mixup (the
+right zip was tested, the wrong report is rendered) or whether the wrong zip was
+actually tested (in which case the green badge on our version is not backed by a
+run against our code). That distinction is the reason we are reporting it: the
+first is cosmetic, the second means a reviewer is looking at a pass that never
+happened.
+
+What the report contains
+------------------------
+
+Opening the test results for version 26709 shows a run described as "RUN PHP Lint
+on mod_playercross" over 80 files, and referring to:
+
+- mod_form.php
+- playercross_add_instance
+- mod/playercross:addinstance
+- tests/behat/mod_playercross_*.feature
+
+None of these can belong to our plugin. local_ai_course_assistant is a local
+plugin: it has no mod_form.php, no mod/* capability namespace, no *_add_instance
+function, and considerably more than 80 files.
+
+Counting occurrences in the rendered report: 31 mentions of "playercross", 0
+mentions of "ai_course_assistant".
+
+Evidence that this is bound to our version, not a misread
+---------------------------------------------------------
+
+1. The report is in the modal with id testResultsModal26709, which is scoped to
+   version id 26709.
+
+2. Version 26709 is genuinely ours. The corresponding pluginDetailsModal26709
+   shows local_ai_course_assistant, build 2026082200, release 7.0.3, repository
+   tag v7.0.3, Moodle 4.5 / 5.0 / 5.1 / 5.2 - all correct for our upload.
+
+3. The report is server-rendered into our version's page, not fetched separately.
+   A same-origin fetch of the raw page HTML (71,561 bytes) contains the same 31
+   occurrences of "playercross" as the rendered modal.
+
+4. The summary line and the mismatched detail are the same block, so the summary
+   is not independent of the wrong report. In the raw HTML:
+
+     offset 38159  - "Automated test passed" badge (version card)
+     offset 47084  - "0 test problems found" (inside .modal-body)
+     offset 48579  - first occurrence of "playercross" (same .modal-body)
+
+Expected behavior
+-----------------
+
+The test results shown for a version should be the results of testing that
+version's zip.
+
+Actual behavior
+---------------
+
+The results shown for version 26709 of local_ai_course_assistant are results for
+mod_playercross.
+
+Impact
+------
+
+- A reviewer working CONTRIB-10574 sees a pass badge whose supporting evidence is
+  another plugin's. We are not able to represent our version as having passed
+  automated testing on this basis, and we would rather say so than let it stand.
+- It also means another plugin's lint output is visible on our version's page. If
+  that plugin's submission is not yet public, this discloses more than intended.
+
+What we would like to know
+--------------------------
+
+1. Was our 7.0.3 zip actually tested? If it was, we would appreciate the run being
+   re-attached or re-rendered so the correct report is visible.
+2. If it was not, we would like the badge cleared and the version re-queued, so
+   the review is based on a real result.
+3. Whether other versions or other plugins are affected by the same mismatch.
+
+For reference: our own CI runs moodle-plugin-ci against the same commit that tag
+v7.0.3 points at (729b33e8), across PHP 8.1, 8.2 and 8.3 on both MariaDB and
+PostgreSQL, on MOODLE_405_STABLE, and all checks pass. So we have no reason to
+expect a genuine failure hiding behind this - the concern is purely that the
+result displayed is not ours.
+
+Happy to supply the raw page HTML or anything else useful.

--- a/.drafts/sola-voyage4-benchmark-2026-08-21.md
+++ b/.drafts/sola-voyage4-benchmark-2026-08-21.md
@@ -216,3 +216,83 @@ If storage or budget argues against the flagship: **`voyage-4-lite` at $0.02/MTo
 | **Total** | **~$5.62** |
 
 **One caveat on the rerank token figures from this run:** document text was capped at 8,000 characters, giving 11,175–11,822 tokens per rerank against production's 21,124. The recall deltas are unaffected — same candidates, same reranker — but the token and cost figures from *this* run understate production, and the $1.06/1k figure above is the production-measured one.
+
+---
+
+## 8. In-product validation of the shipped asymmetric setting (2026-08-22)
+
+Everything in sections 1-7 was measured with a purpose-written evaluator over cached
+embeddings, because the harness cannot express asymmetric arms. SOLA v7.0.3 shipped the
+`embed_query_model` setting *after* that work, so the configuration we now ship had never
+been exercised end to end. This section covers that gap. It is a validation of the code
+path, not a re-measurement of the quality question settled in section 5.
+
+### Setup
+
+dev.sylr.org, SOLA 7.0.3 (build 2026082200). Config changed from the site's OpenAI default
+to `embed_provider=voyage`, `embed_model=voyage-4-large`, `embed_query_model=voyage-4`,
+`embed_dimensions=1024`, `embed_dtype=float`, reranking off. The corpus was rebuilt through
+the product indexer (`content_indexer::index_course`), not a script: 1,525 chunks over
+courses 2 (108), 11 (793) and 43 (624), zero errors, 313.6s wall.
+
+### The shipped setting does what it claims
+
+Asserted directly against `base_embedding_provider::create_from_config()`:
+
+| Check | Result |
+|---|---|
+| `get_model()` (documents) | `voyage-4-large` |
+| `get_query_model()` (queries) | `voyage-4` |
+| `supports_query_model()` | `true` |
+| `embedding_compat::are_comparable('voyage-4','voyage-4-large')` | `true` (both resolve to family `voyage-4`) |
+| Live round trip | document 1024d, query 1024d, cosine 0.6112 on a relevant pair |
+| `rag_retriever::retrieve()` | returns ranked chunks; top hit for `bus-001` contains its expected substring |
+
+No configured-but-ignored value is reported as the query model, and the comparability gate
+admits the cross-model pair rather than refusing it. 60 live retrievals ran with zero errors.
+
+**The migration-insurance claim holds in practice.** Both arms below ran against the *same*
+stored document vectors with no reindex between them — only `embed_query_model` changed.
+That is the property section 5 argued was the real value of the shared embedding space, and
+it is now demonstrated rather than assumed.
+
+### Paired A/B, product retrieval path
+
+30 content-anchored fixtures from `rag_fixtures_bus101_pol101.json` (course 11; the
+remaining 10 target course 7, which is not indexed on dev). Scored by whether the fixture's
+`expected_substring` appears in the returned chunk, which is immune to chunk-id churn.
+
+| Arm | R@1 | R@3 | MRR | P50 |
+|---|---|---|---|---|
+| docs `voyage-4-large` / queries `voyage-4` (asymmetric) | 26.7% | 33.3% | 0.300 | 203 ms |
+| docs `voyage-4-large` / queries `voyage-4-large` (symmetric) | 26.7% | **36.7%** | **0.317** | 216 ms |
+| **delta (asymmetric - symmetric)** | 0.0 pp | **-3.3 pp** | **-0.017** | -13 ms |
+
+**Direction agrees with section 5; the magnitude here proves nothing.** At n=30 a single
+fixture is worth 3.3 pp, so the R@3 gap *is* one fixture. Read this as "the in-product path
+did not contradict the evaluator", not as a second independent measurement. Section 5's
+1,008-query result remains the number to cite.
+
+Absolute recall is not comparable to sections 1-7: those measured bare cosine rank over a
+cached 10,910-chunk corpus, whereas this runs the real retriever with window expansion,
+`rag_topk=3` and the `rag_min_similarity=0.25` floor, over 1,525 chunks. Only the paired
+delta within this table is meaningful.
+
+### Recommendation unchanged
+
+Use `voyage-4-large` for documents *and* queries. The asymmetric pairing has now been shown
+twice not to help and never to help; its value is that the query model can be changed later
+without re-embedding the corpus, which this run demonstrates directly.
+
+### Fixture debt incurred by this run
+
+Rebuilding the index reassigned chunk ids for courses 2, 11 and 43. The prodshape and
+conv_1k fixtures anchor ground truth on `expected_chunk_id` alone — `expected_substring` is
+empty in all 1,008 rows of both — so **189 of the 1,008 prodshape fixtures (those three
+courses) no longer align with dev's index** and cannot be repaired from the fixture files.
+The other 819, covering 13 untouched courses, are unaffected.
+
+Options: regenerate those 189 against current ids, exclude courses 2/11/43 from prodshape
+runs, or add an `expected_substring` to the generator so future fixtures survive a reindex.
+The third is the one worth doing — content-anchored fixtures are why the 40-row
+`bus101_pol101` set was still usable here and the 1,008-row set was not.

--- a/.drafts/v7.0.4-release-notes-and-walkthrough.md
+++ b/.drafts/v7.0.4-release-notes-and-walkthrough.md
@@ -1,0 +1,56 @@
+# SOLA v7.0.4 — Release Notes, Feature Summary, and 20-minute Admin Walkthrough
+
+## Part 1: Release Notes (22 August 2026)
+
+### The quantization feature could not be adopted safely. Three predicates and a skip test.
+
+v7.0.3 shipped int8 and binary vector storage. A quantized chunk keeps its vector in `embedding_bin` and leaves the JSON `embedding` column null. Retrieval was taught to read either column — the three checks standing in front of it were not, and every one of them failed silently.
+
+- **Every chat turn re-indexed the whole course.** `is_course_indexed()` tested the JSON column alone, so on a quantized index it returned false permanently. Both chat paths re-index when that returns false, so one student message re-extracted and re-chunked the entire course before the reply: a `pdftotext` subprocess per PDF, DOCX/PPTX parsing, a full chunk-table scan, and outbound HTTP per media module when transcript fetching is on. Because the v7.0.3 hash-skip fix works, it then embedded nothing and reported `indexed 0, skipped N` — no error anywhere, just latency and load, amplified from one cheap authenticated POST.
+- **Changing the precision and re-indexing did nothing.** The setting's description says a precision change requires a full re-index; the chunk-level skip compared the content hash only, and a hash covers the text, not the model or encoding that vectorized it. So the documented adoption path was a no-op. Worse for `binary`: the index stayed float, retrieval then rejected every row as an encoding mismatch, and the tutor returned no chunks on every query behind a `DEBUG_NORMAL` line invisible in production. The skip now compares `embed_model` and `embed_dtype` and re-embeds when either differs from what the run writes.
+- **The admin page hid its own new feature.** `rag_admin.php` counted embedded chunks with the same stale predicate, so a fully-embedded quantized index read as 0 embedded. Every course was flagged un-embedded, and because the v7.0.3 storage projection is gated on that count, the projection never rendered on the quantized indexes it exists to size — while the storage card beside it correctly reported the megabytes.
+
+Two dev CLI tools carried the same predicate and saw an empty corpus. `backfill_embedding_bin.php` keeps the JSON-only predicate deliberately, and now documents why: it packs float32 out of `embedding`, so a row with no JSON has nothing to read.
+
+None of this fires on a float index, which is every production site today. That is why it shipped green through a 13/13 CI matrix — and why the fix is low-risk to take.
+
+- **Regression cover.** A new test asserts a quantized index is visible to `is_course_indexed()` at int8, binary and dual-written float, plus source-level guards that fail for the *next* writer of a JSON-only predicate rather than only for these three.
+
+**Known limitation, unchanged from v7.0.3.** `voyage-context-4` is wired into indexing only; querying and the drift-reindex task still use the plain embeddings endpoint, so documents and queries would come from different pipelines under the same model name — which the comparability guard cannot detect. Leave `embed_model` off `voyage-context-4`. The plain `voyage-4` family is unaffected and is what the benchmark recommends.
+
+### Testing
+
+- PHP lint clean on every modified file.
+- Validator suite: 36 passed, 0 failed, 0 skipped.
+- New `quantized_index_visibility_test` plus the v7.0.3 embedding suites (`embedding_compat_test`, `embed_query_model_test`, `chunk_vector_writers_test`) pass under PHPUnit on Moodle 4.5 / PHP 8.3 / MySQL.
+- In-product validation on dev.sylr.org against live Voyage vectors: `voyage-4-large` documents with `voyage-4` queries, 1,525 chunks re-indexed through the product indexer with zero errors, 60 live retrievals with zero errors. Recorded in `.drafts/sola-voyage4-benchmark-2026-08-21.md` section 8.
+- No `amd/` change in this release, so no AMD rebuild is required.
+
+Plugin version `2026082300`, release `7.0.4`.
+
+---
+
+## Part 2: Key SOLA Features
+
+Carried forward from v6.9.8. This release adds no learner-facing surface and no new setting; every change is a correctness fix beneath the administrator's view.
+
+---
+
+## Part 3: Admin Walkthrough
+
+Core drawer, quiz, voice, analytics, privacy, Soapbox and WSCUC-outcomes flows carry forward from v6.9.8. The v7.0.3 notes on the collapsed settings page, inactivity reminders and rebranding still apply. One thing is new, and it only matters if you intend to use quantized storage.
+
+### Adopting quantized vector storage, which now actually works
+
+Site administration → Plugins → Local plugins → AI Course Assistant → Settings, under the RAG section. "Stored vector precision" offers full precision, one byte per dimension, or one bit per dimension.
+
+Before v7.0.4, changing this and pressing Reindex reported success and did nothing. Now the re-index notices that the stored encoding differs from the one it is about to write and re-embeds. Two things to expect:
+
+1. **It is a real re-index.** Every chunk is sent to the embedding provider again. On a large catalog, run it when you can afford the spend and the time, and watch the RAG admin page rather than the settings page.
+2. **The storage card and the projection now agree.** Open Site administration → Reports → AI Course Assistant → RAG index. "Embedded chunks" will show your true count on a quantized index instead of zero, and the projection line beneath the storage card will finally appear, telling you what each precision would occupy before you commit to the switch.
+
+If you upgraded from v7.0.3 having already tried to switch precision, check the RAG index page. If "Embedded chunks" was reading zero while the storage card showed a size, that was the display bug and your index is intact. If you switched to `binary` on v7.0.3 and the tutor stopped citing course content, the index is still float and a re-index on v7.0.4 will now genuinely convert it.
+
+### Leave the contextualized model alone
+
+If you set `embed_model` to `voyage-context-4` on v7.0.3, change it back to `voyage-4-large`. That model is only half-wired — indexing uses the contextualized endpoint, querying does not — and because both sides report the same model name, the guard that protects every other mixing case cannot see it. This is unchanged in v7.0.4 and is tracked for a later release.

--- a/admin/cli/backfill_embedding_bin.php
+++ b/admin/cli/backfill_embedding_bin.php
@@ -67,6 +67,12 @@ TXT
 $courseid = (int) $options['courseid'];
 $batch = max(1, (int) $options['batch']);
 
+// Deliberately the JSON column alone, unlike every other predicate in the
+// plugin: this tool packs the float32 vector held in `embedding` into
+// `embedding_bin`, so a row with no JSON has nothing to read. Quantized rows
+// (int8/binary) leave `embedding` null and are therefore correctly invisible
+// here — widening this to `OR embedding_bin IS NOT NULL` would select rows whose
+// only vector is already packed and re-pack them as float32.
 $where = 'embedding IS NOT NULL';
 $params = [];
 if ($courseid > 0) {

--- a/admin/cli/generate_conversational_fixtures.php
+++ b/admin/cli/generate_conversational_fixtures.php
@@ -97,7 +97,7 @@ foreach ($courses as $cid) {
     // skipped while still reaching the per-course target.
     $rows = $DB->get_records_select(
         'local_ai_course_assistant_chunks',
-        'courseid = ? AND embedding IS NOT NULL',
+        'courseid = ? AND (embedding IS NOT NULL OR embedding_bin IS NOT NULL)',
         [$cid],
         'id',
         'id, content',

--- a/admin/cli/run_rag_fixture_benchmark.php
+++ b/admin/cli/run_rag_fixture_benchmark.php
@@ -946,7 +946,7 @@ $courseids = array_unique(array_column($fixtures, 'courseid'));
 foreach ($courseids as $courseid) {
     $rows = $DB->get_records_select(
         'local_ai_course_assistant_chunks',
-        'courseid = :cid AND embedding IS NOT NULL',
+        'courseid = :cid AND (embedding IS NOT NULL OR embedding_bin IS NOT NULL)',
         ['cid' => $courseid],
         '',
         'id, content, embedding'

--- a/admin/cli/run_rag_fixture_benchmark.php
+++ b/admin/cli/run_rag_fixture_benchmark.php
@@ -949,12 +949,34 @@ foreach ($courseids as $courseid) {
         'courseid = :cid AND (embedding IS NOT NULL OR embedding_bin IS NOT NULL)',
         ['cid' => $courseid],
         '',
-        'id, content, embedding'
+        'id, content, embedding, embedding_bin, embed_dtype'
     );
     $coursechunks[$courseid] = [];
+    $binaryskipped = 0;
     foreach ($rows as $row) {
-        $vec = json_decode($row->embedding, true);
-        if (is_array($vec) && !empty($vec)) {
+        // Widening the predicate above is not enough on its own: a quantized row
+        // has embedding = NULL, so a json_decode() of that column discarded every
+        // row the predicate had just admitted and the tool reported "Loaded 0
+        // embedded chunks" on exactly the indexes it was widened to support.
+        // Decode through the retriever so this tool reads a vector the same way
+        // retrieval does.
+        $dtype = \local_ai_course_assistant\embedding_compat::normalize_dtype($row->embed_dtype ?? null);
+
+        if ($dtype === \local_ai_course_assistant\embedding_compat::DTYPE_BINARY) {
+            // decode_vector() returns [] for binary by design — those vectors are
+            // scored on packed bytes by binary_similarity(), while this tool's
+            // cosine helper takes float arrays. Count them and say so below,
+            // rather than silently benchmarking nothing.
+            $binaryskipped++;
+            continue;
+        }
+
+        $vec = \local_ai_course_assistant\rag_retriever::decode_vector(
+            $row->embedding_bin ?? null,
+            $row->embedding ?? null,
+            $dtype
+        );
+        if (!empty($vec)) {
             $coursechunks[$courseid][$row->id] = [
                 'content' => $row->content,
                 'vec'     => $vec,
@@ -962,6 +984,11 @@ foreach ($courseids as $courseid) {
         }
     }
     echo "Loaded " . count($coursechunks[$courseid]) . " embedded chunks for courseid={$courseid}\n";
+    if ($binaryskipped > 0) {
+        echo "  WARNING: skipped {$binaryskipped} binary-encoded chunks. This tool scores float\n"
+           . "           arrays; binary vectors are compared as packed bytes. Re-run against a\n"
+           . "           float or int8 index to benchmark this course.\n";
+    }
 }
 echo "\n";
 

--- a/classes/content_indexer.php
+++ b/classes/content_indexer.php
@@ -150,13 +150,28 @@ class content_indexer {
                         $existing = $DB->get_record('local_ai_course_assistant_chunks', [
                             'courseid'    => $courseid,
                             'contenthash' => $hash,
-                        ], 'id, embedding, embedding_bin');
+                        ], 'id, embedding, embedding_bin, embed_model, embed_dtype');
 
                         // Either column proves the chunk is embedded. Testing only the
                         // JSON column made every quantized row look unembedded, so a
                         // reindex re-embedded the entire course on every run and the
                         // hash-skip optimization silently stopped working.
-                        if ($existing && (!empty($existing->embedding) || !empty($existing->embedding_bin))) {
+                        //
+                        // But identical content is NOT sufficient on its own: the
+                        // encoding has to match too. The hash covers the text, not
+                        // the model or the dtype that turned it into a vector, so a
+                        // content-only skip made "change embed_dtype, then reindex"
+                        // a silent no-op — the documented way to adopt quantization
+                        // did nothing, and for binary it left a float index that the
+                        // retriever then refused row by row, emptying retrieval with
+                        // only a DEBUG_NORMAL line to show for it. Re-embed whenever
+                        // the stored encoding differs from what this run writes.
+                        $sameencoding = $existing
+                            && (string) $existing->embed_model === (string) $modelname
+                            && embedding_compat::normalize_dtype($existing->embed_dtype ?? null) === $dtype;
+
+                        if ($existing && $sameencoding
+                                && (!empty($existing->embedding) || !empty($existing->embedding_bin))) {
                             $stats['skipped']++;
                             continue;
                         }
@@ -470,9 +485,16 @@ class content_indexer {
      */
     public static function is_course_indexed(int $courseid): bool {
         global $DB;
+        // Either column proves the course is indexed, matching the predicate
+        // rag_retriever uses to read vectors. Testing only the JSON column made
+        // a quantized index (int8/binary, where that column is null on every
+        // row) look permanently unindexed, so both chat paths re-extracted and
+        // re-chunked the whole course before every single reply — embedding
+        // nothing, reporting "indexed 0, skipped N", and showing up only as
+        // latency.
         return $DB->record_exists_select(
             'local_ai_course_assistant_chunks',
-            'courseid = :courseid AND embedding IS NOT NULL',
+            'courseid = :courseid AND (embedding IS NOT NULL OR embedding_bin IS NOT NULL)',
             ['courseid' => $courseid]
         );
     }

--- a/classes/rag_retriever.php
+++ b/classes/rag_retriever.php
@@ -876,7 +876,13 @@ class rag_retriever {
                 // bytes directly via binary_similarity(), which is the whole
                 // point of the encoding: expanding 128 bytes into 1024 floats
                 // would throw away both the memory and the speed win.
-                // decode_binary_vector() is the accessor for this case.
+                //
+                // There is no separate accessor: callers that need the packed
+                // bytes read the embedding_bin column directly and hand it to
+                // binary_similarity(), as retrieve() does. An earlier version of
+                // this comment pointed at a decode_binary_vector() that has never
+                // existed, which sent readers looking for a method rather than
+                // the column.
                 return [];
             } else if (strlen($bin) % 4 === 0) {
                 // A truncated blob would silently yield a short vector and score

--- a/rag_admin.php
+++ b/rag_admin.php
@@ -180,7 +180,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 // Include: courses that have chunks OR are active (visible + have enrolments).
 $sql = "SELECT c.id, c.fullname,
                COUNT(ch.id) AS chunks,
-               SUM(CASE WHEN ch.embedding IS NOT NULL THEN 1 ELSE 0 END) AS embedded,
+               SUM(CASE WHEN ch.embedding IS NOT NULL OR ch.embedding_bin IS NOT NULL
+                        THEN 1 ELSE 0 END) AS embedded,
                MAX(ch.timeindexed) AS lastindexed
           FROM {course} c
           LEFT JOIN {local_ai_course_assistant_chunks} ch ON ch.courseid = c.id

--- a/tests/quantized_index_visibility_test.php
+++ b/tests/quantized_index_visibility_test.php
@@ -1,0 +1,202 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Guards that a quantized index is visible to the code that gates on it.
+ *
+ * v7.0.3 added int8/binary vector storage. A quantized row stores its vector in
+ * `embedding_bin` and leaves the JSON `embedding` column NULL. Retrieval was
+ * taught to read either column, but three predicates in front of it were not,
+ * and each failure was silent:
+ *
+ *  - `is_course_indexed()` returned false forever on a quantized index, so both
+ *    chat paths re-extracted and re-chunked the entire course before every
+ *    reply. It embedded nothing and reported "indexed 0, skipped N", so the only
+ *    symptom was latency and load — one authenticated message became a
+ *    pdftotext subprocess per PDF plus a full chunk-table scan.
+ *  - `rag_admin.php` reported 0 embedded chunks, which in turn gated off the
+ *    v7.0.3 storage projection — the feature never rendered on the quantized
+ *    indexes it exists to size.
+ *  - Two dev CLI tools saw an empty corpus.
+ *
+ * None of it fired on a float index, which is why it shipped.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_ai_course_assistant\content_indexer::is_course_indexed
+ */
+final class quantized_index_visibility_test extends \advanced_testcase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest(true);
+    }
+
+    /**
+     * Insert one chunk row.
+     *
+     * @param int $courseid
+     * @param string|null $json Value for the JSON `embedding` column.
+     * @param string|null $bin Value for the packed `embedding_bin` column.
+     * @param string $model
+     * @param string|null $dtype
+     * @return int
+     */
+    private function make_chunk(int $courseid, ?string $json, ?string $bin,
+                                string $model = 'voyage-4-large', ?string $dtype = null): int {
+        global $DB;
+        return (int) $DB->insert_record('local_ai_course_assistant_chunks', (object) [
+            'courseid'      => $courseid,
+            'cmid'          => 1,
+            'modtype'       => 'page',
+            'chunkindex'    => 0,
+            'content'       => 'Opportunity cost is the value of the next-best alternative forgone.',
+            'contenthash'   => sha1('chunk-' . $courseid . '-' . ($dtype ?? 'float')),
+            'embedding'     => $json,
+            'embedding_bin' => $bin,
+            'embed_model'   => $model,
+            'embed_dtype'   => $dtype,
+            'timecreated'   => time(),
+            'timeindexed'   => time(),
+        ]);
+    }
+
+    public function test_a_float_index_is_visible(): void {
+        $this->make_chunk(101, json_encode([0.1, 0.2]), null, 'text-embedding-3-small', 'float');
+        $this->assertTrue(content_indexer::is_course_indexed(101));
+    }
+
+    public function test_an_int8_index_is_visible(): void {
+        // The regression. Vector lives only in embedding_bin.
+        $this->make_chunk(102, null, pack('C*', 1, 2, 3, 4), 'voyage-4-large', 'int8');
+        $this->assertTrue(
+            content_indexer::is_course_indexed(102),
+            'an int8 index must not look unindexed — that makes every chat turn reindex the course'
+        );
+    }
+
+    public function test_a_binary_index_is_visible(): void {
+        $this->make_chunk(103, null, pack('C*', 0xFF, 0x00), 'voyage-4-large', 'binary');
+        $this->assertTrue(content_indexer::is_course_indexed(103));
+    }
+
+    public function test_a_dual_written_row_is_visible(): void {
+        // What a float reindex actually writes since v6.9.5: both columns.
+        $this->make_chunk(104, json_encode([0.5]), pack('g*', 0.5), 'voyage-4-large', 'float');
+        $this->assertTrue(content_indexer::is_course_indexed(104));
+    }
+
+    public function test_a_chunk_with_no_vector_at_all_is_not_indexed(): void {
+        // Extracted and chunked but never embedded — genuinely not indexed.
+        $this->make_chunk(105, null, null, 'voyage-4-large', 'int8');
+        $this->assertFalse(content_indexer::is_course_indexed(105));
+    }
+
+    public function test_an_empty_course_is_not_indexed(): void {
+        $this->assertFalse(content_indexer::is_course_indexed(106));
+    }
+
+    public function test_visibility_does_not_leak_across_courses(): void {
+        $this->make_chunk(107, null, pack('C*', 9), 'voyage-4-large', 'int8');
+        $this->assertTrue(content_indexer::is_course_indexed(107));
+        $this->assertFalse(content_indexer::is_course_indexed(108));
+    }
+
+    // ---------- source-level guards, so the next writer of a predicate is caught ----------
+
+    /**
+     * Every PHP file that queries the chunks table.
+     *
+     * @return array<string, string> relative path => source
+     */
+    private function sources(): array {
+        global $CFG;
+        $base = $CFG->dirroot . '/local/ai_course_assistant';
+        $out = [];
+        $rii = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($base));
+        foreach ($rii as $file) {
+            if ($file->isDir() || $file->getExtension() !== 'php') {
+                continue;
+            }
+            $rel = ltrim(str_replace($base, '', $file->getPathname()), '/');
+            if (strpos($rel, 'tests/') === 0) {
+                continue;
+            }
+            $out[$rel] = file_get_contents($file->getPathname());
+        }
+        return $out;
+    }
+
+    public function test_no_predicate_tests_the_json_column_alone(): void {
+        // backfill_embedding_bin.php is the one legitimate exception: it packs
+        // the float32 vector held in `embedding` into `embedding_bin`, so a row
+        // with no JSON has nothing for it to read.
+        $allowed = ['admin/cli/backfill_embedding_bin.php'];
+        $offenders = [];
+        foreach ($this->sources() as $rel => $src) {
+            if (in_array($rel, $allowed, true)) {
+                continue;
+            }
+            // Match "embedding IS NOT NULL" only where it is NOT paired with the
+            // packed column in the same predicate.
+            foreach (preg_split('/\R/', $src) as $i => $line) {
+                if (stripos($line, 'embedding IS NOT NULL') === false) {
+                    continue;
+                }
+                if (stripos($line, 'embedding_bin IS NOT NULL') !== false) {
+                    continue;
+                }
+                // Allow a multi-line predicate that continues onto the next line.
+                $next = preg_split('/\R/', $src)[$i + 1] ?? '';
+                if (stripos($next, 'embedding_bin IS NOT NULL') !== false) {
+                    continue;
+                }
+                $offenders[] = $rel . ':' . ($i + 1);
+            }
+        }
+        $this->assertSame([], $offenders,
+            'these predicates see a quantized index as empty: ' . implode(', ', $offenders));
+    }
+
+    public function test_the_hash_skip_also_compares_the_encoding(): void {
+        // Content hash covers the text, not the model or dtype that vectorized
+        // it. Without an encoding comparison, "change embed_dtype then reindex"
+        // — the documented way to adopt quantization — silently does nothing.
+        $src = $this->sources()['classes/content_indexer.php'] ?? '';
+        $this->assertNotSame('', $src);
+
+        $this->assertMatchesRegularExpression(
+            '/get_record\(\s*\'local_ai_course_assistant_chunks\'.*?embed_model,\s*embed_dtype\'/s',
+            $src,
+            'the hash-skip lookup must select embed_model and embed_dtype to compare them'
+        );
+        $this->assertMatchesRegularExpression(
+            '/embed_model\s*===\s*\(string\)\s*\$modelname/',
+            $src,
+            'the hash-skip must re-embed when the stored model differs from this run'
+        );
+        $this->assertMatchesRegularExpression(
+            '/normalize_dtype\(\$existing->embed_dtype\s*\?\?\s*null\)\s*===\s*\$dtype/',
+            $src,
+            'the hash-skip must re-embed when the stored dtype differs from this run'
+        );
+    }
+}

--- a/tests/quantized_index_visibility_test.php
+++ b/tests/quantized_index_visibility_test.php
@@ -176,6 +176,55 @@ final class quantized_index_visibility_test extends \advanced_testcase {
             'these predicates see a quantized index as empty: ' . implode(', ', $offenders));
     }
 
+    public function test_no_vector_is_decoded_from_the_json_column_alone(): void {
+        // A widened WHERE clause is only half the fix. run_rag_fixture_benchmark
+        // shipped with the predicate corrected but the field list still
+        // 'id, content, embedding' and the loop still json_decode()ing that
+        // column — so on a quantized index every newly-admitted row was fetched
+        // and immediately discarded, and the tool reported "Loaded 0 embedded
+        // chunks" on exactly the indexes the predicate was widened to support.
+        //
+        // The predicate scan above cannot see that, because the predicate was
+        // right. So: any file that decodes a vector out of the JSON column must
+        // also know about the packed column.
+        $offenders = [];
+        foreach ($this->sources() as $rel => $src) {
+            // rag_retriever implements decode_vector(), so it necessarily
+            // references both columns; it is covered by its own tests.
+            if ($rel === 'classes/rag_retriever.php') {
+                continue;
+            }
+            if (!preg_match('/json_decode\s*\(\s*\$\w+->embedding\b/', $src)) {
+                continue;
+            }
+            if (strpos($src, 'embedding_bin') === false) {
+                $offenders[] = $rel;
+            }
+        }
+        $this->assertSame([], $offenders,
+            'these files decode a vector from the JSON column without knowing the packed column exists: '
+            . implode(', ', $offenders));
+    }
+
+    public function test_the_benchmark_harness_selects_what_it_decodes(): void {
+        $src = $this->sources()['admin/cli/run_rag_fixture_benchmark.php'] ?? '';
+        $this->assertNotSame('', $src);
+
+        // The chunk loader must select both storage columns and the encoding,
+        // and route them through the retriever's decoder rather than a bare
+        // json_decode of one column.
+        $this->assertStringContainsString(
+            "'id, content, embedding, embedding_bin, embed_dtype'",
+            $src,
+            'the chunk loader must select the packed column and the dtype, not just the JSON column'
+        );
+        $this->assertStringContainsString(
+            'rag_retriever::decode_vector(',
+            $src,
+            'the chunk loader must decode the way retrieval does'
+        );
+    }
+
     public function test_the_hash_skip_also_compares_the_encoding(): void {
         // Content hash covers the text, not the model or dtype that vectorized
         // it. Without an encoding comparison, "change embed_dtype then reindex"

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_ai_course_assistant';
-$plugin->version = 2026082200;
+$plugin->version = 2026082300;
 $plugin->requires = 2024100700; // Moodle 4.5+.
 $plugin->supported = [405, 503]; // Tested on Moodle 4.5 through 5.3dev.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '7.0.3';
+$plugin->release = '7.0.4';


### PR DESCRIPTION
## What broke

v7.0.3 added int8/binary vector storage. A quantized chunk keeps its vector in `embedding_bin` and leaves the JSON `embedding` column null. Retrieval was taught to read either column — **the three checks standing in front of it were not**, and every failure was silent.

### 1. Every chat turn re-indexed the whole course

`is_course_indexed()` tested the JSON column alone, so on a quantized index it returned false permanently. Both chat paths (`sse.php`, `classes/external/send_message.php`) re-index when that returns false, so one student message re-extracted and re-chunked the entire course before the reply: a `pdftotext` subprocess per PDF, DOCX/PPTX parsing, a full chunk-table scan, and outbound HTTP per media module when transcript fetching is on.

Because the v7.0.3 hash-skip fix works, it then embedded nothing and reported `indexed 0, skipped N` — no error anywhere, just latency and load amplified from one cheap authenticated POST.

### 2. Changing the precision and re-indexing did nothing

The setting's description says a precision change requires a full re-index. The chunk-level skip compared the content hash only, and a hash covers the text — not the model or encoding that vectorized it. So the documented adoption path was a no-op.

Worse for `binary`: the index stayed float, and the retriever then rejected every row as an encoding mismatch, returning no chunks on every query behind a `DEBUG_NORMAL` line invisible in production. The tutor quietly stopped citing course content.

The skip now selects and compares `embed_model` and `embed_dtype`, and re-embeds when either differs from what the run writes.

### 3. The admin page hid its own new feature

`rag_admin.php` counted embedded chunks with the same stale predicate, so a fully-embedded quantized index read as 0 embedded. Every course was flagged un-embedded, and because the v7.0.3 storage projection is gated on that count, the projection never rendered on the quantized indexes it exists to size — while the storage card beside it correctly reported the megabytes.

Two dev CLI tools carried the same predicate. `admin/cli/backfill_embedding_bin.php` keeps the JSON-only predicate **deliberately** and now documents why: it packs float32 out of `embedding`, so a row with no JSON has nothing to read.

## Why CI was green

None of this fires on a float index, which is every production site today. v7.0.3 passed a 13/13 matrix without touching any of it.

## Testing

- `tests/quantized_index_visibility_test.php` — 9 tests: int8, binary and dual-written float visible to `is_course_indexed()`; a chunk with no vector correctly not indexed; no cross-course leakage; plus source-level guards for JSON-only predicates and for the encoding comparison in the skip.
- **Verified the test has teeth:** reverting only the deployed copy to the pre-fix predicate fails 4 of 9, with the source guard naming `content_indexer.php:497`. Restoring it returns 9/9.
- No regressions: `embedding_compat_test` 20/20, `embed_query_model_test` 9/9, `chunk_vector_writers_test` 5/5, `rag_quantization_test` 29/29.
- Validators: 36 passed, 0 failed, 0 skipped. PHP lint clean on all modified files.
- No `amd/` change, so no AMD rebuild required.

## Known limitation, unchanged

`voyage-context-4` remains wired into indexing only — querying and the drift-reindex task still use the plain embeddings endpoint, so both sides report the same model name and the comparability guard cannot detect the mismatch. Leave `embed_model` off `voyage-context-4`; the plain `voyage-4` family is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)