### PR TITLE
ci: grant the code-review workflow the shell utilities its subagents pipe through

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -99,10 +99,37 @@ jobs:
           # match anything, so every gh call was still denied: 28 denials, $2.34
           # billed, nothing posted. Keep every pattern space-free.
           #
+          # The read-only shell utilities are here because Claude Code matches a
+          # compound command segment by segment: `gh pr diff 207 | head -200`
+          # needs BOTH `gh` and `head` granted or the whole call is denied. The
+          # review's subagents pipe gh output constantly, which is the most
+          # likely source of the 26 denials on the v7.2.1 run (11 turns, $1.61,
+          # nothing posted, `--comment` correctly present). None of these
+          # binaries can execute code from the checked-out branch, so the
+          # untrusted-head property the gh scoping protects is unaffected --
+          # unlike a blanket Bash grant, or a grant of php/npm/make.
+          #
           # Edit and Write are deliberately absent. A reviewer reports; it does
           # not rewrite the branch it is reviewing.
           claude_args: >-
             --allowedTools
-            Task,Read,Grep,Glob,TodoWrite,Bash(gh:*),mcp__github_inline_comment__create_inline_comment
+            Task,Read,Grep,Glob,TodoWrite,Bash(gh:*),Bash(git:*),Bash(jq:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(grep:*),Bash(sort:*),Bash(uniq:*),Bash(cut:*),Bash(tr:*),Bash(find:*),Bash(ls:*),Bash(echo:*),mcp__github_inline_comment__create_inline_comment
+
+          # This has now been diagnosed five times from a log that does not say
+          # what was denied -- the action hides the SDK output by default, so
+          # every round has been a guess, and three of the guesses were wrong.
+          # Turning it on ends that: the next run names the denied calls
+          # directly. The repository is public and the review output is posted
+          # publicly anyway, so there is nothing here the log did not already
+          # contain; the API key is masked by the action, not by this flag.
+          show_full_output: true
+          # One more way this posts nothing, and it is in the command, not here:
+          # step 1 of /code-review launches a haiku agent that stops the whole
+          # review if the PR is closed, is a draft, looks automated, or if
+          # "claude has already commented on this PR". So asking @claude for a
+          # review in a comment and then pushing again means the second review
+          # exits at step 1 by design. Not a bug, but indistinguishable from
+          # the failure modes above unless you know to look for it.
+          #
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
The v7.2.1 review ran green, billed \$1.61 across 11 turns, and posted nothing — `permission_denials_count: 26`, with `--comment` correctly present. That rules out all four causes the workflow file already documents.

Claude Code matches a compound command **segment by segment**: `gh pr diff 207 | head -200` needs both `gh` and `head` granted or the whole call is denied. The review's subagents pipe `gh` output constantly.

None of the binaries added here can execute code from the checked-out branch, so the untrusted-head property the `gh` scoping protects is unaffected — unlike a blanket `Bash` grant, or a grant of `php`/`npm`/`make`.

`show_full_output: true` is on because this has now been diagnosed five times from a log that does not say what was denied, and three of those guesses were wrong. The repository is public and the review output is posted publicly anyway; the API key is masked by the action, not by this flag.

Also documents a **fifth** way the review posts nothing, which lives in the command rather than the workflow: step 1 of `/code-review` stops the whole run if claude has already commented on the PR. Asking `@claude` for a review and then pushing again makes the next review exit at step 1 by design.

**This PR cannot test its own change** — the action requires the workflow file to match the default branch — so it is split out ahead of #208, which will be the first run to exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)