### PR TITLE
v7.2.9: six fixes from the 7.2.7 staging pass

### DIFF
--- a/.drafts/v7.2.9-release-notes-and-walkthrough.md
+++ b/.drafts/v7.2.9-release-notes-and-walkthrough.md
@@ -1,0 +1,137 @@
+# SOLA v7.2.9 — Release Notes, Feature Summary, and 20-minute Admin Walkthrough
+
+## Part 1: Release Notes (2 September 2026)
+
+**Six fixes from the final 7.2.7 staging pass.** Two arrived as authored patches
+and were applied as written (S9, S10). The other four were implemented here from
+their descriptions, because the patches never reached the machine across five
+delivery attempts — they may differ in shape from the originals.
+
+### Fixed
+
+- **S14 (high) — course front matter was invisible to SOLA, on every course.**
+  The extractor walked a course's activities only, and the prompt path appended
+  a section summary just when it was under 200 characters. ARTH101 states its
+  five-step analysis system in a 2,037-character section-0 summary, so the
+  assistant could not see it: 258 of 258 chunks were module-derived and a live
+  turn declined to answer. Course and section summaries are now indexed through
+  the same paths as activities, emitted as a single document so the shared
+  upsert key on nullable `cmid` cannot collide.
+
+- **S12 (high) — escalation had been switched off by the 7.2.7 FAQ change.** The
+  `[NEEDS_ESCALATION]` instruction was gated on the FAQ being inline. Making the
+  FAQ retrievable empties that variable on exactly the sites where retrieval
+  works, so the instruction vanished and escalation could never fire. Now gated
+  on whether escalation is actually available.
+
+- **S11 — a turn refused by the quiz lock wrote before it refused**, leaving a
+  question with no answer in the learner's transcript and a `message_sent` audit
+  row for a blocked turn.
+
+- **S13 — high contrast hid four settings labels** at a measured 1:1 contrast
+  ratio, with the panel's link at 1.22:1. Now 21:1 and 17.2:1.
+
+- **S9 — compressed citation groups** reached learners as raw markup.
+
+- **S10 — the prompt metrics page** stopped advertising the deprecated
+  auto-tuner.
+
+### What administrators should do after upgrading
+
+**Reindex.** S14 changes what gets indexed, so existing indexes have no
+course-level content until courses are reindexed. On a site where many courses
+are enabled but unindexed, that reindex is also what makes them grounded at all
+— on Saylor staging at the time of the pass, 350 of 350 courses were enabled and
+136 indexed, meaning 214 answered ungrounded. Reindexing before this release
+would not have been enough on its own.
+
+**Check escalation actually fires** if you rely on it. S12 means it has been
+silently unavailable on any site where the retrievable FAQ was active.
+
+### Verification
+
+1111 tests passing (up 9), 5139 assertions, 0 failures. Every new test was
+confirmed to fail without its fix. Validators 36/36. PHP lint clean across 475
+files. JS citation check passes, including its stale-build guard.
+
+### Known follow-ups
+
+- `rag_drift_detector` watches page and book modification times only, so editing
+  a course or section summary does not trigger the automatic reindex. Reported
+  alongside S14 and not addressed here.
+- `anonymizer::name()` is not anonymization: a constant salt in open-source code
+  over a 9,999-label space is trivially reversible and collides (two real user
+  ids verified rendering the same label). A keyed HMAC with a per-session label
+  space fixes both halves, but the right shape is a decision, so it is not
+  patched.
+- PostgreSQL remains uncovered by manual testing in this series, though CI
+  exercises it.
+
+## Part 2: Key SOLA Features
+
+Carried forward from v7.2.3. No feature changes. Admin settings added since
+then: System prompt budget mode (7.2.4), quiz-lock scope (7.2.5), and a
+settings-page warning when auto budget mode has no context window to derive
+from (7.2.7). One new admin CLI, `audit_config_log_secrets.php` (7.2.4). The
+budget auto-tuner is deprecated as of 7.2.6 and stands down unless the budget
+mode is `fixed`.
+
+---
+
+## Part 3: Admin Walkthrough
+
+### 1. Finish a quiz and immediately ask a question
+
+Start an attempt on a quiz in a course, confirm the drawer is disabled and shows
+the integrity notice, submit the attempt, then send a message in the same course.
+
+**Expected:** it answers immediately. The lock lifts on submission, not when a
+freshness window expires. Before this release it would keep refusing — and would
+also refuse in every other course you opened.
+
+### 2. Confirm the lock does not follow you between courses
+
+With an attempt open in course A, open the assistant in course B.
+
+**Expected:** course B works normally. Only course A is locked. If you want the
+old site-wide behavior, Site administration → AI Course Assistant → *How far the
+lock reaches* → **Every course**.
+
+Worth knowing why the default changed: an abandoned attempt stays `inprogress`
+forever, so under site-wide scope one forgotten quiz anywhere in a learner's
+history disables the assistant in all their courses permanently.
+
+### 3. Check that the input is disabled exactly when the server will refuse
+
+While an attempt is open, open the drawer in that course.
+
+**Expected:** the textarea and all six starter chips are disabled, and the notice
+names the remedy — submit or close the attempt. There should be no state where
+the box looks usable and the send is then refused.
+
+### 4. Reload a conversation that had a failed turn
+
+Open a course conversation with history.
+
+**Expected:** zero occurrences of `core\`, `exception`, or `moodle_` anywhere in
+the transcript. Old rows stored before 7.2.4 render the same learner-facing
+notice as new ones.
+
+### 5. Analytics with All courses selected
+
+Site administration → Analytics, picker on **All courses**.
+
+**Expected:** TOTAL ENROLLED carries a real number, at least as large as any
+single course and at least as large as ACTIVE AI USERS. The two measure
+different things: TOTAL ENROLLED is active enrollments, ACTIVE AI USERS is
+people who actually used SOLA, so the gap between them is your adoption rate.
+MSGS / ACTIVE USER divides by the second of those, not the first — which is why
+both tiles were renamed in this release.
+
+### 6. Read the privacy notice next to the audit log
+
+Open the learner privacy notice, then the admin audit log.
+
+**Expected:** the notice says SOLA keeps no record of its own of your name, and
+that a name shown alongside SOLA data comes from your existing Moodle account.
+That should read as consistent with the audit log showing full names.

--- a/classes/content_extractor.php
+++ b/classes/content_extractor.php
@@ -88,6 +88,76 @@ TXT;
     ];
 
     /**
+     * Extract the course-level text a course carries outside its activities:
+     * the course summary and every section summary.
+     *
+     * S14, found on staging 2026-09-02. Nothing indexed these. The extractor
+     * walked $modinfo->get_cms() only, and the prompt path appended a section
+     * summary just when it was under 200 characters (below a 2,500-char course
+     * overview backstop). ARTH101 states its five-step analysis system in a
+     * 2,037-character section-0 summary, so the assistant could not see it: 258
+     * of 258 chunks were module-derived, and a live turn declined to answer.
+     * Every course with substantive front matter had the same hole.
+     *
+     * Returned as ONE logical document rather than one per section, and that is
+     * deliberate. Course-level rows carry cmid = null (the schema documents the
+     * column as "null = course-level content"), so the indexer's upsert key of
+     * courseid + cmid + chunkindex is identical for every course-level document
+     * in a course. Emitting several would make section 2's chunk 0 delete
+     * section 1's chunk 0 on every run. One document means one continuous
+     * chunkindex range and no collision to fix.
+     *
+     * @param int $courseid
+     * @return array|null ['cmid'=>null, 'modtype'=>'course', 'title'=>string,
+     *                     'section'=>'', 'text'=>string] or null when the course
+     *                     carries no substantial front matter.
+     */
+    public static function extract_course_level(int $courseid): ?array {
+        global $DB;
+
+        $course = $DB->get_record('course', ['id' => $courseid], 'id, fullname, summary', IGNORE_MISSING);
+        if (!$course) {
+            return null;
+        }
+
+        $parts = [];
+
+        $coursesummary = trim(html_to_text((string) ($course->summary ?? ''), 0, false));
+        if ($coursesummary !== '') {
+            $parts[] = "Course overview\n" . $coursesummary;
+        }
+
+        // Section summaries, in course order, each labelled with its own name so
+        // a retrieved chunk still says which part of the course it came from.
+        $modinfo = get_fast_modinfo($courseid);
+        foreach ($modinfo->get_section_info_all() as $section) {
+            $summary = trim(html_to_text((string) ($section->summary ?? ''), 0, false));
+            if ($summary === '') {
+                continue;
+            }
+            $name = get_section_name($courseid, $section);
+            $parts[] = trim($name) . "\n" . $summary;
+        }
+
+        if (empty($parts)) {
+            return null;
+        }
+
+        $text = implode("\n\n", $parts);
+        if (!self::is_indexable_text($text)) {
+            return null;
+        }
+
+        return [
+            'cmid'    => null,
+            'modtype' => 'course',
+            'title'   => (string) $course->fullname,
+            'section' => '',
+            'text'    => $text,
+        ];
+    }
+
+    /**
      * Extract text content from all supported modules in a course.
      *
      * @param int $courseid
@@ -170,6 +240,15 @@ TXT;
                 'section' => $sectionnames[$cm->id] ?? '',
                 'text'    => $text,
             ];
+        }
+
+        // S14: course-level front matter is indexed alongside the activities, so
+        // it flows through the same chunking, embedding and prune paths. Placed
+        // first because a course overview is the most general context a learner
+        // question can match against.
+        $courselevel = self::extract_course_level($courseid);
+        if ($courselevel !== null) {
+            array_unshift($results, $courselevel);
         }
 
         return ['modules' => $results, 'skipped' => $skipped];

--- a/classes/context_builder.php
+++ b/classes/context_builder.php
@@ -601,6 +601,18 @@ class context_builder {
         // must keep getting its FAQ rather than silently losing it to a stale
         // background index.
         $faq = faq_manager::is_retrievable($courseid) ? '' : faq_manager::get_faq_for_prompt();
+        // v7.2.9 (S12): the escalation marker is gated on escalation being
+        // AVAILABLE, not on the FAQ happening to be inline.
+        //
+        // It used to read `!empty($faq)`, which was harmless while the FAQ was
+        // always injected. Making the FAQ retrievable in 7.2.7 empties $faq on
+        // exactly the sites where retrieval works, so the instruction vanished
+        // from the prompt, the model stopped emitting [NEEDS_ESCALATION], and
+        // sse.php -- which requires that marker tail-anchored -- could never
+        // escalate. A privacy notice promising human handover was left with no
+        // path to reach one, and nothing logged a failure because nothing
+        // failed.
+        $canescalate = \local_ai_course_assistant\zendesk_client::is_enabled();
         if (!empty($faq)) {
             $sections[] = new section(
                 'faq',
@@ -617,7 +629,7 @@ class context_builder {
             'output_markers',
             section::CAT_MARKERS,
             90,
-            self::get_marker_instructions($ragmode, $offtopicon, !empty($faq)),
+            self::get_marker_instructions($ragmode, $offtopicon, $canescalate),
             0
         );
 
@@ -821,7 +833,7 @@ class context_builder {
         ) {
             foreach ($sections as $sec) {
                 if ($sec->name === 'output_markers') {
-                    $sec->content = self::get_marker_instructions(false, $offtopicon, !empty($faq));
+                    $sec->content = self::get_marker_instructions(false, $offtopicon, $canescalate);
                 }
             }
             $assembled = prompt_builder::assemble($sections, $budget);
@@ -1932,11 +1944,11 @@ class context_builder {
      *
      * @param bool $hasrag Whether RAG chunks are present (controls citation marker).
      * @param bool $offtopic Whether off-topic detection is enabled.
-     * @param bool $hasfaq Whether FAQ content is appended.
+     * @param bool $canescalate Whether a support escalation can actually be opened.
      * @param bool $hasnext Whether SOLA_NEXT suggestions are wired (always true today).
      * @return string
      */
-    private static function get_marker_instructions(bool $hasrag, bool $offtopic, bool $hasfaq, bool $hasnext = true): string {
+    private static function get_marker_instructions(bool $hasrag, bool $offtopic, bool $canescalate, bool $hasnext = true): string {
         $lines = ["\n\n## Output markers\nUse exactly the markers below when applicable, on their own line at the very end of your response unless otherwise noted. Markers are stripped before display."];
         if ($hasrag) {
             $lines[] = "- `[[c:N]]` inline (not at end) — cite a retrieved passage you actually used. Example: \"Photosynthesis occurs in chloroplasts [[c:0]].\"";
@@ -1948,8 +1960,8 @@ class context_builder {
         if ($offtopic) {
             $lines[] = "- `[OFF_TOPIC]` — only if the message is clearly unrelated to this course or learning.";
         }
-        if ($hasfaq) {
-            $lines[] = "- `[NEEDS_ESCALATION]` — only on a support/admin question the FAQ does not cover.";
+        if ($canescalate) {
+            $lines[] = "- `[NEEDS_ESCALATION]` — only on a support/admin question the course material and support FAQ do not answer.";
         }
         return implode("\n", $lines);
     }

--- a/classes/rag_retriever.php
+++ b/classes/rag_retriever.php
@@ -628,11 +628,17 @@ class rag_retriever {
         // ordinary case, and exactly where a learner asks "how do I get my
         // certificate?" -- reached the model with the FAQ in neither the prompt
         // nor the retrieved set.
+        // v7.2.9 (S14): course-level rows are exempt for the same reason. The
+        // course summary and section summaries carry cmid = null (the schema
+        // documents it as "null = course-level content"), which reads back as 0
+        // here, so without this they would be discarded on exactly the
+        // module-page turns where a learner asks about the course as a whole.
         $faqtype = \local_ai_course_assistant\faq_manager::MODTYPE;
+        $exempt = [$faqtype, 'course'];
 
         $docpresent = false;
         foreach ($ranked as $row) {
-            if (($row['modtype'] ?? '') === $faqtype) {
+            if (in_array($row['modtype'] ?? '', $exempt, true)) {
                 continue;
             }
             if ((int) ($row['cmid'] ?? 0) === $currentcmid) {
@@ -644,7 +650,7 @@ class rag_retriever {
         // Single pass, so the caller's rank order survives across both partitions.
         $out = [];
         foreach ($ranked as $row) {
-            if (($row['modtype'] ?? '') === $faqtype) {
+            if (in_array($row['modtype'] ?? '', $exempt, true)) {
                 $out[] = $row;
                 continue;
             }

--- a/tests/course_level_indexing_test.php
+++ b/tests/course_level_indexing_test.php
@@ -1,0 +1,136 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+
+/**
+ * Course-level front matter must be indexed and retrievable (S14).
+ *
+ * Found on staging 2026-09-02. The extractor walked $modinfo->get_cms() only,
+ * so the course summary and every section summary were invisible to SOLA on
+ * every course; the prompt path appended a section summary only when it was
+ * under 200 characters. ARTH101 states its five-step analysis system in a
+ * 2,037-character section-0 summary, and the assistant could not see it.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_ai_course_assistant\content_extractor::extract_course_level
+ */
+final class course_level_indexing_test extends \advanced_testcase {
+
+    /** @var string Stands in for ARTH101's section-0 summary: long enough that the old 200-char rule dropped it. */
+    private const LONG_SECTION_SUMMARY =
+        'The five-step system for analyzing a work of art. Description: what you literally see. '
+        . 'Analysis: how the formal elements work together. Context: when and why it was made. '
+        . 'Meaning: what it communicates to a viewer. Judgment: A critical assessment of how well '
+        . 'the work achieves what it sets out to do, argued from the previous four steps rather '
+        . 'than from taste alone.';
+
+    /**
+     * The course summary and a long section summary both reach the extractor.
+     */
+    public function test_course_and_section_summaries_are_extracted(): void {
+        $this->resetAfterTest();
+        $course = $this->getDataGenerator()->create_course([
+            'summary' => '<p>An introduction to art appreciation and visual analysis.</p>',
+            'summaryformat' => FORMAT_HTML,
+            'numsections' => 2,
+        ]);
+
+        // Give section 0 the long summary the old code path dropped.
+        global $DB;
+        $DB->set_field('course_sections', 'summary', self::LONG_SECTION_SUMMARY,
+            ['course' => $course->id, 'section' => 0]);
+        rebuild_course_cache($course->id, true);
+
+        $item = content_extractor::extract_course_level((int) $course->id);
+
+        $this->assertNotNull($item, 'course-level front matter was not extracted at all');
+        $this->assertNull($item['cmid'], 'course-level rows must carry cmid = null');
+        $this->assertSame('course', $item['modtype']);
+        $this->assertStringContainsString('art appreciation', $item['text'],
+            'the course summary is missing from the extracted text');
+        $this->assertStringContainsString('Judgment: A critical', $item['text'],
+            'the long section summary is missing -- this is the ARTH101 failure');
+        $this->assertGreaterThan(200, strlen($item['text']),
+            'the old prompt path only kept section summaries under 200 chars');
+    }
+
+    /**
+     * A course with no summaries yields nothing rather than an empty chunk.
+     */
+    public function test_course_without_front_matter_yields_null(): void {
+        $this->resetAfterTest();
+        $course = $this->getDataGenerator()->create_course(['summary' => '', 'numsections' => 1]);
+        $this->assertNull(content_extractor::extract_course_level((int) $course->id));
+    }
+
+    /**
+     * Course-level content is emitted as ONE document.
+     *
+     * Course-level rows share the indexer's upsert key (courseid + cmid +
+     * chunkindex) because cmid is null for all of them. Two documents would
+     * make the second one's chunk 0 delete the first one's chunk 0 on every
+     * run. One document means one continuous index range and no collision.
+     */
+    public function test_course_level_is_a_single_document_so_chunkindex_cannot_collide(): void {
+        $this->resetAfterTest();
+        $course = $this->getDataGenerator()->create_course([
+            'summary' => 'Overview text for the course, long enough to be indexable on its own.',
+            'summaryformat' => FORMAT_HTML,
+            'numsections' => 3,
+        ]);
+        global $DB;
+        foreach ([0, 1, 2] as $s) {
+            $DB->set_field('course_sections', 'summary',
+                "Section {$s} summary. " . self::LONG_SECTION_SUMMARY,
+                ['course' => $course->id, 'section' => $s]);
+        }
+        rebuild_course_cache($course->id, true);
+
+        $modules = content_extractor::extract_course_modules((int) $course->id);
+        $courselevel = array_values(array_filter($modules, static function ($m) {
+            return ($m['modtype'] ?? '') === 'course';
+        }));
+
+        $this->assertCount(1, $courselevel,
+            'course-level content must be one document; several would collide on chunkindex');
+        foreach ([0, 1, 2] as $s) {
+            $this->assertStringContainsString("Section {$s} summary.", $courselevel[0]['text'],
+                "section {$s}'s summary is missing from the single course-level document");
+        }
+    }
+
+    /**
+     * Retrieval must not discard course-level rows on a module-page turn.
+     *
+     * They read back with cmid 0, so the document filter would drop them on
+     * exactly the turns where a learner asks about the course as a whole.
+     */
+    public function test_course_level_rows_survive_document_scoping(): void {
+        $this->resetAfterTest();
+        $courserow = ['cmid' => 0, 'modtype' => 'course', 'rank' => 0.9];
+        $onpage    = ['cmid' => 42, 'modtype' => 'page', 'rank' => 0.8];
+        $offpage   = ['cmid' => 99, 'modtype' => 'page', 'rank' => 0.7];
+        $ranked = [$courserow, $onpage, $offpage];
+
+        $this->assertSame([$courserow, $onpage],
+            rag_retriever::scope_to_document($ranked, 42, 'document_first'));
+        $this->assertSame([$courserow],
+            rag_retriever::scope_to_document($ranked, 7, 'document_only'));
+    }
+}

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_ai_course_assistant';
-$plugin->version = 2026090100;
+$plugin->version = 2026090200;
 $plugin->requires = 2024100700; // Moodle 4.5+.
 $plugin->supported = [405, 503]; // Tested on Moodle 4.5 through 5.3dev.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '7.2.8';
+$plugin->release = '7.2.9';


### PR DESCRIPTION
Six fixes from the final staging pass on 7.2.7.

**Provenance note:** S9 and S10 arrived as authored patches (`0001`, `0002`) and
were applied as written. S11, S12, S13 and S14 were implemented here from their
descriptions — the patches for them (`0003`, `0004`, `0005`, later a git bundle)
never reached this machine across five delivery attempts and five checked
locations. They may differ in shape from the originals.

## Fixed

| # | Defect |
|---|---|
| **S14** (high) | Course and section summaries were invisible to SOLA on **every course**. The extractor walked activities only; the prompt path kept a section summary only under 200 chars. ARTH101's five-step system lives in a 2,037-char section-0 summary — 258/258 chunks were module-derived and a live turn declined to answer. |
| **S12** (high) | The `[NEEDS_ESCALATION]` instruction was gated on the FAQ being inline. Making the FAQ retrievable in 7.2.7 emptied that variable on exactly the sites where retrieval works, so escalation could never fire. **A regression introduced by my own C1 change.** |
| **S11** | A turn refused by the quiz lock had already persisted the learner's message and written a `message_sent` audit row. |
| **S13** | High contrast rendered four settings labels at a measured **1:1** ratio (white on white); the panel link at 1.22:1. |
| **S9** | `[[c:2], [c:4]]` citation groups reached learners as raw markup. |
| **S10** | The metrics page still invited admins to enable the deprecated auto-tuner. |

## On S14's single-document choice

`chunks.cmid` is nullable and documented "null = course-level content" — the
schema anticipated this. That nullability is also the trap: every course-level
row shares the indexer's upsert key (`courseid + cmid + chunkindex`), so one
document per section would make section 2's chunk 0 delete section 1's chunk 0
on every run. Course-level content is emitted as **one** document with a single
continuous index range, so the collision cannot arise rather than being fixed
after the fact.

Course-level rows are also exempt from `scope_to_document()`, for the same
reason FAQ rows are — they read back with `cmid 0` and would be discarded on
exactly the module-page turns where a learner asks about the course as a whole.
That trap has now caught two features, so the exemption is a list.

## Corrections to the report, made while implementing

- S11 said to "check the lock before persisting, as sse.php does". **sse.php did
  not do that** — it persisted at 341, audited at 357, checked at 486.
  Enforcement actually lives in `base_provider`, later still, and the web service
  had no check at all.
- The intro-screen half of C3 says to "make the feature list conditional". It
  already is — on `hasTts`, while the affordance is gated on the voice tab. Two
  different signals. Not changed here; it needs a new root data attribute.

## Testing

1111 passing (up 9), 5139 assertions, 0 failures. Validators 36/36. Lint clean
across 475 files. JS citation check passes including its stale-build guard.
**Every new test was confirmed to fail without its fix**, including the two S14
tests that error on the missing method.

## For administrators

**A reindex is required** — S14 changes what gets indexed, so existing indexes
carry no course-level content until courses are reindexed. And **check
escalation fires** if you depend on it; S12 means it has been silently
unavailable wherever the retrievable FAQ was active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)