### PR TITLE
fix(phpdoc): unblock CI — the sniff cannot parse a generic array shape on @param

### DIFF
--- a/classes/provider/batch_capable_interface.php
+++ b/classes/provider/batch_capable_interface.php
@@ -82,9 +82,10 @@ interface batch_capable_interface {
     /**
      * Submit one or more chat completions for offline processing.
      *
-     * @param array<string, array{systemprompt: string, messages: array, options?: array}> $requests
-     *        Keyed by custom_id. The key is echoed back by fetch_batch(), and is
-     *        how a multi-request batch is demultiplexed on collection.
+     * @param array $requests Keyed by custom_id, each entry
+     *        ['systemprompt' => string, 'messages' => array, 'options' => array (optional)].
+     *        The key is echoed back by fetch_batch(), and is how a
+     *        multi-request batch is demultiplexed on collection.
      * @return string Provider batch id, to be persisted and passed to fetch_batch().
      * @throws \moodle_exception When the submission itself fails.
      */

--- a/tests/phpdoc_param_consistency_test.php
+++ b/tests/phpdoc_param_consistency_test.php
@@ -74,6 +74,22 @@ final class phpdoc_param_consistency_test extends \basic_testcase {
             }
             foreach ($ms as $m) {
                 [$whole, $doc, $name, $sig] = $m;
+                $line = substr_count(substr($src, 0, strpos($src, $whole)), "\n") + 1;
+
+                // A generic type or array shape on a param tag reads as
+                // undocumented to the Moodle sniff, so it must be flagged.
+                // This check MUST run before the "no param tags" bail below:
+                // the extraction regex there is '\S+\s+\$name', so a type
+                // containing a space -- array<string, array{...}> -- yields no
+                // match at all, $documented comes back empty, and the function
+                // is skipped before ever reaching this check. That blind spot
+                // is how the submit_batch() generic reached CI in v7.4.4.
+                if (preg_match_all('/@param\s+\S*[<{][^$]*\$(\w+)/', $doc, $gm)) {
+                    $offenders[] = sprintf('%s:%d %s() uses a generic type on @param $%s',
+                        $path, $line, $name, implode(', $', $gm[1]));
+                    continue;
+                }
+
                 preg_match_all('/@param\s+\S+\s+\$(\w+)/', $doc, $dm);
                 $documented = $dm[1];
                 if (!$documented) {
@@ -84,18 +100,6 @@ final class phpdoc_param_consistency_test extends \basic_testcase {
                 $checked++;
                 preg_match_all('/\$(\w+)/', $sig, $sm);
                 $actual = $sm[1];
-                $line = substr_count(substr($src, 0, strpos($src, $whole)), "\n") + 1;
-
-                // A generic type on a param tag reads as undocumented to the
-                // Moodle sniff, so it must be flagged even though this
-                // scanner's own regex parses it happily and would otherwise
-                // see the parameter as documented and matching. Checking the
-                // scanner against a planted example is what caught this.
-                if (preg_match_all('/@param\s+\S*<[^$]*\$(\w+)/', $doc, $gm)) {
-                    $offenders[] = sprintf('%s:%d %s() uses a generic type on @param $%s',
-                        $path, $line, $name, implode(', $', $gm[1]));
-                    continue;
-                }
 
                 $dupes = array_keys(array_filter(array_count_values($documented), fn($n) => $n > 1));
                 if ($dupes) {

--- a/tests/phpdoc_param_consistency_test.php
+++ b/tests/phpdoc_param_consistency_test.php
@@ -76,6 +76,12 @@ final class phpdoc_param_consistency_test extends \basic_testcase {
                 [$whole, $doc, $name, $sig] = $m;
                 $line = substr_count(substr($src, 0, strpos($src, $whole)), "\n") + 1;
 
+                // The Moodle PHPDoc Checker (moodlehq/moodle-local_moodlecheck)
+                // is the authority here, not this test: it gates CI, and it
+                // cannot parse a generic or an array shape on @param. Do not
+                // relax this check to allow the modern annotation style --
+                // that puts main straight back in the red.
+                //
                 // A generic type or array shape on a param tag reads as
                 // undocumented to the Moodle sniff, so it must be flagged.
                 // This check MUST run before the "no param tags" bail below:


### PR DESCRIPTION
## Why

**`main` is red, and has been since v7.4.4 shipped.** The Moodle PHPDoc Checker fails on every CI job:

```
classes/provider/batch_capable_interface.php
Line 85: Phpdocs for function batch_capable_interface::submit_batch
         has incomplete parameters list (error)
```

This is not a flake and it is not caused by any open PR. It is in the released v7.4.4 tree. It is currently the **only** failing step on #224 as well, which is otherwise green — that PR is blocked entirely by this bug, not by its own changes.

## The actual cause

The docblock *looks* complete — `@param`, `@return` and `@throws` are all present — which is what made this hard to read. Two plausible theories were tested and are both **wrong**: it is not the wrapped description line, and it is not the internal whitespace.

The real cause is that the checker has **no support for PHPStan/Psalm generics or array shapes on `@param`**, via two independent mechanisms in `moodlehq/moodle-local_moodlecheck`:

1. `local_moodlecheck_phpdocs::get_params()` (`file.php:1176`) splits each tag with `preg_split('/\s+/', $token, 3)` into `type $name description`. Any whitespace *inside* the type shifts `$name` out of slot 1.
2. `local_moodlecheck_functionarguments()` (`rules/phpdocs_basic.php`) then does a **string equality** of the documented type against the PHP typehint, with exactly one exemption: an `array` hint accepts a documented `X[]`. Neither `array<…>` nor `array{…}` is accepted.

So collapsing the whitespace would *not* have helped. Measured against the real checker:

| `@param` type on `submit_batch(array $requests)` | errors |
|---|---|
| `array<string, array{systemprompt: string, messages: array, options?: array}>` (shipped) | 1 |
| same, whitespace collapsed | 1 |
| same, description un-wrapped onto one line | 1 |
| `array<string,array>` | 1 |
| `array{a:int}` | 1 |
| `array` | **0** |
| `array[]` | **0** |

## The fix

Type becomes plain `array`; the shape moves into the description, where it is still documented. Nothing else in the file changes.

**`@return` is deliberately left alone.** The rule only checks a return tag for non-empty and `!= 'type'`, so the **159** generic `@return` tags in this codebase (e.g. `array{status: string, …}` on `fetch_batch()`) are legal and must stay. Only `@param` is affected.

**Other occurrences: none.** A full-plugin run reports this as the only `functionarguments` error, and `grep -rE '@param +[^ ]*[<{]'` finds exactly one hit in shipped PHP — the other two are a prose string in a test's failure message and JSDoc inside single-quoted PHP string literals (never parsed as `T_DOC_COMMENT`).

## Second commit: the guard that should have caught this

`tests/phpdoc_param_consistency_test.php` exists *specifically* to front-run this sniff, and it **passed** on the offending file. It had a blind spot.

It extracted documented names with `/@param\s+\S+\s+\$(\w+)/` and bailed out with "no param tags at all" when that produced nothing. But `\S+` cannot cross whitespace, so for a type containing a space the pattern never matches, `$documented` comes back empty, and the function is skipped — **before** reaching the generic check below it. That check was correct and simply unreachable for exactly the inputs it existed to catch. It caught `array<int,string>` (the shape the planted example used) and nothing with a space in it.

Two changes: run the generic check *before* the empty-`$documented` bail, and widen its class from `<` to `[<{]` so bare array shapes are caught too.

This commit is **separable** — drop it if you'd rather not widen the guard in this PR, and the CI fix still stands on its own.

## Verification

- **Moodle PHPDoc Checker**, full plugin, run locally against a real `moodle-local_moodlecheck` clone: **540 files, 0 errors** (was 1).
- Reproduced the CI error byte-identically on a pristine `origin/main` worktree first, confirming it is a shipped v7.4.4 regression and not an artefact of any working tree.
- **Guard proven in both directions**: with the pre-fix docblock restored the reordered guard now **fails** with `submit_batch() uses a generic type on @param $requests`; with the fix applied it passes.
- Full plugin suite: see the comment below.

## Merge order

This should land **first**. #224 is green except for this one inherited error and will pass once it picks this up.
