### PR TITLE
fix(embeddings): bounded retry on rate limits, and batch the FAQ

### DIFF
--- a/classes/embedding_provider/base_embedding_provider.php
+++ b/classes/embedding_provider/base_embedding_provider.php
@@ -316,6 +316,75 @@ abstract class base_embedding_provider {
      * @throws \moodle_exception On HTTP errors.
      */
     protected function http_post(string $url, array $headers, string $body): string {
+        // v7.4.5: bounded retry on transient rate limits.
+        //
+        // Embeddings were the ONLY provider path with no backoff. The chat path
+        // has had base_provider::with_transient_retry() since v5.10.0, and the
+        // asymmetry bit in production: re-embedding the site FAQ issues one
+        // sequential call per Q/A pair and aborts the whole run on the first
+        // failure, so a single 429 from a concurrent bulk migration made the FAQ
+        // permanently un-embeddable -- every retry restarted at pair 1 and hit
+        // the same limit. The retriever then skips the stale FAQ chunks and
+        // context_builder silently falls back to injecting the entire FAQ inline,
+        // which is a prompt-budget regression with no error anywhere.
+        //
+        // Same knobs as the chat path so an operator tunes one thing, not two.
+        $attempts = (int) get_config('local_ai_course_assistant', 'backend_retry_attempts');
+        if ($attempts < 0) {
+            $attempts = 0;
+        }
+        $rawmax = get_config('local_ai_course_assistant', 'backend_retry_max_wait');
+        $maxwait = ($rawmax === false || $rawmax === '') ? 5 : (int) $rawmax;
+
+        $backoffs = [0.5, 1.5, 3.0];
+        $tries = 0;
+        while (true) {
+            try {
+                return $this->http_post_once($url, $headers, $body);
+            } catch (\moodle_exception $e) {
+                $retryafter = self::transient_retry_after($e);
+                if ($retryafter === false || $tries >= $attempts) {
+                    throw $e;
+                }
+                $wait = is_int($retryafter) ? min($retryafter, $maxwait) : ($backoffs[$tries] ?? 3.0);
+                // usleep rather than sleep: sub-second waits matter when a
+                // batch of pairs is being embedded behind a web request.
+                usleep((int) round($wait * 1000000));
+                $tries++;
+            }
+        }
+    }
+
+    /**
+     * Whether an exception is a retryable rate limit, and any Retry-After.
+     *
+     * @param \moodle_exception $e
+     * @return int|bool Seconds from Retry-After, true when retryable with no
+     *                  hint, or false when the error must not be retried.
+     */
+    private static function transient_retry_after(\moodle_exception $e) {
+        if (empty($e->debuginfo) || !is_string($e->debuginfo)) {
+            return false;
+        }
+        $d = json_decode($e->debuginfo, true);
+        if (!is_array($d) || empty($d['transient'])) {
+            return false;
+        }
+        return isset($d['retry_after']) && $d['retry_after'] !== null
+            ? (int) $d['retry_after']
+            : true;
+    }
+
+    /**
+     * One POST attempt. See http_post() for the retry wrapper.
+     *
+     * @param string $url
+     * @param array  $headers
+     * @param string $body JSON-encoded request body.
+     * @return string Raw response body.
+     * @throws \moodle_exception On HTTP errors.
+     */
+    private function http_post_once(string $url, array $headers, string $body): string {
         global $CFG;
         if (!\local_ai_course_assistant\security::is_safe_provider_url($url)) {
             throw new \moodle_exception(
@@ -346,8 +415,33 @@ abstract class base_embedding_provider {
             if ($httpcode === 401 || $httpcode === 403) {
                 throw new \moodle_exception('chat:error_auth', 'local_ai_course_assistant');
             }
-            if ($httpcode === 429) {
-                throw new \moodle_exception('chat:error_ratelimit', 'local_ai_course_assistant');
+            if ($httpcode === 429 || $httpcode === 503) {
+                // debuginfo carries the machine-readable marker the retry
+                // wrapper reads; the learner-facing string is unchanged.
+                // Moodle's curl documents getResponse() as an array of arrays, and
+                // a repeated header does arrive as an array, so handle both shapes
+                // rather than stringifying an array into "Array" and silently never
+                // matching. A missing or unparseable value is fine: the wrapper
+                // falls back to its own backoff schedule.
+                $retryafter = null;
+                foreach ((array) $curl->getResponse() as $name => $value) {
+                    if (strcasecmp(trim((string) $name), 'Retry-After') !== 0) {
+                        continue;
+                    }
+                    $raw = is_array($value) ? reset($value) : $value;
+                    $raw = trim((string) $raw);
+                    if (is_numeric($raw)) {
+                        $retryafter = (int) $raw;
+                    }
+                    break;
+                }
+                $ex = new \moodle_exception('chat:error_ratelimit', 'local_ai_course_assistant');
+                $ex->debuginfo = json_encode([
+                    'transient'   => true,
+                    'status'      => $httpcode,
+                    'retry_after' => $retryafter,
+                ]);
+                throw $ex;
             }
             throw new \moodle_exception(
                 'chat:error',

--- a/classes/faq_manager.php
+++ b/classes/faq_manager.php
@@ -162,19 +162,45 @@ class faq_manager {
 
         // Build every row before touching the table, so a provider failure
         // halfway through leaves the existing index intact.
-        $records = [];
-        foreach (array_values($entries) as $idx => $entry) {
+        // v7.4.5: ONE batched call rather than one call per pair.
+        //
+        // This used to loop embed() per Q/A pair, so a 17-pair FAQ meant 17
+        // sequential requests -- seventeen chances to trip a rate limit, for a
+        // run that is all-or-nothing and restarts from pair 1 every time. In
+        // production a concurrent bulk re-embed was enough to make the FAQ
+        // permanently un-embeddable: it failed at pair 4 on every attempt.
+        // embed_batch() is on the base class and every provider implements it,
+        // so this is one request with the same result. Paired with the transient
+        // retry now in base_embedding_provider, the failure mode is gone rather
+        // than merely less likely.
+        $texts = [];
+        foreach (array_values($entries) as $entry) {
             $text = 'Q: ' . $entry['question'] . "\nA: " . $entry['answer'];
             // Sanitised on the same terms as course material. The FAQ is
             // admin-authored rather than learner-authored, but it is still text
             // that re-enters the prompt at retrieval time.
             $sanitized = \local_ai_course_assistant\security::sanitize_rag_chunk($text);
-            try {
-                $vector = $provider->embed($sanitized['text']);
-            } catch (\Throwable $e) {
-                $out['error'] = 'embedding failed on pair ' . ($idx + 1) . ': ' . $e->getMessage();
-                return $out;
-            }
+            $texts[] = $sanitized['text'];
+        }
+
+        try {
+            $vectors = $provider->embed_batch($texts);
+        } catch (\Throwable $e) {
+            $out['error'] = 'embedding failed: ' . $e->getMessage();
+            return $out;
+        }
+        if (count($vectors) !== count($texts)) {
+            // A short batch would silently drop pairs from the index, so refuse
+            // rather than write a partial FAQ that looks complete.
+            $out['error'] = 'embedding returned ' . count($vectors) . ' vector(s) for '
+                . count($texts) . ' pair(s)';
+            return $out;
+        }
+
+        $records = [];
+        foreach ($texts as $idx => $sanitizedtext) {
+            $sanitized = ['text' => $sanitizedtext];
+            $vector = $vectors[$idx] ?? null;
             if (empty($vector)) {
                 $out['error'] = 'embedding returned nothing for pair ' . ($idx + 1);
                 return $out;

--- a/tests/embedding_rate_limit_test.php
+++ b/tests/embedding_rate_limit_test.php
@@ -1,0 +1,148 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_ai_course_assistant;
+
+/**
+ * The embedding path must survive a transient rate limit.
+ *
+ * Embeddings were the only provider path with no backoff: the chat path has had
+ * base_provider::with_transient_retry() since v5.10.0, and this one threw on the
+ * first 429. Combined with the FAQ embedding one Q/A pair at a time and being
+ * all-or-nothing, a concurrent bulk re-embed made the site FAQ permanently
+ * un-embeddable in production -- it failed at pair 4 on every attempt, because
+ * every attempt restarted at pair 1.
+ *
+ * The consequence was silent: the retriever skips FAQ chunks left on the old
+ * model, and context_builder falls back to injecting the whole FAQ inline, which
+ * costs prompt budget on every turn with no error anywhere.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor Academy
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class embedding_rate_limit_test extends \advanced_testcase {
+
+    /**
+     * Read the embedding base class source.
+     *
+     * @return string
+     */
+    private function src(): string {
+        global $CFG;
+        $s = file_get_contents($CFG->dirroot
+            . '/local/ai_course_assistant/classes/embedding_provider/base_embedding_provider.php');
+        $this->assertNotFalse($s);
+        return $s;
+    }
+
+    /**
+     * A 429 must be marked transient so the retry wrapper can act on it.
+     */
+    public function test_rate_limit_is_marked_transient(): void {
+        $this->resetAfterTest();
+        $src = $this->src();
+
+        $i = strpos($src, '$httpcode === 429');
+        $this->assertNotFalse($i, 'the 429 branch is gone');
+        // Generous window: the branch carries explanatory comments, and a slice
+        // too small silently misses the assertion target and reports a defect
+        // that is not there.
+        $block = substr($src, $i, 2000);
+
+        $this->assertMatchesRegularExpression(
+            "/'transient'\s*=>\s*true/",
+            $block,
+            'A 429 must carry the transient marker in debuginfo, or the retry wrapper '
+            . 'cannot distinguish it from a permanent failure and will rethrow immediately.'
+        );
+        $this->assertStringContainsString(
+            'retry_after',
+            $block,
+            "Retry-After must be captured; a vendor's own hint beats a fixed backoff."
+        );
+    }
+
+    /**
+     * The POST must actually be wrapped in a bounded retry.
+     */
+    public function test_http_post_retries_with_bounded_backoff(): void {
+        $this->resetAfterTest();
+        $src = $this->src();
+
+        $this->assertStringContainsString(
+            'private function http_post_once(',
+            $src,
+            'http_post() must delegate to a single-attempt helper so it can retry it.'
+        );
+        $this->assertMatchesRegularExpression(
+            '/backend_retry_attempts/',
+            $src,
+            'Retry depth must reuse the chat path\'s setting, so an operator tunes one '
+            . 'knob rather than two that can disagree.'
+        );
+        $this->assertMatchesRegularExpression(
+            '/backend_retry_max_wait/',
+            $src,
+            'A vendor Retry-After must be clamped, or a hostile or mistaken header '
+            . 'could park a web request for minutes.'
+        );
+
+        // The retry must be bounded, never a bare while(true) with no exit.
+        $i = strpos($src, 'protected function http_post(');
+        $body = substr($src, $i, 2600);
+        $this->assertMatchesRegularExpression(
+            '/\$tries\s*>=\s*\$attempts/',
+            $body,
+            'The loop must exit on attempt count; an unbounded retry against a rate '
+            . 'limit is worse than failing.'
+        );
+    }
+
+    /**
+     * The FAQ must embed in ONE batched call, not one per pair.
+     */
+    public function test_faq_embeds_in_a_single_batched_call(): void {
+        global $CFG;
+        $this->resetAfterTest();
+
+        $src = file_get_contents($CFG->dirroot
+            . '/local/ai_course_assistant/classes/faq_manager.php');
+        $this->assertNotFalse($src);
+
+        $i = strpos($src, 'function index_faq');
+        $this->assertNotFalse($i);
+        $body = substr($src, $i);
+
+        $this->assertStringContainsString(
+            '$provider->embed_batch(',
+            $body,
+            'index_faq must use the batch API. One call per Q/A pair is N chances to '
+            . 'trip a rate limit for a run that restarts from pair 1 on any failure.'
+        );
+        $this->assertStringNotContainsString(
+            '$provider->embed(',
+            $body,
+            'No per-pair embed() calls should remain in index_faq.'
+        );
+        $this->assertStringContainsString(
+            'count($vectors) !== count($texts)',
+            $body,
+            'A short batch must be refused rather than written, or pairs are silently '
+            . 'dropped from an index that then looks complete.'
+        );
+    }
+}


### PR DESCRIPTION
Found on production while migrating Degrees to `voyage-4-large`. Re-embedding the
site FAQ failed with *"Too many requests"* at pair 4 — **on every attempt**, and
could not be made to succeed by retrying.

## Three things compounded

1. **Embeddings were the only provider path with no backoff.** The chat path has
   had `base_provider::with_transient_retry()` since v5.10.0.
   `base_embedding_provider` threw on the first 429 and never retried.
2. **`index_faq()` embedded one Q/A pair per request.** A 17-pair FAQ was 17
   sequential chances to trip a rate limit.
3. **The run is all-or-nothing by design** — *"Build every row before touching the
   table, so a provider failure halfway through leaves the existing index
   intact."* Correct for consistency, but it means a failure at pair 4 discards
   pairs 1–3, and every retry restarts at pair 1 into the same limit.

Together these make the FAQ **permanently un-embeddable** under mild rate
pressure — which is exactly what a concurrent bulk re-embed produces. Not a
transient annoyance: a state the operator cannot exit by retrying.

## Why it mattered more than it looked

`index_faq()` is gated on a hash of the FAQ **text**, not the model, so after a
model change it will not re-embed itself. The retriever then skips those chunks
as not comparable, and `context_builder` **quietly falls back to injecting the
whole FAQ inline** — prompt budget spent on every turn, with no error anywhere.
`embedding_migration`'s own docblock documents this, which is why the admin page
offers the action at all.

## Fixes

- `http_post()` wraps a single-attempt `http_post_once()` in a **bounded** retry,
  honouring `Retry-After` (clamped) and reusing the chat path's
  `backend_retry_attempts` / `backend_retry_max_wait` so an operator tunes one
  knob rather than two that can disagree. 429 and 503 are marked transient in
  `debuginfo`; the learner-facing string is unchanged.
- **Retry-After parsing handles both header shapes.** Moodle's curl promotes a
  repeated header to an array; stringifying that yields `"Array"`, which would
  silently never match and quietly fall back to the fixed schedule.
- `index_faq()` makes **one `embed_batch()` call**. That method already existed on
  the base class and every provider implements it. A short batch is **refused**
  rather than written — silently dropping pairs leaves an index that looks
  complete.

The retry alone fixes the reported symptom. Batching is what stops it recurring
at 40 pairs, and it's a 17× reduction in requests.

## Testing

`tests/embedding_rate_limit_test.php`, all three guards **watched failing**
against the real `origin/main` sources before being trusted.

- Suite: **1,599 tests / 0 failures**
- Validators: **36/36**

## Scope

Branch is off `origin/main` in an isolated worktree. **Touches only two files
plus a new test** — no overlap with the embedding-migration work, the default
flip, or anything in the shared checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)