### PR TITLE
docs: version lines to 7.4.5 / 2026091006

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 SOLA (Saylor Online Learning Assistant) is a Moodle local plugin that provides an AI-powered learning coach embedded in course pages. Students interact via a side tab on the right edge of the page (default: halfway down), which opens a chat drawer. A floating avatar button at the bottom corner is an alternative placement available via the Display Mode admin setting.
 
 - **Plugin component:** `local_ai_course_assistant`
-- **Current version:** `2026091003`, release `7.4.3`
+- **Current version:** `2026091006`, release `7.4.5`
 - **Source folder (canonical):** the git repo at `~/ai-projects/ai_course_assistant/` (edit and commit here; the older `aicoursetutor/ai_course_assistant` path is a stale remnant, do not deploy from it)
 - **Zip for upload:** built from the repo via `create_fixed_zip.sh`
 - **GitHub:** `https://github.com/saylordotorg/moodle-local_ai_course_assistant` (public)

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 A comprehensive AI-powered chat widget for Moodle 4.5+ that provides context-aware tutoring, support, and study planning for students.
 
-## Version 7.4.4
+## Version 7.4.5
 
 **Release Date:** September 2026
-**Plugin build:** 2026091005
+**Plugin build:** 2026091006
 **Requires:** Moodle 4.5+ (2024100700). Continuously tested against Moodle 4.5, 5.0 and 5.1; supported through 5.3.
 **License:** GPL v3+
 **Maturity:** Stable. In production on Saylor's Learn and Degrees sites.


### PR DESCRIPTION
`version.php` has been `2026091006` / `7.4.5` since #227 merged, but two docs files still advertise older builds:

- `README.md` — `## Version 7.4.4`, `**Plugin build:** 2026091005`
- `CLAUDE.md` — `Current version: 2026091003, release 7.4.3` (already stale at 7.4.4)

This is the release gate item "version.php = 2026091006 / 7.4.5 and README.md agrees". Docs only: no code, no lang strings, no version bump, so no `init.php` re-run is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)