### PR TITLE
fix(context): rewrite pluginfile URLs and pass module context to format_text

### DIFF
--- a/classes/context_builder.php
+++ b/classes/context_builder.php
@@ -900,6 +900,54 @@ class context_builder {
     }
 
     /**
+     * Rewrite @@PLUGINFILE@@ placeholders, then format module HTML for text extraction.
+     *
+     * Moodle requires file_rewrite_pluginfile_urls() before format_text(). Without it
+     * core emits "Before calling format_text(), the content must be processed with
+     * file_rewrite_pluginfile_urls()" on every call. This was observed on production:
+     * one load of objectives_admin.php for a single course produced hundreds of those
+     * warnings, because the objective extractor walks every Page and Book in the course.
+     *
+     * Passing the module context explicitly matters just as much. Without it
+     * format_text() falls back to $PAGE->context, which is the wrong context whenever
+     * this runs anywhere other than that module's own page, and is unavailable in
+     * non-web callers such as scheduled tasks, where $PAGE may not exist at all.
+     *
+     * @param string   $html      Raw stored HTML.
+     * @param int|null $format    One of the FORMAT_* constants.
+     * @param int      $cmid      Course-module id supplying the context.
+     * @param string   $component Owning component, e.g. 'mod_page'.
+     * @param string   $filearea  File area within that component.
+     * @param int|null $itemid    File area item id, or null when the area has none.
+     * @return string Formatted HTML, or the unmodified input if the context is gone.
+     */
+    private static function format_module_html(
+        string $html,
+        ?int $format,
+        int $cmid,
+        string $component,
+        string $filearea,
+        ?int $itemid
+    ): string {
+        $context = \context_module::instance($cmid, IGNORE_MISSING);
+        if (!$context) {
+            // The module vanished between the modinfo read and here. Returning the
+            // raw HTML keeps the caller's strip_tags() fallback working rather than
+            // throwing inside what is only a best-effort content extraction.
+            return $html;
+        }
+        $html = file_rewrite_pluginfile_urls(
+            $html,
+            'pluginfile.php',
+            $context->id,
+            $component,
+            $filearea,
+            $itemid
+        );
+        return format_text($html, $format, ['context' => $context]);
+    }
+
+    /**
      * Extract readable text content from a single course module (page or book).
      * Used by quiz generation and system prompt page injection.
      *
@@ -967,7 +1015,14 @@ class context_builder {
                     // short summary post-filter. Tomi @ Debrecen reproduced
                     // this on a Page activity with full body text that
                     // returned empty here on his site.
-                    $filtered = strip_tags(format_text($record->content, $record->contentformat));
+                    $filtered = strip_tags(self::format_module_html(
+                        (string) $record->content,
+                        isset($record->contentformat) ? (int) $record->contentformat : null,
+                        $cmid,
+                        'mod_page',
+                        'content',
+                        isset($record->revision) ? (int) $record->revision : null
+                    ));
                     $filtered = preg_replace('/\s+/', ' ', trim($filtered));
                     if (strlen($filtered) >= 30) {
                         return substr($filtered, 0, $maxchars);
@@ -991,7 +1046,14 @@ class context_builder {
                     $parts = [];
                     $perchapter = ($maxchars > 6000) ? 2400 : 1200;
                     foreach ($chapters as $ch) {
-                        $text = strip_tags(format_text($ch->content, $ch->contentformat));
+                        $text = strip_tags(self::format_module_html(
+                            (string) $ch->content,
+                            isset($ch->contentformat) ? (int) $ch->contentformat : null,
+                            $cmid,
+                            'mod_book',
+                            'chapter',
+                            (int) $ch->id
+                        ));
                         $text = preg_replace('/\s+/', ' ', trim($text));
                         if (strlen($text) > 50) {
                             $heading = !empty($ch->title) ? "{$ch->title}: " : '';
@@ -1656,7 +1718,14 @@ class context_builder {
                     try {
                         $record = $pagerows[(int) $cm->instance] ?? null;
                         if ($record && !empty($record->content)) {
-                            $text = strip_tags(format_text($record->content, $record->contentformat));
+                            $text = strip_tags(self::format_module_html(
+                                (string) $record->content,
+                                isset($record->contentformat) ? (int) $record->contentformat : null,
+                                (int) $cm->id,
+                                'mod_page',
+                                'content',
+                                isset($record->revision) ? (int) $record->revision : null
+                            ));
                             $text = preg_replace('/\s+/', ' ', trim($text));
                             if (strlen($text) > 80) {
                                 $content = substr($text, 0, $maxperresource);
@@ -1680,7 +1749,14 @@ class context_builder {
                         if ($chapters) {
                             $parts = [];
                             foreach ($chapters as $ch) {
-                                $text = strip_tags(format_text($ch->content, $ch->contentformat));
+                                $text = strip_tags(self::format_module_html(
+                                    (string) $ch->content,
+                                    isset($ch->contentformat) ? (int) $ch->contentformat : null,
+                                    (int) $cm->id,
+                                    'mod_book',
+                                    'chapter',
+                                    (int) $ch->id
+                                ));
                                 $text = preg_replace('/\s+/', ' ', trim($text));
                                 if (strlen($text) > 50) {
                                     $heading = !empty($ch->title) ? "{$ch->title}: " : '';


### PR DESCRIPTION
## What this fixes

Production debug output from `objectives_admin.php?courseid=44` on degrees.saylor.org, captured during an unrelated incident, showed hundreds of identical warnings from a single page load:

```
Before calling format_text(), the content must be processed with file_rewrite_pluginfile_urls()
line 994 of /local/ai_course_assistant/classes/context_builder.php: call to format_text()
line 846 of /local/ai_course_assistant/classes/objective_manager.php: call to context_builder::get_module_content()
line 750 of /local/ai_course_assistant/classes/objective_manager.php: call to extract_from_section_content()
line 278 of /local/ai_course_assistant/objectives_admin.php: call to objective_manager::detect_best_source()
```

The volume is the point. The objective extractor walks every Page and Book in the course, so one admin page load repeats the same defect once per module.

## Four call sites, not two

The trace named 970 and 994, both in `get_module_content()`. Lines 1659 and 1683 are the same pattern in `build_course_content()` and were not in the trace only because that page does not reach them. Fixing the reported pair alone would have left the other two.

## Two defects per site

1. **No `file_rewrite_pluginfile_urls()`.** Moodle requires it before `format_text()`, which is exactly what the warning says. Embedded `@@PLUGINFILE@@` placeholders never resolved.
2. **No context passed.** `format_text()` then falls back to `$PAGE->context`. That is the wrong context whenever this runs anywhere other than that module's own page, and it is unavailable to non-web callers such as scheduled tasks, where `$PAGE` may not exist at all. This extractor is called from exactly those places.

Both are fixed by one new private helper, `format_module_html()`, which resolves the module context, rewrites the URLs with the correct component and file area (`mod_page`/`content`/`revision` and `mod_book`/`chapter`/`id`), and passes the context through.

If the module context has gone missing between the modinfo read and the format call, the helper returns the raw HTML unchanged so the callers' existing `strip_tags()` fallback still works, rather than throwing inside what is only best-effort content extraction.

## Recorded, deliberately not changed here

Running the full filter chain over every module only to `strip_tags()` the result is expensive. On Degrees the active filter set includes `filter_algebra`, which shells out to `algebra2tex.pl` per match, so this path can fan out to hundreds of subprocesses on a single page load. That same production output also carried `preg_match(): Passing null to parameter #2` from `filter/algebra/classes/text_filter.php`, because the shell-out returns null.

Narrowing this needs a behaviour decision, and the comment at line 960 says the filter pass is deliberate (it exists to handle multilang and a reported filter-collapse case). Raising it here rather than changing it silently.

## Testing

`php -l` clean. The local PHPUnit harness could not be initialised on this machine because the default `php` is 8.5.9 and Moodle 4.5 refuses above 8.3, so the suite is left to CI rather than reported as passing here.