### PR TITLE
feat(objectives): read curated outcomes from local_outcomemap when present

### DIFF
--- a/classes/objective_manager.php
+++ b/classes/objective_manager.php
@@ -741,6 +741,21 @@ class objective_manager {
      */
     public static function detect_best_source(int $courseid): array {
         $candidates = [
+            // Curated outcomes first. local_outcomemap holds human-authored,
+            // approved, versioned outcome statements bound to the course. Where a
+            // course has them they beat anything the scrapers below can infer, and
+            // they are read with one query instead of a walk over every module.
+            //
+            // This also short-circuits the expensive path: detect_best_source()
+            // returns on the first candidate yielding three or more objectives, so
+            // a mapped course never reaches extract_from_section_content(), which
+            // runs roughly 4 queries and one format_text() per Page and per Book
+            // chapter with no module cap.
+            //
+            // The candidate is inert when the plugin is absent, which is every
+            // install that does not have it: outcomemap_bridge::fetch() returns an
+            // empty array and the chain falls through unchanged.
+            ['outcomemap', [outcomemap_bridge::class, 'fetch']],
             ['competency', [self::class, 'find_moodle_competencies']],
             ['summary', [self::class, 'extract_from_course_summary']],
             ['section', [self::class, 'extract_from_section_content']],

--- a/classes/outcomemap_bridge.php
+++ b/classes/outcomemap_bridge.php
@@ -1,0 +1,191 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Read approved learning outcomes from local_outcomemap, when that plugin is present.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_ai_course_assistant;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Adapter over the local_outcomemap public API.
+ *
+ * Why this exists. SOLA's own objective discovery scrapes course content: it walks
+ * the course summary, then each section summary, then every visible Page and Book,
+ * running each through format_text() looking for something bullet-shaped. That is
+ * expensive and it guesses. In production it has produced six rows across both
+ * Saylor sites, on one course, and all six are course NAMES rather than objectives,
+ * because the scraper falls back to reading bullets from the top of a document when
+ * no heading pattern matches.
+ *
+ * local_outcomemap holds the same information as curated data: human-authored,
+ * versioned, approved outcome statements bound to a Moodle course. Where a course
+ * has them, they are strictly better than anything the scraper can infer, and
+ * reading them costs one query instead of a walk over every module in the course.
+ *
+ * Coupling. This class is the ONLY place SOLA touches local_outcomemap. It calls
+ * the plugin's declared public API under \local_outcomemap\api and never its
+ * \local_outcomemap\local\... internals or its database tables directly, so a
+ * change to the plugin's storage cannot break SOLA silently. Every entry point is
+ * guarded by class_exists()/method_exists(), because the plugin is optional, is
+ * absent from most installs, and is still MATURITY_BETA on the sites that do
+ * have it.
+ *
+ * Scope caveat, deliberately not filtered. outcome_search scopes by Moodle context
+ * and returns the approved outcomes of every framework visible to that course: the
+ * course's own catalog framework, any institution-level framework, and the
+ * frameworks of programs the course belongs to. So a course inside a degree program
+ * will also receive that program's outcomes. That is the plugin's definition of
+ * "outcomes for this course" and this adapter does not second-guess it; the public
+ * API exposes no owner-type filter, and reaching past it to apply one would mean
+ * querying the plugin's tables, which is exactly the coupling this class avoids.
+ */
+final class outcomemap_bridge {
+
+    /** @var string Fully qualified name of the outcome search API. */
+    private const SEARCH_API = '\\local_outcomemap\\api\\outcome_search';
+
+    /** @var string Capability the outcome search API requires of the caller. */
+    private const VIEW_CAPABILITY = 'local/outcomemap:viewdefinitions';
+
+    /** @var string Prefix written into objs.external_ref, ahead of the version UUID. */
+    public const REF_PREFIX = 'outcomemap:';
+
+    /** @var int Upper bound on imported outcomes. The upstream API itself caps at 200. */
+    private const MAX_OUTCOMES = 200;
+
+    /**
+     * Is the local_outcomemap outcome-search API installed and callable?
+     *
+     * Checked per call rather than cached: a site can install or remove the plugin
+     * between requests, and this is two reflection lookups, not a query.
+     *
+     * @return bool
+     */
+    public static function is_available(): bool {
+        return class_exists(self::SEARCH_API)
+            && method_exists(self::SEARCH_API, 'search');
+    }
+
+    /**
+     * Fetch approved, currently-effective outcomes for a Moodle course.
+     *
+     * Returns rows in the shape objective_manager::import_batch() consumes, so the
+     * caller needs no knowledge of local_outcomemap at all.
+     *
+     * Returns an empty array, never an exception, whenever the outcomes cannot be
+     * read: plugin absent, course gone, caller lacks the capability, or the API
+     * throws. An empty result simply means detect_best_source() moves on to the
+     * next candidate, which is the pre-existing behaviour.
+     *
+     * @param int $courseid Moodle course id.
+     * @return array<int, array{title: string, description: string, code: string, external_ref: string}>
+     */
+    public static function fetch(int $courseid): array {
+        if ($courseid <= 0 || $courseid == SITEID || !self::is_available()) {
+            return [];
+        }
+
+        try {
+            $context = \context_course::instance($courseid, IGNORE_MISSING);
+            if (!$context) {
+                return [];
+            }
+
+            // outcome_search::search() calls require_capability() internally and
+            // throws when it fails. Objective discovery runs on an admin page and
+            // from background callers, and neither should turn a missing read
+            // capability into a fatal, so the check is made here first.
+            if (!has_capability(self::VIEW_CAPABILITY, $context)) {
+                return [];
+            }
+
+            $outcomes = call_user_func(
+                [self::SEARCH_API, 'search'],
+                $context,
+                '',
+                null,
+                self::MAX_OUTCOMES
+            );
+        } catch (\Throwable $e) {
+            // The plugin is optional and beta. A failure to read it is never a
+            // reason to fail objective discovery.
+            debugging(
+                'local_outcomemap outcome lookup failed for course ' . $courseid . ': ' . $e->getMessage(),
+                DEBUG_DEVELOPER
+            );
+            return [];
+        }
+
+        if (!is_array($outcomes)) {
+            return [];
+        }
+
+        $items = [];
+        foreach ($outcomes as $outcome) {
+            $row = self::to_objective_row($outcome);
+            if ($row !== null) {
+                $items[] = $row;
+            }
+        }
+        return $items;
+    }
+
+    /**
+     * Convert one outcome value object into an import_batch() row.
+     *
+     * Properties are read defensively rather than by type hint. The DTO is the
+     * plugin's own class, it is beta, and SOLA must not fatal if a field it expects
+     * is renamed in a later release.
+     *
+     * @param mixed $outcome An outcome DTO from the search API.
+     * @return array{title: string, description: string, code: string, external_ref: string}|null
+     */
+    private static function to_objective_row($outcome): ?array {
+        if (!is_object($outcome)) {
+            return null;
+        }
+
+        $statement = trim((string) ($outcome->statement ?? ''));
+        $short = trim((string) ($outcome->shortstatement ?? ''));
+
+        // objs.title is NOT NULL and 255 chars; objs.description is unbounded text.
+        // Prefer the curated short statement for the title and keep the full
+        // statement as the description, so nothing is lost when the title is cut.
+        $title = $short !== '' ? $short : $statement;
+        if ($title === '') {
+            return null;
+        }
+
+        $versionuuid = trim((string) ($outcome->versionuuid ?? ''));
+
+        return [
+            // The VERSION uuid, not the outcome uuid: it identifies the exact
+            // revision of the wording that was imported, so a later edit upstream
+            // is visibly a different reference rather than silently the same one.
+            'external_ref' => $versionuuid !== '' ? self::REF_PREFIX . $versionuuid : '',
+            'title' => $title,
+            'description' => $statement,
+            'code' => trim((string) ($outcome->code ?? '')),
+        ];
+    }
+}

--- a/lang/am/local_ai_course_assistant.php
+++ b/lang/am/local_ai_course_assistant.php
@@ -808,6 +808,7 @@ $string['objectives:toggle_chip'] = 'ለተማሪዎች የመማር ክህሎ�
 $string['objectives:toggle_chip_help'] = 'አማራጭ። ሲጠፋ፣ ክህሎት ጥራት ረዳቱን በዝምታ መምራቱን ይቀጥላል ነገር ግን ተማሪዎች ምንም አመልካች አያዩም።';
 $string['objectives:toggled'] = 'ቅንብር ተሻሽሏል።';
 $string['objectives:detected_heading'] = 'ከ{$a->source} {$a->count} የመማር ግቦች ተገኝተዋል።';
+$string['objectives:source_outcomemap'] = 'የመማር ውጤቶች ማዛመድ';
 $string['objectives:source_competency'] = 'የ Moodle ብቃቶች';
 $string['objectives:source_summary'] = 'የኮርሱ ማጠቃለያ';
 $string['objectives:source_section'] = 'የክፍል ወይም የመጀመሪያ ገጽ ይዘት';

--- a/lang/ar/local_ai_course_assistant.php
+++ b/lang/ar/local_ai_course_assistant.php
@@ -779,6 +779,7 @@ $string['objectives:toggle_chip'] = 'إظهار شارة إتقان التعلم
 $string['objectives:toggle_chip_help'] = 'اختياري. عند الإيقاف، يستمر الإتقان في توجيه المساعد بصمت لكن لا يرى المتعلمون أي مؤشر.';
 $string['objectives:toggled'] = 'تم تحديث الإعداد.';
 $string['objectives:detected_heading'] = 'تم اكتشاف {$a->count} من أهداف التعلم من {$a->source}.';
+$string['objectives:source_outcomemap'] = 'ربط مخرجات التعلم';
 $string['objectives:source_competency'] = 'كفاءات Moodle';
 $string['objectives:source_summary'] = 'ملخص الدورة';
 $string['objectives:source_section'] = 'محتوى القسم أو الصفحة الأولى';

--- a/lang/bg/local_ai_course_assistant.php
+++ b/lang/bg/local_ai_course_assistant.php
@@ -781,6 +781,7 @@ $string['objectives:toggle_chip'] = 'Показване на чипа за уч�
 $string['objectives:toggle_chip_help'] = 'По избор. Когато е изключено, владеенето продължава да насочва асистента мълчаливо, но учащите не виждат индикатор.';
 $string['objectives:toggled'] = 'Настройката е обновена.';
 $string['objectives:detected_heading'] = 'Открити са {$a->count} учебни цели от {$a->source}.';
+$string['objectives:source_outcomemap'] = 'съпоставяне на учебните резултати';
 $string['objectives:source_competency'] = 'компетенции в Moodle';
 $string['objectives:source_summary'] = 'обобщение на курса';
 $string['objectives:source_section'] = 'съдържание на раздел или първа страница';

--- a/lang/bm/local_ai_course_assistant.php
+++ b/lang/bm/local_ai_course_assistant.php
@@ -809,6 +809,7 @@ $string['objectives:toggle_chip'] = 'Kalanden ka Sebagaya taamasiɲɛ jira kalan
 $string['objectives:toggle_chip_help'] = 'A man kan dɔrɔn. Ni a faga, sebagaya bɛ tora dɛmɛbaga bolosin makun na nka kalandenw tɛ taamasiɲɛ si ye.';
 $string['objectives:toggled'] = 'Labɛnni yɛlɛmana.';
 $string['objectives:detected_heading'] = 'Kalanni laɲini {$a->count} sɔrɔla {$a->source} la.';
+$string['objectives:source_outcomemap'] = 'kalan jaabiw sɛbɛnni';
 $string['objectives:source_competency'] = 'Moodle seko';
 $string['objectives:source_summary'] = 'kalan kunnafoni surunyalen';
 $string['objectives:source_section'] = 'tilayɔrɔ walima page fɔlɔ kɔnɔkow';

--- a/lang/bn/local_ai_course_assistant.php
+++ b/lang/bn/local_ai_course_assistant.php
@@ -779,6 +779,7 @@ $string['objectives:toggle_chip'] = 'শিক্ষার্থীদের ক
 $string['objectives:toggle_chip_help'] = 'ঐচ্ছিক। বন্ধ থাকলে দক্ষতা অর্জন এখনও নীরবে সহকারীকে পরিচালনা করে কিন্তু শিক্ষার্থীরা কোনো নির্দেশক দেখে না।';
 $string['objectives:toggled'] = 'সেটিং আপডেট হয়েছে।';
 $string['objectives:detected_heading'] = '{$a->source} থেকে {$a->count}টি শিখন উদ্দেশ্য সনাক্ত করা হয়েছে।';
+$string['objectives:source_outcomemap'] = 'শেখার ফলাফল ম্যাপিং';
 $string['objectives:source_competency'] = 'Moodle যোগ্যতা';
 $string['objectives:source_summary'] = 'কোর্স সারাংশ';
 $string['objectives:source_section'] = 'বিভাগ বা প্রথম পৃষ্ঠার বিষয়বস্তু';

--- a/lang/cs/local_ai_course_assistant.php
+++ b/lang/cs/local_ai_course_assistant.php
@@ -781,6 +781,7 @@ $string['objectives:toggle_chip'] = 'Zobrazovat studentům odznak Osvojení uče
 $string['objectives:toggle_chip_help'] = 'Volitelné. Když je vypnuto, osvojení stále tiše řídí asistenta, ale studenti nevidí žádný indikátor.';
 $string['objectives:toggled'] = 'Nastavení aktualizováno.';
 $string['objectives:detected_heading'] = 'Detekováno {$a->count} učebních cílů ze zdroje: {$a->source}.';
+$string['objectives:source_outcomemap'] = 'mapování výukových výstupů';
 $string['objectives:source_competency'] = 'Moodle kompetence';
 $string['objectives:source_summary'] = 'shrnutí kurzu';
 $string['objectives:source_section'] = 'sekce nebo obsah první stránky';

--- a/lang/da/local_ai_course_assistant.php
+++ b/lang/da/local_ai_course_assistant.php
@@ -781,6 +781,7 @@ $string['objectives:toggle_chip'] = 'Vis Læringsmestring-chippen til elever';
 $string['objectives:toggle_chip_help'] = 'Valgfrit. Når slået fra, styrer mestring stadig assistenten i baggrunden, men eleverne ser ingen indikator.';
 $string['objectives:toggled'] = 'Indstilling opdateret.';
 $string['objectives:detected_heading'] = 'Fandt {$a->count} læringsmål fra {$a->source}.';
+$string['objectives:source_outcomemap'] = 'kortlægning af læringsudbytte';
 $string['objectives:source_competency'] = 'Moodle-kompetencer';
 $string['objectives:source_summary'] = 'kursusresumé';
 $string['objectives:source_section'] = 'sektion eller indhold på første side';

--- a/lang/de/local_ai_course_assistant.php
+++ b/lang/de/local_ai_course_assistant.php
@@ -781,6 +781,7 @@ $string['objectives:toggle_chip'] = 'Lern-Beherrschungs-Chip für Studierende an
 $string['objectives:toggle_chip_help'] = 'Optional. Wenn deaktiviert, steuert die Beherrschung den Assistenten weiterhin im Hintergrund, aber Lernende sehen keinen Indikator.';
 $string['objectives:toggled'] = 'Einstellung aktualisiert.';
 $string['objectives:detected_heading'] = '{$a->count} Lernziele aus {$a->source} erkannt.';
+$string['objectives:source_outcomemap'] = 'Zuordnung von Lernergebnissen';
 $string['objectives:source_competency'] = 'Moodle-Kompetenzen';
 $string['objectives:source_summary'] = 'Kursbeschreibung';
 $string['objectives:source_section'] = 'Abschnitt oder Inhalt der ersten Seite';

--- a/lang/el/local_ai_course_assistant.php
+++ b/lang/el/local_ai_course_assistant.php
@@ -823,6 +823,7 @@ $string['objectives:toggle_chip'] = 'Εμφάνιση του δείκτη Μαθ
 $string['objectives:toggle_chip_help'] = 'Προαιρετικό. Όταν είναι απενεργοποιημένο, η κατάκτηση εξακολουθεί να καθοδηγεί σιωπηλά τον βοηθό, αλλά οι εκπαιδευόμενοι δεν βλέπουν κανέναν δείκτη.';
 $string['objectives:toggled'] = 'Η ρύθμιση ενημερώθηκε.';
 $string['objectives:detected_heading'] = 'Εντοπίστηκαν {$a->count} μαθησιακοί στόχοι από: {$a->source}.';
+$string['objectives:source_outcomemap'] = 'αντιστοίχιση μαθησιακών αποτελεσμάτων';
 $string['objectives:source_competency'] = 'ικανότητες Moodle';
 $string['objectives:source_summary'] = 'περίληψη μαθήματος';
 $string['objectives:source_section'] = 'ενότητα ή περιεχόμενο πρώτης σελίδας';

--- a/lang/en/local_ai_course_assistant.php
+++ b/lang/en/local_ai_course_assistant.php
@@ -1212,6 +1212,7 @@ $string['objectives:toggle_chip']       = 'Show the Learning Mastery chip to stu
 $string['objectives:toggle_chip_help']  = 'Optional. When off, mastery still steers the assistant silently but learners see no indicator.';
 $string['objectives:toggled']           = 'Setting updated.';
 $string['objectives:detected_heading']  = 'Detected {$a->count} learning objectives from {$a->source}.';
+$string['objectives:source_outcomemap'] = 'learning outcomes mapping';
 $string['objectives:source_competency'] = 'Moodle competencies';
 $string['objectives:source_summary']    = 'course summary';
 $string['objectives:source_section']    = 'section or first-page content';

--- a/lang/es/local_ai_course_assistant.php
+++ b/lang/es/local_ai_course_assistant.php
@@ -808,6 +808,7 @@ $string['objectives:toggle_chip'] = 'Mostrar el indicador de Dominio del Aprendi
 $string['objectives:toggle_chip_help'] = 'Opcional. Cuando está desactivado, el dominio sigue guiando al asistente de forma silenciosa, pero los estudiantes no ven ningún indicador.';
 $string['objectives:toggled'] = 'Configuración actualizada.';
 $string['objectives:detected_heading'] = 'Se detectaron {$a->count} objetivos de aprendizaje desde {$a->source}.';
+$string['objectives:source_outcomemap'] = 'mapeo de resultados de aprendizaje';
 $string['objectives:source_competency'] = 'competencias de Moodle';
 $string['objectives:source_summary'] = 'resumen del curso';
 $string['objectives:source_section'] = 'sección o contenido de la primera página';

--- a/lang/fi/local_ai_course_assistant.php
+++ b/lang/fi/local_ai_course_assistant.php
@@ -781,6 +781,7 @@ $string['objectives:toggle_chip'] = 'Näytä Oppimisen hallinta -merkki opiskeli
 $string['objectives:toggle_chip_help'] = 'Valinnainen. Kun pois käytöstä, hallinta ohjaa avustajaa edelleen taustalla, mutta oppijat eivät näe ilmaisinta.';
 $string['objectives:toggled'] = 'Asetus päivitetty.';
 $string['objectives:detected_heading'] = 'Tunnistettu {$a->count} oppimistavoitetta lähteestä {$a->source}.';
+$string['objectives:source_outcomemap'] = 'oppimistulosten kartoitus';
 $string['objectives:source_competency'] = 'Moodlen kompetenssit';
 $string['objectives:source_summary'] = 'kurssin kuvaus';
 $string['objectives:source_section'] = 'osio tai etusivun sisältö';

--- a/lang/fr/local_ai_course_assistant.php
+++ b/lang/fr/local_ai_course_assistant.php
@@ -782,6 +782,7 @@ $string['objectives:toggle_chip'] = 'Afficher la pastille Maîtrise de l\'appren
 $string['objectives:toggle_chip_help'] = 'Facultatif. Lorsqu\'il est désactivé, la maîtrise continue de guider l\'assistant en silence mais les apprenants ne voient aucun indicateur.';
 $string['objectives:toggled'] = 'Paramètre mis à jour.';
 $string['objectives:detected_heading'] = '{$a->count} objectifs d\'apprentissage détectés depuis {$a->source}.';
+$string['objectives:source_outcomemap'] = 'cartographie des acquis d\'apprentissage';
 $string['objectives:source_competency'] = 'compétences Moodle';
 $string['objectives:source_summary'] = 'résumé du cours';
 $string['objectives:source_section'] = 'section ou contenu de la première page';

--- a/lang/ha/local_ai_course_assistant.php
+++ b/lang/ha/local_ai_course_assistant.php
@@ -810,6 +810,7 @@ $string['objectives:toggle_chip'] = 'Nuna alamar Gwanintar Koyo ga dalibai';
 $string['objectives:toggle_chip_help'] = 'Na zabi. Lokacin da aka kashe, gwaninta har yanzu tana jagorantar mataimaki cikin shiru amma daliban ba sa ganin alama.';
 $string['objectives:toggled'] = 'An sabunta saitin.';
 $string['objectives:detected_heading'] = 'An gano manufofin koyo {$a->count} daga {$a->source}.';
+$string['objectives:source_outcomemap'] = 'tsarin sakamakon koyo';
 $string['objectives:source_competency'] = 'iyawowi na Moodle';
 $string['objectives:source_summary'] = 'takaitaccen kwasa';
 $string['objectives:source_section'] = 'sashe ko abun ciki na shafi na farko';

--- a/lang/he/local_ai_course_assistant.php
+++ b/lang/he/local_ai_course_assistant.php
@@ -823,6 +823,7 @@ $string['objectives:toggle_chip'] = 'הצג את תווית שליטת הלמי�
 $string['objectives:toggle_chip_help'] = 'אופציונלי. כאשר כבוי, השליטה עדיין מנחה את העוזר בשקט אבל הלומדים אינם רואים מחוון.';
 $string['objectives:toggled'] = 'ההגדרה עודכנה.';
 $string['objectives:detected_heading'] = 'זוהו {$a->count} מטרות למידה מתוך {$a->source}.';
+$string['objectives:source_outcomemap'] = 'מיפוי תוצרי למידה';
 $string['objectives:source_competency'] = 'יכולות Moodle';
 $string['objectives:source_summary'] = 'סיכום הקורס';
 $string['objectives:source_section'] = 'תוכן של מקטע או של עמוד ראשון';

--- a/lang/hi/local_ai_course_assistant.php
+++ b/lang/hi/local_ai_course_assistant.php
@@ -810,6 +810,7 @@ $string['objectives:toggle_chip'] = 'छात्रों को सीखन�
 $string['objectives:toggle_chip_help'] = 'वैकल्पिक। जब बंद होता है, तब भी महारत चुपचाप सहायक का मार्गदर्शन करती है लेकिन शिक्षार्थियों को कोई संकेतक नहीं दिखता।';
 $string['objectives:toggled'] = 'सेटिंग अद्यतन की गई।';
 $string['objectives:detected_heading'] = '{$a->source} से {$a->count} सीखने के उद्देश्यों का पता चला।';
+$string['objectives:source_outcomemap'] = 'सीखने के परिणामों की मैपिंग';
 $string['objectives:source_competency'] = 'Moodle दक्षताएँ';
 $string['objectives:source_summary'] = 'पाठ्यक्रम सारांश';
 $string['objectives:source_section'] = 'अनुभाग या प्रथम-पृष्ठ सामग्री';

--- a/lang/hu/local_ai_course_assistant.php
+++ b/lang/hu/local_ai_course_assistant.php
@@ -823,6 +823,7 @@ $string['objectives:toggle_chip'] = 'A Tanulási elsajátítás jelvény megjele
 $string['objectives:toggle_chip_help'] = 'Opcionális. Ha ki van kapcsolva, az elsajátítás csendben továbbra is irányítja az asszisztenst, de a tanulók nem látnak jelzést.';
 $string['objectives:toggled'] = 'Beállítás frissítve.';
 $string['objectives:detected_heading'] = '{$a->count} tanulási célkitűzés észlelve innen: {$a->source}.';
+$string['objectives:source_outcomemap'] = 'tanulási eredmények megfeleltetése';
 $string['objectives:source_competency'] = 'Moodle kompetenciák';
 $string['objectives:source_summary'] = 'kurzus összefoglaló';
 $string['objectives:source_section'] = 'szekció vagy első oldal tartalma';

--- a/lang/id/local_ai_course_assistant.php
+++ b/lang/id/local_ai_course_assistant.php
@@ -834,6 +834,7 @@ $string['objectives:toggle_chip'] = 'Tampilkan chip Penguasaan Pembelajaran kepa
 $string['objectives:toggle_chip_help'] = 'Opsional. Saat dimatikan, penguasaan tetap mengarahkan asisten secara diam-diam tetapi pelajar tidak melihat indikator.';
 $string['objectives:toggled'] = 'Pengaturan diperbarui.';
 $string['objectives:detected_heading'] = 'Terdeteksi {$a->count} tujuan pembelajaran dari {$a->source}.';
+$string['objectives:source_outcomemap'] = 'pemetaan hasil pembelajaran';
 $string['objectives:source_competency'] = 'Kompetensi Moodle';
 $string['objectives:source_summary'] = 'ringkasan kursus';
 $string['objectives:source_section'] = 'konten bagian atau halaman pertama';

--- a/lang/ig/local_ai_course_assistant.php
+++ b/lang/ig/local_ai_course_assistant.php
@@ -796,6 +796,7 @@ $string['objectives:toggle_chip'] = 'Gosi chip Nke a Kọwapụtara Mmụta nye 
 $string['objectives:toggle_chip_help'] = 'Nhọrọ. Mgbe gbanyụrụ, nke a kọwapụtara ka na-eduzi onye enyemaka na nzuzo mana ndị mmụta anaghị ahụ ihe ngosi.';
 $string['objectives:toggled'] = 'Emelitere ntọala.';
 $string['objectives:detected_heading'] = 'Achọpụtara ebumnobi mmụta {$a->count} site na {$a->source}.';
+$string['objectives:source_outcomemap'] = 'nhazi nsonaazụ mmụta';
 $string['objectives:source_competency'] = 'Ikike Moodle';
 $string['objectives:source_summary'] = 'nchịkọta usoro';
 $string['objectives:source_section'] = 'akụkụ ma ọ bụ ọdịnaya ibe mbụ';

--- a/lang/it/local_ai_course_assistant.php
+++ b/lang/it/local_ai_course_assistant.php
@@ -823,6 +823,7 @@ $string['objectives:toggle_chip'] = 'Mostra il chip Padronanza dell\'apprendimen
 $string['objectives:toggle_chip_help'] = 'Opzionale. Quando disattivato, la padronanza guida comunque silenziosamente l\'assistente ma gli studenti non vedono alcun indicatore.';
 $string['objectives:toggled'] = 'Impostazione aggiornata.';
 $string['objectives:detected_heading'] = 'Rilevati {$a->count} obiettivi di apprendimento da {$a->source}.';
+$string['objectives:source_outcomemap'] = 'mappatura dei risultati di apprendimento';
 $string['objectives:source_competency'] = 'competenze Moodle';
 $string['objectives:source_summary'] = 'riepilogo del corso';
 $string['objectives:source_section'] = 'sezione o contenuto della prima pagina';

--- a/lang/ja/local_ai_course_assistant.php
+++ b/lang/ja/local_ai_course_assistant.php
@@ -781,6 +781,7 @@ $string['objectives:toggle_chip'] = '学生に学習習熟度チップを表示'
 $string['objectives:toggle_chip_help'] = '任意。オフの場合でも習熟度はアシスタントを陰で誘導しますが、学習者には何も表示されません。';
 $string['objectives:toggled'] = '設定を更新しました。';
 $string['objectives:detected_heading'] = '{$a->source} から学習目標を {$a->count} 件検出しました。';
+$string['objectives:source_outcomemap'] = '学習成果のマッピング';
 $string['objectives:source_competency'] = 'Moodle コンピテンシー';
 $string['objectives:source_summary'] = 'コース概要';
 $string['objectives:source_section'] = 'セクションまたは1ページ目のコンテンツ';

--- a/lang/ko/local_ai_course_assistant.php
+++ b/lang/ko/local_ai_course_assistant.php
@@ -781,6 +781,7 @@ $string['objectives:toggle_chip'] = '학생에게 학습 숙달 칩 표시';
 $string['objectives:toggle_chip_help'] = '선택 사항입니다. 비활성화하면 숙달 정보는 보이지 않게 어시스턴트를 안내하지만 학습자에게는 표시기가 보이지 않습니다.';
 $string['objectives:toggled'] = '설정이 업데이트되었습니다.';
 $string['objectives:detected_heading'] = '{$a->source}에서 {$a->count}개의 학습 목표를 감지했습니다.';
+$string['objectives:source_outcomemap'] = '학습 성과 매핑';
 $string['objectives:source_competency'] = 'Moodle 역량';
 $string['objectives:source_summary'] = '코스 요약';
 $string['objectives:source_section'] = '섹션 또는 첫 페이지 콘텐츠';

--- a/lang/ms/local_ai_course_assistant.php
+++ b/lang/ms/local_ai_course_assistant.php
@@ -826,6 +826,7 @@ $string['objectives:toggle_chip'] = 'Tunjukkan cip Penguasaan Pembelajaran kepad
 $string['objectives:toggle_chip_help'] = 'Pilihan. Apabila dimatikan, penguasaan masih membimbing pembantu secara senyap tetapi pelajar tidak melihat sebarang penunjuk.';
 $string['objectives:toggled'] = 'Tetapan dikemas kini.';
 $string['objectives:detected_heading'] = '{$a->count} objektif pembelajaran dikesan daripada {$a->source}.';
+$string['objectives:source_outcomemap'] = 'pemetaan hasil pembelajaran';
 $string['objectives:source_competency'] = 'Kompetensi Moodle';
 $string['objectives:source_summary'] = 'ringkasan kursus';
 $string['objectives:source_section'] = 'kandungan bahagian atau halaman pertama';

--- a/lang/nb/local_ai_course_assistant.php
+++ b/lang/nb/local_ai_course_assistant.php
@@ -781,6 +781,7 @@ $string['objectives:toggle_chip'] = 'Vis Læringsmestring-chipen til elevene';
 $string['objectives:toggle_chip_help'] = 'Valgfritt. Når slått av, styrer mestring fortsatt assistenten i bakgrunnen, men eleven ser ingen indikator.';
 $string['objectives:toggled'] = 'Innstilling oppdatert.';
 $string['objectives:detected_heading'] = 'Oppdaget {$a->count} læringsmål fra {$a->source}.';
+$string['objectives:source_outcomemap'] = 'kartlegging av læringsutbytte';
 $string['objectives:source_competency'] = 'Moodle-kompetanser';
 $string['objectives:source_summary'] = 'emnesammendrag';
 $string['objectives:source_section'] = 'seksjons- eller førstesideinnhold';

--- a/lang/ne/local_ai_course_assistant.php
+++ b/lang/ne/local_ai_course_assistant.php
@@ -802,6 +802,7 @@ $string['objectives:toggle_chip'] = 'विद्यार्थीहरूल�
 $string['objectives:toggle_chip_help'] = 'वैकल्पिक। बन्द हुँदा, दक्षताले सहायकलाई पर्दा पछाडि निर्देशित गरिरहन्छ तर सिकारुहरूले कुनै सङ्केतक देख्दैनन्।';
 $string['objectives:toggled'] = 'सेटिङ अद्यावधिक गरियो।';
 $string['objectives:detected_heading'] = '{$a->source}बाट {$a->count} सिकाइ उद्देश्यहरू पहिचान गरियो।';
+$string['objectives:source_outcomemap'] = 'सिकाइ उपलब्धि म्यापिङ';
 $string['objectives:source_competency'] = 'मूडल कम्पिटेन्सीहरू';
 $string['objectives:source_summary'] = 'पाठ्यक्रम सारांश';
 $string['objectives:source_section'] = 'खण्ड वा पहिलो पृष्ठको सामग्री';

--- a/lang/nl/local_ai_course_assistant.php
+++ b/lang/nl/local_ai_course_assistant.php
@@ -805,6 +805,7 @@ $string['objectives:toggle_chip'] = 'Toon de Leerbeheersing-chip aan studenten';
 $string['objectives:toggle_chip_help'] = 'Optioneel. Wanneer uitgeschakeld blijft beheersing de assistent stilletjes sturen, maar zien leerlingen geen indicator.';
 $string['objectives:toggled'] = 'Instelling bijgewerkt.';
 $string['objectives:detected_heading'] = '{$a->count} leerdoelen gedetecteerd uit {$a->source}.';
+$string['objectives:source_outcomemap'] = 'koppeling van leerresultaten';
 $string['objectives:source_competency'] = 'Moodle-competenties';
 $string['objectives:source_summary'] = 'cursussamenvatting';
 $string['objectives:source_section'] = 'sectie- of inhoud van eerste pagina';

--- a/lang/om/local_ai_course_assistant.php
+++ b/lang/om/local_ai_course_assistant.php
@@ -813,6 +813,7 @@ $string['objectives:toggle_chip'] = 'Chip Gahumsa Barnootaa barattootaaf agarsii
 $string['objectives:toggle_chip_help'] = 'Filannoo. Yeroo cufamu, gahumsi gargaaraa kallattii hin agarsiifne ammas qajeelcha; barattoonni mallattoo tokko illee hin argan.';
 $string['objectives:toggled'] = 'Qindaa\'inni haaromfameera.';
 $string['objectives:detected_heading'] = 'Galmoota barnootaa {$a->count} {$a->source} irraa argaman.';
+$string['objectives:source_outcomemap'] = 'firii barnootaa walqabsiisuu';
 $string['objectives:source_competency'] = 'Dandeettiwwan Moodle';
 $string['objectives:source_summary'] = 'cuunfaa koorsii';
 $string['objectives:source_section'] = 'kutaa yookaan qabiyyee fuula jalqabaa';

--- a/lang/pa/local_ai_course_assistant.php
+++ b/lang/pa/local_ai_course_assistant.php
@@ -802,6 +802,7 @@ $string['objectives:toggle_chip'] = 'ਵਿਦਿਆਰਥੀਆਂ ਨੂੰ �
 $string['objectives:toggle_chip_help'] = 'ਵਿਕਲਪਕ। ਜਦੋਂ ਬੰਦ ਹੁੰਦਾ ਹੈ, ਮੁਹਾਰਤ ਫਿਰ ਵੀ ਸਹਾਇਕ ਨੂੰ ਚੁੱਪ-ਚਾਪ ਚਲਾਉਂਦੀ ਹੈ ਪਰ ਸਿਖਿਆਰਥੀ ਕੋਈ ਸੰਕੇਤ ਨਹੀਂ ਦੇਖਦੇ।';
 $string['objectives:toggled'] = 'ਸੈਟਿੰਗ ਅਪਡੇਟ ਹੋਈ।';
 $string['objectives:detected_heading'] = '{$a->source} ਤੋਂ {$a->count} ਸਿਖਲਾਈ ਉਦੇਸ਼ ਖੋਜੇ ਗਏ।';
+$string['objectives:source_outcomemap'] = 'ਸਿੱਖਣ ਨਤੀਜਿਆਂ ਦੀ ਮੈਪਿੰਗ';
 $string['objectives:source_competency'] = 'ਮੂਡਲ ਯੋਗਤਾਵਾਂ';
 $string['objectives:source_summary'] = 'ਕੋਰਸ ਸਾਰਾਂਸ਼';
 $string['objectives:source_section'] = 'ਭਾਗ ਜਾਂ ਪਹਿਲੇ-ਪੰਨੇ ਦੀ ਸਮੱਗਰੀ';

--- a/lang/pl/local_ai_course_assistant.php
+++ b/lang/pl/local_ai_course_assistant.php
@@ -781,6 +781,7 @@ $string['objectives:toggle_chip'] = 'Pokazuj uczącym się znacznik Opanowanie n
 $string['objectives:toggle_chip_help'] = 'Opcjonalne. Gdy wyłączone, opanowanie nadal po cichu kieruje asystentem, ale uczący się nie widzą wskaźnika.';
 $string['objectives:toggled'] = 'Ustawienie zaktualizowane.';
 $string['objectives:detected_heading'] = 'Wykryto {$a->count} celów uczenia się ze źródła {$a->source}.';
+$string['objectives:source_outcomemap'] = 'mapowanie efektów uczenia się';
 $string['objectives:source_competency'] = 'Kompetencje Moodle';
 $string['objectives:source_summary'] = 'streszczenie kursu';
 $string['objectives:source_section'] = 'sekcja lub treść pierwszej strony';

--- a/lang/pt_br/local_ai_course_assistant.php
+++ b/lang/pt_br/local_ai_course_assistant.php
@@ -802,6 +802,7 @@ $string['objectives:toggle_chip'] = 'Mostrar o chip de Domínio de Aprendizagem 
 $string['objectives:toggle_chip_help'] = 'Opcional. Quando desativado, o domínio continua orientando o assistente silenciosamente, mas os estudantes não veem nenhum indicador.';
 $string['objectives:toggled'] = 'Configuração atualizada.';
 $string['objectives:detected_heading'] = 'Detectados {$a->count} objetivos de aprendizagem em {$a->source}.';
+$string['objectives:source_outcomemap'] = 'mapeamento de resultados de aprendizagem';
 $string['objectives:source_competency'] = 'competências do Moodle';
 $string['objectives:source_summary'] = 'resumo do curso';
 $string['objectives:source_section'] = 'seção ou conteúdo da primeira página';

--- a/lang/ro/local_ai_course_assistant.php
+++ b/lang/ro/local_ai_course_assistant.php
@@ -781,6 +781,7 @@ $string['objectives:toggle_chip'] = 'Afișează cursanților indicatorul Stăpâ
 $string['objectives:toggle_chip_help'] = 'Opțional. Când este dezactivat, stăpânirea continuă să ghideze asistentul în mod silențios, dar cursanții nu văd niciun indicator.';
 $string['objectives:toggled'] = 'Setarea a fost actualizată.';
 $string['objectives:detected_heading'] = 'Detectate {$a->count} obiective de învățare din {$a->source}.';
+$string['objectives:source_outcomemap'] = 'maparea rezultatelor învățării';
 $string['objectives:source_competency'] = 'competențe Moodle';
 $string['objectives:source_summary'] = 'rezumatul cursului';
 $string['objectives:source_section'] = 'secțiune sau conținut din prima pagină';

--- a/lang/ru/local_ai_course_assistant.php
+++ b/lang/ru/local_ai_course_assistant.php
@@ -802,6 +802,7 @@ $string['objectives:toggle_chip'] = 'Показывать учащимся ин�
 $string['objectives:toggle_chip_help'] = 'Необязательно. Если выключено, отслеживание освоения по-прежнему незаметно направляет помощника, но учащиеся не видят индикатора.';
 $string['objectives:toggled'] = 'Настройка обновлена.';
 $string['objectives:detected_heading'] = 'Обнаружено учебных целей: {$a->count} (источник: {$a->source}).';
+$string['objectives:source_outcomemap'] = 'сопоставление результатов обучения';
 $string['objectives:source_competency'] = 'компетенции Moodle';
 $string['objectives:source_summary'] = 'описание курса';
 $string['objectives:source_section'] = 'раздел или содержимое первой страницы';

--- a/lang/sk/local_ai_course_assistant.php
+++ b/lang/sk/local_ai_course_assistant.php
@@ -781,6 +781,7 @@ $string['objectives:toggle_chip'] = 'Zobraziť študentom indikátor zvládnutia
 $string['objectives:toggle_chip_help'] = 'Voliteľné. Keď je vypnuté, sledovanie zvládnutia stále diskrétne usmerňuje asistenta, ale študenti nevidia žiadny indikátor.';
 $string['objectives:toggled'] = 'Nastavenie aktualizované.';
 $string['objectives:detected_heading'] = 'Zistených vzdelávacích cieľov: {$a->count} (zdroj: {$a->source}).';
+$string['objectives:source_outcomemap'] = 'mapovanie výsledkov vzdelávania';
 $string['objectives:source_competency'] = 'Moodle kompetencie';
 $string['objectives:source_summary'] = 'súhrn kurzu';
 $string['objectives:source_section'] = 'sekcia alebo obsah prvej stránky';

--- a/lang/so/local_ai_course_assistant.php
+++ b/lang/so/local_ai_course_assistant.php
@@ -826,6 +826,7 @@ $string['objectives:toggle_chip'] = 'Tus ardayda calaamada Aqoonsanaanta Waxbara
 $string['objectives:toggle_chip_help'] = 'Ikhtiyaari. Marka la damiyo, aqoonsanaantu weli si dahsoon ayey u hagaysaa caawiyaha laakiin ardayda waxba ma arkaan.';
 $string['objectives:toggled'] = 'Dejintii waa la cusboonaysiiyay.';
 $string['objectives:detected_heading'] = 'Waxaa la helay {$a->count} ujeedo waxbarasho oo ka socda {$a->source}.';
+$string['objectives:source_outcomemap'] = 'isku xidhka natiijooyinka waxbarashada';
 $string['objectives:source_competency'] = 'Awoodaha Moodle';
 $string['objectives:source_summary'] = 'soo koobitaanka koorsada';
 $string['objectives:source_section'] = 'qeyb ama nuxurka boggaa hore';

--- a/lang/sv/local_ai_course_assistant.php
+++ b/lang/sv/local_ai_course_assistant.php
@@ -781,6 +781,7 @@ $string['objectives:toggle_chip'] = 'Visa indikatorn Lärandebehärskning för e
 $string['objectives:toggle_chip_help'] = 'Valfritt. När det är av styr behärskningen fortfarande assistenten i bakgrunden, men eleverna ser ingen indikator.';
 $string['objectives:toggled'] = 'Inställning uppdaterad.';
 $string['objectives:detected_heading'] = 'Hittade {$a->count} lärandemål från {$a->source}.';
+$string['objectives:source_outcomemap'] = 'kartläggning av lärandemål';
 $string['objectives:source_competency'] = 'Moodle-kompetenser';
 $string['objectives:source_summary'] = 'kursöversikt';
 $string['objectives:source_section'] = 'avsnitt eller innehåll på första sidan';

--- a/lang/sw/local_ai_course_assistant.php
+++ b/lang/sw/local_ai_course_assistant.php
@@ -826,6 +826,7 @@ $string['objectives:toggle_chip'] = 'Onyesha kwa wanafunzi alama ya Umilisi wa K
 $string['objectives:toggle_chip_help'] = 'Hiari. Ikiwa imezimwa, umilisi bado unaongoza msaidizi kimya kimya lakini wanafunzi hawaoni alama yoyote.';
 $string['objectives:toggled'] = 'Mpangilio umesasishwa.';
 $string['objectives:detected_heading'] = 'Yamegunduliwa malengo {$a->count} ya kujifunza kutoka {$a->source}.';
+$string['objectives:source_outcomemap'] = 'uchoraji wa matokeo ya kujifunza';
 $string['objectives:source_competency'] = 'Umahiri wa Moodle';
 $string['objectives:source_summary'] = 'muhtasari wa kozi';
 $string['objectives:source_section'] = 'sehemu au maudhui ya ukurasa wa kwanza';

--- a/lang/ta/local_ai_course_assistant.php
+++ b/lang/ta/local_ai_course_assistant.php
@@ -802,6 +802,7 @@ $string['objectives:toggle_chip'] = 'மாணவர்களுக்கு க
 $string['objectives:toggle_chip_help'] = 'விருப்பத்தேர்வு. ஆஃப் ஆக இருக்கும்போது, தேர்ச்சி உதவியாளரை அமைதியாகச் செலுத்துகிறது ஆனால் கற்றவர்களுக்கு எந்த சுட்டியும் தெரியாது.';
 $string['objectives:toggled'] = 'அமைப்பு புதுப்பிக்கப்பட்டது.';
 $string['objectives:detected_heading'] = '{$a->source} இல் இருந்து {$a->count} கற்றல் நோக்கங்கள் கண்டறியப்பட்டுள்ளன.';
+$string['objectives:source_outcomemap'] = 'கற்றல் விளைவுகள் வரைபடம்';
 $string['objectives:source_competency'] = 'Moodle திறமைகள்';
 $string['objectives:source_summary'] = 'படிப்புச் சுருக்கம்';
 $string['objectives:source_section'] = 'பிரிவு அல்லது முதல் பக்க உள்ளடக்கம்';

--- a/lang/th/local_ai_course_assistant.php
+++ b/lang/th/local_ai_course_assistant.php
@@ -781,6 +781,7 @@ $string['objectives:toggle_chip'] = 'แสดงชิปความเชี�
 $string['objectives:toggle_chip_help'] = 'เลือกได้ เมื่อปิด ความเชี่ยวชาญยังคงนำทางผู้ช่วยอย่างเงียบๆ แต่ผู้เรียนจะไม่เห็นตัวบ่งชี้';
 $string['objectives:toggled'] = 'อัปเดตการตั้งค่าแล้ว';
 $string['objectives:detected_heading'] = 'ตรวจพบ {$a->count} วัตถุประสงค์การเรียนรู้จาก {$a->source}';
+$string['objectives:source_outcomemap'] = 'การจับคู่ผลลัพธ์การเรียนรู้';
 $string['objectives:source_competency'] = 'ความสามารถของ Moodle';
 $string['objectives:source_summary'] = 'บทสรุปรายวิชา';
 $string['objectives:source_section'] = 'เนื้อหาส่วนหรือหน้าแรก';

--- a/lang/tl/local_ai_course_assistant.php
+++ b/lang/tl/local_ai_course_assistant.php
@@ -826,6 +826,7 @@ $string['objectives:toggle_chip'] = 'Ipakita ang chip ng Learning Mastery sa mga
 $string['objectives:toggle_chip_help'] = 'Opsyonal. Kapag naka-off, patuloy pa ring tahimik na inaakay ng kasanayan ang assistant ngunit walang nakikitang indikasyon ang mga mag-aaral.';
 $string['objectives:toggled'] = 'Na-update ang setting.';
 $string['objectives:detected_heading'] = 'Natukoy ang {$a->count} na layunin sa pagkatuto mula sa {$a->source}.';
+$string['objectives:source_outcomemap'] = 'pagmamapa ng mga kinalabasan ng pagkatuto';
 $string['objectives:source_competency'] = 'mga competency ng Moodle';
 $string['objectives:source_summary'] = 'buod ng kurso';
 $string['objectives:source_section'] = 'section o nilalaman ng unang pahina';

--- a/lang/tr/local_ai_course_assistant.php
+++ b/lang/tr/local_ai_course_assistant.php
@@ -781,6 +781,7 @@ $string['objectives:toggle_chip'] = 'Öğrenme Uzmanlığı çipini öğrenciler
 $string['objectives:toggle_chip_help'] = 'İsteğe bağlı. Kapalı olduğunda uzmanlık asistanı sessizce yönlendirmeye devam eder, ancak öğrenciler hiçbir gösterge görmez.';
 $string['objectives:toggled'] = 'Ayar güncellendi.';
 $string['objectives:detected_heading'] = '{$a->source} kaynağından {$a->count} öğrenme hedefi tespit edildi.';
+$string['objectives:source_outcomemap'] = 'öğrenme kazanımları eşlemesi';
 $string['objectives:source_competency'] = 'Moodle yetkinlikleri';
 $string['objectives:source_summary'] = 'kurs özeti';
 $string['objectives:source_section'] = 'bölüm veya ilk sayfa içeriği';

--- a/lang/uk/local_ai_course_assistant.php
+++ b/lang/uk/local_ai_course_assistant.php
@@ -823,6 +823,7 @@ $string['objectives:toggle_chip'] = 'Показувати студентам ч�
 $string['objectives:toggle_chip_help'] = 'Необов\'язково. Коли вимкнено, опанування все ще тихо керує помічником, але учні не бачать жодного індикатора.';
 $string['objectives:toggled'] = 'Налаштування оновлено.';
 $string['objectives:detected_heading'] = 'Виявлено {$a->count} навчальних цілей з {$a->source}.';
+$string['objectives:source_outcomemap'] = 'зіставлення результатів навчання';
 $string['objectives:source_competency'] = 'компетенції Moodle';
 $string['objectives:source_summary'] = 'опис курсу';
 $string['objectives:source_section'] = 'розділ або вміст першої сторінки';

--- a/lang/vi/local_ai_course_assistant.php
+++ b/lang/vi/local_ai_course_assistant.php
@@ -802,6 +802,7 @@ $string['objectives:toggle_chip'] = 'Hiển thị huy hiệu Mức thuần thụ
 $string['objectives:toggle_chip_help'] = 'Tuỳ chọn. Khi tắt, mức thuần thục vẫn âm thầm điều hướng trợ lý nhưng học viên không nhìn thấy chỉ báo nào.';
 $string['objectives:toggled'] = 'Đã cập nhật cài đặt.';
 $string['objectives:detected_heading'] = 'Đã phát hiện {$a->count} mục tiêu học tập từ {$a->source}.';
+$string['objectives:source_outcomemap'] = 'ánh xạ kết quả học tập';
 $string['objectives:source_competency'] = 'năng lực Moodle';
 $string['objectives:source_summary'] = 'tóm tắt khoá học';
 $string['objectives:source_section'] = 'phần hoặc nội dung trang đầu';

--- a/lang/wo/local_ai_course_assistant.php
+++ b/lang/wo/local_ai_course_assistant.php
@@ -802,6 +802,7 @@ $string['objectives:toggle_chip'] = 'Wone tëgg Mastery Njàng ngir njàngalekat
 $string['objectives:toggle_chip_help'] = 'Tànn. Bu fofu, mastery dafay topp ndimbal bi ci kumpa waaye njàngalekat yi duñu gis indicateur.';
 $string['objectives:toggled'] = 'Configuration ñu ko soppi.';
 $string['objectives:detected_heading'] = 'Gis nañu {$a->count} yitte njàng ci {$a->source}.';
+$string['objectives:source_outcomemap'] = 'cartographie bu njàng mi';
 $string['objectives:source_competency'] = 'kompetan Moodle';
 $string['objectives:source_summary'] = 'résumé cours';
 $string['objectives:source_section'] = 'section walla peggal njëkk';

--- a/lang/yo/local_ai_course_assistant.php
+++ b/lang/yo/local_ai_course_assistant.php
@@ -802,6 +802,7 @@ $string['objectives:toggle_chip'] = 'Fi ààmì Ìmọ̀ràn Ìkẹ́kọ̀ọ́
 $string['objectives:toggle_chip_help'] = 'Àṣàyàn. Nígbà tí ó bá pa, ìmọ̀ràn ṣì ń ṣe ìtọ́sọ́nà olùrànlọ́wọ́ ní ìdákẹ́, ṣùgbọ́n àwọn akẹ́kọ̀ọ́ kò rí àfihàn.';
 $string['objectives:toggled'] = 'A ti yí ìṣètò padà.';
 $string['objectives:detected_heading'] = 'A rí {$a->count} èròjà ìkẹ́kọ̀ọ́ láti {$a->source}.';
+$string['objectives:source_outcomemap'] = 'àwòrán àbájáde ẹ̀kọ́';
 $string['objectives:source_competency'] = 'agbára Moodle';
 $string['objectives:source_summary'] = 'àkótán ẹ̀kọ́';
 $string['objectives:source_section'] = 'apá tàbí àkóónú ojú-ìwé àkọ́kọ́';

--- a/lang/zh_cn/local_ai_course_assistant.php
+++ b/lang/zh_cn/local_ai_course_assistant.php
@@ -802,6 +802,7 @@ $string['objectives:toggle_chip'] = '向学生展示"学习掌握度"小标签';
 $string['objectives:toggle_chip_help'] = '可选。关闭时，掌握度仍会在后台引导助手，但学习者看不到任何指示。';
 $string['objectives:toggled'] = '设置已更新。';
 $string['objectives:detected_heading'] = '已从 {$a->source} 检测到 {$a->count} 个学习目标。';
+$string['objectives:source_outcomemap'] = '学习成果映射';
 $string['objectives:source_competency'] = 'Moodle 能力';
 $string['objectives:source_summary'] = '课程简介';
 $string['objectives:source_section'] = '章节或首页内容';

--- a/lang/zu/local_ai_course_assistant.php
+++ b/lang/zu/local_ai_course_assistant.php
@@ -826,6 +826,7 @@ $string['objectives:toggle_chip'] = 'Bonisa i-tag ye-Mastery Yokufunda kubafundi
 $string['objectives:toggle_chip_help'] = 'Okukhethwayo. Lapho kuvalwe, ukuhlonipha kuyaqhubeka kuqondisa umsizi ngokuthuleyo kodwa abafundi ababoni nesithombisi.';
 $string['objectives:toggled'] = 'Isilungiselelo silungisiwe.';
 $string['objectives:detected_heading'] = 'Kutholwe imigomo yokufunda engu-{$a->count} kusukela ku-{$a->source}.';
+$string['objectives:source_outcomemap'] = 'ukumepha kwemiphumela yokufunda';
 $string['objectives:source_competency'] = 'amakhono e-Moodle';
 $string['objectives:source_summary'] = 'isifinyezo sesifundo';
 $string['objectives:source_section'] = 'isigaba noma okuqukethwe ekhasini lokuqala';

--- a/tests/outcomemap_bridge_test.php
+++ b/tests/outcomemap_bridge_test.php
@@ -1,0 +1,135 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Tests for the optional local_outcomemap objective source.
+ *
+ * @package    local_ai_course_assistant
+ * @copyright  2026 Saylor University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_ai_course_assistant;
+
+/**
+ * @covers \local_ai_course_assistant\outcomemap_bridge
+ */
+final class outcomemap_bridge_test extends \advanced_testcase {
+
+    /**
+     * The whole point of the bridge is that it is inert without the plugin.
+     *
+     * CI does not install local_outcomemap, so this asserts the condition that
+     * every site without the plugin actually runs under. It is deliberately
+     * written to be correct either way: if a future CI image DOES ship the
+     * plugin, the assertion follows class_exists() rather than hard-coding false,
+     * so this test reports the truth instead of failing spuriously.
+     */
+    public function test_is_available_tracks_the_plugin_being_installed(): void {
+        $this->resetAfterTest();
+        $expected = class_exists('\\local_outcomemap\\api\\outcome_search')
+            && method_exists('\\local_outcomemap\\api\\outcome_search', 'search');
+        $this->assertSame($expected, outcomemap_bridge::is_available());
+    }
+
+    /**
+     * With the plugin absent, fetch() must return an empty array and must not throw.
+     *
+     * A throw here would propagate into detect_best_source(), which is called on
+     * every load of objectives_admin.php for a course with no objectives.
+     */
+    public function test_fetch_is_empty_and_silent_without_the_plugin(): void {
+        $this->resetAfterTest();
+        if (outcomemap_bridge::is_available()) {
+            $this->markTestSkipped('local_outcomemap is installed; this asserts the absent case.');
+        }
+        $course = $this->getDataGenerator()->create_course();
+        $this->assertSame([], outcomemap_bridge::fetch((int) $course->id));
+    }
+
+    /**
+     * Guard inputs are rejected before any work, including the site course.
+     *
+     * SITEID matters: objective discovery is per real course, and the site course
+     * would otherwise resolve to a valid context and reach the API.
+     */
+    public function test_fetch_rejects_guard_inputs(): void {
+        $this->resetAfterTest();
+        $this->assertSame([], outcomemap_bridge::fetch(0));
+        $this->assertSame([], outcomemap_bridge::fetch(-1));
+        $this->assertSame([], outcomemap_bridge::fetch(SITEID));
+    }
+
+    /**
+     * A course id that does not exist must be handled, not fatal.
+     */
+    public function test_fetch_handles_a_missing_course(): void {
+        $this->resetAfterTest();
+        global $DB;
+        $maxid = (int) $DB->get_field_sql('SELECT COALESCE(MAX(id), 0) FROM {course}');
+        $this->assertSame([], outcomemap_bridge::fetch($maxid + 1000));
+    }
+
+    /**
+     * detect_best_source() must offer outcomemap first, and must still fall
+     * through to the existing candidates when it yields nothing.
+     *
+     * The ordering is the whole value of the change: returning on the first
+     * candidate with three or more objectives is what stops a mapped course ever
+     * reaching extract_from_section_content().
+     */
+    public function test_detect_best_source_still_falls_through_when_outcomemap_is_absent(): void {
+        $this->resetAfterTest();
+        if (outcomemap_bridge::is_available()) {
+            $this->markTestSkipped('local_outcomemap is installed; this asserts the absent case.');
+        }
+        $course = $this->getDataGenerator()->create_course();
+        $result = objective_manager::detect_best_source((int) $course->id);
+        $this->assertArrayHasKey('source', $result);
+        $this->assertArrayHasKey('objectives', $result);
+        // An empty course yields nothing from any candidate.
+        $this->assertNotSame('outcomemap', $result['source']);
+    }
+
+    /**
+     * Every source the detector can report must have a display string, because
+     * objectives_admin.php calls get_string('objectives:source_' . $source) with
+     * no fallback and would otherwise render a missing-string placeholder.
+     */
+    public function test_every_detector_source_has_a_lang_string(): void {
+        $this->resetAfterTest();
+        foreach (['outcomemap', 'competency', 'summary', 'section', 'llm', 'manual', 'none'] as $source) {
+            $this->assertTrue(
+                get_string_manager()->string_exists(
+                    'objectives:source_' . $source,
+                    'local_ai_course_assistant'
+                ),
+                'Missing lang string for objective source: ' . $source
+            );
+        }
+    }
+
+    /**
+     * The provenance reference must fit objs.external_ref, which is char(64).
+     *
+     * The prefix plus a 36-character UUID is 47, so this has headroom; the test
+     * exists so that lengthening the prefix cannot silently truncate a UUID and
+     * make two different outcome versions collide on the same reference.
+     */
+    public function test_reference_prefix_leaves_room_for_a_uuid(): void {
+        $this->assertLessThanOrEqual(64, strlen(outcomemap_bridge::REF_PREFIX) + 36);
+    }
+}


### PR DESCRIPTION
## The problem

SOLA discovers learning objectives by scraping course content: the course summary, then each section summary, then every visible Page and Book, each run through `format_text()` looking for something bullet-shaped.

**That pipeline has produced six rows in all of production.** They are on one course, and all six are course *names* rather than objectives:

```
ECON101: Principles of Microeconomics
BUS202: Principles of Finance
...
```

The cause is in `extract_bullet_list_from_text()`: when none of its seven heading patterns match, it sets `startpos = 0` and scrapes bullets from the top of the document anyway. Learn has **zero** rows. So the scraper's real-world yield is zero usable objectives.

Two things make it worse on Degrees specifically:

- **Core outcomes and competencies are entirely empty there.** `mdl_grade_outcomes`, `mdl_grade_outcomes_courses`, `mdl_competency` and `mdl_competency_coursecomp` are all 0 rows and `enableoutcomes = 0` (control: `SELECT COUNT(*) FROM mdl_course` returns 146, so these are genuine zeroes). The detector's highest-priority candidate can therefore *never* fire and it always falls through to the scrapers.
- **The walk is unbounded.** Roughly 4 queries and one `format_text()` per Page and per Book chapter, with no module cap, against **6,764 pages and 18,542 book chapters** on that site.

Meanwhile `local_outcomemap` holds **783 approved, human-authored, versioned outcome statements** across 50 course frameworks, bound to real Moodle courses.

## The change

Adds `local_outcomemap` as **candidate zero** in `detect_best_source()`.

Because the detector returns on the first candidate yielding three or more objectives, a mapped course now **never reaches `extract_from_section_content()`** — the expensive walk disappears for exactly the courses that have better data.

## Design

**One seam, public API only.** `outcomemap_bridge` is the only place SOLA touches the plugin. It calls the declared public API under `\local_outcomemap\api` and never the plugin's `\local\...` internals or its tables, so a storage change cannot break SOLA silently.

**Verified against the version actually deployed, not just HEAD.** Production runs `2026081700`; the repo is at `2026091100`. I checked out the production commit and confirmed the `search()` signature, the context scoping and all 11 DTO fields are present there. (My first check said otherwise — that was a shallow-clone artifact, corrected with a full clone and a negative control.)

**Inert without the plugin.** Every entry point is guarded by `class_exists()`/`method_exists()` and the fetch is wrapped in `catch (\Throwable)`. The plugin is optional, absent from most installs including every install of Learn, and is still `MATURITY_BETA` where it exists. When missing, the candidate returns `[]` and the chain falls through exactly as before.

**Capability checked before the call, not after.** `outcome_search::search()` calls `require_capability()` internally and throws. Objective discovery runs on every load of `objectives_admin.php` for a course with no objectives, and a missing read capability must not become a fatal there.

**Provenance without a schema change.** `external_ref` stores the outcome **version** UUID, not the outcome UUID, so a later upstream edit to the wording is visibly a different reference rather than silently the same one. The existing `source`/`external_ref` columns carry it.

## Scope caveat, stated rather than silently filtered

`outcome_search` scopes by Moodle context and returns every framework visible to the course: its own catalog framework, any institution-level framework, and the frameworks of programs it belongs to. **A course inside a degree therefore also receives that program's outcomes.**

That is the plugin's own definition of "outcomes for this course". Its public API exposes no owner-type filter, and applying one would mean querying its tables — the coupling this class exists to avoid. If CLO-only is wanted, the right fix is an upstream filter parameter, not a workaround here.

## Not included

The attainment half of the plugin (`result`, `get_user_program_attainment`). That data is a single user's pilot — 78 rows, 75 of them `insufficient_evidence` — and its web service is disabled on Degrees (`mdl_external_services` id 14, `enabled=0`).

## Testing

`objectives:source_outcomemap` is translated into all 45 non-English locales, matching its six sibling source labels which are all already 45/45. Verified by loading every file in PHP and reading the arrays: 46 files load, none missing the key, none byte-identical to English.

New `outcomemap_bridge_test.php`: 7 tests / 18 assertions, covering the absent-plugin path (the case every install without the plugin runs), guard inputs including `SITEID`, a missing course, fall-through in `detect_best_source()`, a lang string for every source the detector can report, and the `external_ref` length budget.