### PR TITLE
chore: version 7.4.6 / build 2026091008

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 SOLA (Saylor Online Learning Assistant) is a Moodle local plugin that provides an AI-powered learning coach embedded in course pages. Students interact via a side tab on the right edge of the page (default: halfway down), which opens a chat drawer. A floating avatar button at the bottom corner is an alternative placement available via the Display Mode admin setting.
 
 - **Plugin component:** `local_ai_course_assistant`
-- **Current version:** `2026091007`, release `7.4.5`
+- **Current version:** `2026091008`, release `7.4.6`
 - **Source folder (canonical):** the git repo at `~/ai-projects/ai_course_assistant/` (edit and commit here; the older `aicoursetutor/ai_course_assistant` path is a stale remnant, do not deploy from it)
 - **Zip for upload:** built from the repo via `create_fixed_zip.sh`
 - **GitHub:** `https://github.com/saylordotorg/moodle-local_ai_course_assistant` (public)

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 A comprehensive AI-powered chat widget for Moodle 4.5+ that provides context-aware tutoring, support, and study planning for students.
 
-## Version 7.4.5
+## Version 7.4.6
 
 **Release Date:** September 2026
-**Plugin build:** 2026091007
+**Plugin build:** 2026091008
 **Requires:** Moodle 4.5+ (2024100700). Continuously tested against Moodle 4.5, 5.0 and 5.1; supported through 5.3.
 **License:** GPL v3+
 **Maturity:** Stable. In production on Saylor's Learn and Degrees sites.

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_ai_course_assistant';
-$plugin->version   = 2026091007;
+$plugin->version   = 2026091008;
 $plugin->requires = 2024100700; // Moodle 4.5+.
 $plugin->supported = [405, 503]; // Tested on Moodle 4.5 through 5.3dev.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '7.4.5';
+$plugin->release = '7.4.6';


### PR DESCRIPTION
Bumps the plugin to **7.4.6 / build 2026091008** so the two changes merged after the v7.4.5 tag can ship.

## Why this is needed rather than tidy

`main` was carrying 50 changed files (+467/−4) beyond the `v7.4.5` tag while reporting the **identical** build integer:

```
main: $plugin->version=2026091007;  $plugin->release='7.4.5';
tag : $plugin->version=2026091007;  $plugin->release='7.4.5';
```

Moodle decides whether to run a plugin upgrade by comparing that integer. Two materially different trees claiming the same build are indistinguishable to every site, so anything already running v7.4.5 would never have picked up:

- **#230** — `format_text()` called without `file_rewrite_pluginfile_urls()` at four sites, and with no context so it fell back to `$PAGE->context`
- **#231** — `local_outcomemap` as the first objective source, which also stops mapped courses ever reaching the unbounded content walk

Neither PR bumped the build on purpose: both are code-only, and a bump inside either would have made them conflict.

## No upgrade step needed

`git diff --name-only v7.4.5 origin/main -- db/` is empty. The change is code-only, so the version bump alone is sufficient and no `db/upgrade.php` savepoint is required.

## Files

`version.php`, `README.md`, `CLAUDE.md` — three lines. Verified no stale `2026091007` references remain outside `db/upgrade.php`, where the savepoints correctly reference older builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)